### PR TITLE
fix: hide HF change indicator before user input

### DIFF
--- a/src/components/transactions/Borrow/BorrowModalContent.tsx
+++ b/src/components/transactions/Borrow/BorrowModalContent.tsx
@@ -304,6 +304,7 @@ export const BorrowModalContent = ({ underlyingAsset }: BorrowModalContentProps)
         )}
         <DetailsIncentivesLine incentives={incentive} symbol={poolReserve.symbol} />
         <DetailsHFLine
+          visibleHfChange={!!_amount}
           healthFactor={user.healthFactor}
           futureHealthFactor={newHealthFactor.toString()}
         />

--- a/src/components/transactions/CollateralChange/CollateralChangeModalContent.tsx
+++ b/src/components/transactions/CollateralChange/CollateralChangeModalContent.tsx
@@ -157,6 +157,7 @@ export const CollateralChangeModalContent = ({
           value={userReserve.underlyingBalance}
         />
         <DetailsHFLine
+          visibleHfChange={true}
           healthFactor={user.healthFactor}
           futureHealthFactor={healthFactorAfterSwitch.toString()}
         />

--- a/src/components/transactions/Emode/EmodeModalContent.tsx
+++ b/src/components/transactions/Emode/EmodeModalContent.tsx
@@ -234,6 +234,7 @@ export const EmodeModalContent = () => {
           </>
         )}
         <DetailsHFLine
+          visibleHfChange={!!selectedEmode}
           healthFactor={user.healthFactor}
           futureHealthFactor={newSummary.healthFactor}
         />

--- a/src/components/transactions/FlowCommons/TxModalDetails.tsx
+++ b/src/components/transactions/FlowCommons/TxModalDetails.tsx
@@ -188,9 +188,14 @@ export const DetailsIncentivesLine = ({
 export interface DetailsHFLineProps {
   healthFactor: string;
   futureHealthFactor: string;
+  visibleHfChange: boolean;
 }
 
-export const DetailsHFLine = ({ healthFactor, futureHealthFactor }: DetailsHFLineProps) => {
+export const DetailsHFLine = ({
+  healthFactor,
+  futureHealthFactor,
+  visibleHfChange,
+}: DetailsHFLineProps) => {
   if (healthFactor === '-1' && futureHealthFactor === '-1') return null;
   return (
     <Row
@@ -203,14 +208,18 @@ export const DetailsHFLine = ({ healthFactor, futureHealthFactor }: DetailsHFLin
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
           <HealthFactorNumber value={healthFactor} variant="secondary14" />
 
-          <SvgIcon color="primary" sx={{ fontSize: '14px', mx: 1 }}>
-            <ArrowNarrowRightIcon />
-          </SvgIcon>
+          {visibleHfChange && (
+            <>
+              <SvgIcon color="primary" sx={{ fontSize: '14px', mx: 1 }}>
+                <ArrowNarrowRightIcon />
+              </SvgIcon>
 
-          <HealthFactorNumber
-            value={Number(futureHealthFactor) ? futureHealthFactor : healthFactor}
-            variant="secondary14"
-          />
+              <HealthFactorNumber
+                value={Number(futureHealthFactor) ? futureHealthFactor : healthFactor}
+                variant="secondary14"
+              />
+            </>
+          )}
         </Box>
 
         <Typography variant="helperText" color="text.secondary">

--- a/src/components/transactions/Repay/RepayModalContent.tsx
+++ b/src/components/transactions/Repay/RepayModalContent.tsx
@@ -273,7 +273,11 @@ export const RepayModalContent = ({ underlyingAsset }: RepayProps) => {
           amountUSD={displayAmountAfterRepayInUsd.toString()}
           symbol={poolReserve.iconSymbol}
         />
-        <DetailsHFLine healthFactor={user?.healthFactor} futureHealthFactor={newHF?.toString()} />
+        <DetailsHFLine
+          visibleHfChange={!!_amount}
+          healthFactor={user?.healthFactor}
+          futureHealthFactor={newHF?.toString()}
+        />
       </TxModalDetails>
 
       {repayTxState.gasEstimationError && (

--- a/src/components/transactions/Supply/SupplyModalContent.tsx
+++ b/src/components/transactions/Supply/SupplyModalContent.tsx
@@ -288,6 +288,7 @@ export const SupplyModalContent = ({ underlyingAsset }: SupplyProps) => {
         />
         <DetailsCollateralLine collateralType={willBeUsedAsCollateral} />
         <DetailsHFLine
+          visibleHfChange={!!_amount}
           healthFactor={user ? user.healthFactor : '-1'}
           futureHealthFactor={healthFactorAfterDeposit.toString()}
         />

--- a/src/components/transactions/Swap/SwapModalContent.tsx
+++ b/src/components/transactions/Swap/SwapModalContent.tsx
@@ -242,6 +242,7 @@ export const SwapModalContent = ({ underlyingAsset }: SupplyProps) => {
         />
         {showHealthFactor && (
           <DetailsHFLine
+            visibleHfChange={!!_amount}
             healthFactor={user.healthFactor}
             futureHealthFactor={hfAfterSwap.toString()}
           />

--- a/src/components/transactions/Withdraw/WithdrawModalContent.tsx
+++ b/src/components/transactions/Withdraw/WithdrawModalContent.tsx
@@ -241,6 +241,7 @@ export const WithdrawModalContent = ({ underlyingAsset }: WithdrawModalContentPr
           symbol={symbol}
         />
         <DetailsHFLine
+          visibleHfChange={!!_amount}
           healthFactor={user ? user.healthFactor : '-1'}
           futureHealthFactor={healthFactorAfterWithdraw.toString()}
         />


### PR DESCRIPTION
- Hide HF change indicator before user inputs an amount at all modal actions.

Fixes #275 