### PR TITLE
fix: better item alignemnt & claim icon fixes

### DIFF
--- a/src/components/primitives/TokenIcon.tsx
+++ b/src/components/primitives/TokenIcon.tsx
@@ -173,9 +173,14 @@ interface MultiTokenIconProps extends IconProps {
 export function MultiTokenIcon({ symbols, badgeSymbol, ...rest }: MultiTokenIconProps) {
   if (!badgeSymbol)
     return (
-      <Box>
+      <Box sx={{ display: 'inline-flex', position: 'relative' }}>
         {symbols.map((symbol, ix) => (
-          <SingleTokenIcon key={symbol} symbol={symbol} sx={{ ml: ix === 0 ? 0 : -4 }} {...rest} />
+          <SingleTokenIcon
+            {...rest}
+            key={symbol}
+            symbol={symbol}
+            sx={{ ml: ix === 0 ? 0 : `calc(-1 * 0.5em)`, ...rest.sx }}
+          />
         ))}
       </Box>
     );
@@ -187,7 +192,12 @@ export function MultiTokenIcon({ symbols, badgeSymbol, ...rest }: MultiTokenIcon
       sx={{ '.MuiBadge-anchorOriginTopRight': { top: 9 } }}
     >
       {symbols.map((symbol, ix) => (
-        <SingleTokenIcon key={symbol} symbol={symbol} sx={{ ml: ix === 0 ? 0 : -4 }} {...rest} />
+        <SingleTokenIcon
+          {...rest}
+          key={symbol}
+          symbol={symbol}
+          sx={{ ml: ix === 0 ? 0 : 'calc(-1 * 0.5em)', ...rest.sx }}
+        />
       ))}
     </Badge>
   );

--- a/src/modules/dashboard/DashboardTopPanel.tsx
+++ b/src/modules/dashboard/DashboardTopPanel.tsx
@@ -171,10 +171,7 @@ export const DashboardTopPanel = () => {
                   symbolsVariant={noDataTypographyVariant}
                 />
                 {assets && (
-                  <MultiTokenIcon
-                    symbols={assets}
-                    sx={{ ml: 1, fontSize: { xs: '16px', xsm: '20px' } }}
-                  />
+                  <MultiTokenIcon symbols={assets} sx={{ fontSize: { xs: '16px', xsm: '20px' } }} />
                 )}
               </Box>
 


### PR DESCRIPTION
- closes part of https://github.com/aave/next-ui/issues/309 - the icon alignment is fixed with this pr. Regarding the icon missing that's just the case of "rew" not being a token in public.