### PR TITLE
fix: default to hydration compatible default

### DIFF
--- a/src/components/MarketSwitcher.tsx
+++ b/src/components/MarketSwitcher.tsx
@@ -126,7 +126,6 @@ export const MarketSwitcher = () => {
         ),
         renderValue: (marketId) => {
           const { market, network } = getMarketInfoById(marketId as CustomMarket);
-
           return (
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
               <MarketLogo

--- a/src/hooks/useProtocolDataContext.tsx
+++ b/src/hooks/useProtocolDataContext.tsx
@@ -85,10 +85,7 @@ export function ProtocolDataProvider({ children }: PropsWithChildren<{}>) {
   const { query, pathname, push } = useRouter();
   // const [markets, setMarkets] = useState(marketsData);
   // const [networkConfigs, setNetworkConfigs] = useState(_networkConfigs);
-  const [currentMarket, setCurrentMarket] = useState<CustomMarket>(
-    (typeof window !== 'undefined' && returnValidMarket(localStorage.getItem(LS_KEY))) ||
-      availableMarkets[0]
-  );
+  const [currentMarket, setCurrentMarket] = useState<CustomMarket>(availableMarkets[0]);
   const currentMarketData = marketsData[currentMarket];
 
   const handleSetMarket = (market: CustomMarket) => {


### PR DESCRIPTION
this fixes the issue where on reload the wrong market icon would be shown (which essentially is a hydration issue because localstorage is not available at build time so there's mismatch when the client did not select ethereum market)