### PR TITLE
feat: Oracle Reputation PVE integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@mui/icons-material": "^5.5.1",
     "@mui/material": "^5.5.1",
     "@paraswap/sdk": "5.6.0-alpha.3",
+    "@reputation.link/vyps-kit": "^0.5.7",
     "@visx/axis": "^2.6.0",
     "@visx/curve": "^2.1.0",
     "@visx/event": "^2.6.0",

--- a/pages/reserve-overview.page.tsx
+++ b/pages/reserve-overview.page.tsx
@@ -1,3 +1,4 @@
+import { ChainId } from '@aave/contract-helpers';
 import { Trans } from '@lingui/macro';
 import {
   Box,
@@ -9,6 +10,7 @@ import {
 } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import CustomPVEWidget from 'src/components/CustomVYPSWidget';
 import {
   ComputedReserveData,
   useAppDataContext,
@@ -95,6 +97,7 @@ export default function ReserveOverview() {
           </Box>
         </Box>
       </ContentContainer>
+      <CustomPVEWidget allowedChainIDs={[ChainId.mainnet]} token={reserve?.symbol} />
     </>
   );
 }

--- a/src/components/CustomVYPSWidget.tsx
+++ b/src/components/CustomVYPSWidget.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+import { useTheme } from '@mui/system';
+import { SecurityWidget } from '@reputation.link/vyps-kit';
+
+import { useProtocolDataContext } from 'src/hooks/useProtocolDataContext';
+
+const CustomPVEWidget = ({
+  allowedChainIDs = [1],
+  token,
+}: {
+  allowedChainIDs?: number[];
+  token?: string | undefined;
+}) => {
+  const [isLoaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setLoaded(true);
+  }, []); // Bypass bug in dependency of dependency
+
+  const {
+    palette: {
+      mode,
+      background: { header: lightColor, surface: darkColor },
+    },
+  } = useTheme();
+  const { currentChainId } = useProtocolDataContext();
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  // Oracle Reputation's PVE Implementation doesn't support Polygon or Avalanche yet
+  const show = !!allowedChainIDs.find((id) => id === currentChainId);
+  return (
+    <>
+      {show && (
+        <SecurityWidget
+          inset={[5, 5]}
+          style={{ zIndex: 50 }}
+          left
+          variant="sm"
+          color={mode === 'dark' ? darkColor : lightColor}
+          startOpen
+          protocol="aave"
+          meta={{ token }}
+        />
+      )}
+    </>
+  );
+};
+
+export default CustomPVEWidget;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,6 +2441,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.4.tgz#d8c7b8db9226d2d7664553a0741ad7d0397ee503"
   integrity sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==
 
+"@reputation.link/vyps-kit@^0.5.7":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@reputation.link/vyps-kit/-/vyps-kit-0.5.8.tgz#9d2ff5cb37ee4f2eae2a4491e3c15aa49c7c862e"
+  integrity sha512-ckTaUPSZegsoPlz+eDak+1Etpg++/2D6rGWEPRi2etypTzoohs3rbT9lTTCd4K+i0tOUb4EAdiPpNwPtoQ+RQg==
+
 "@rushstack/eslint-patch@^1.0.8":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz"


### PR DESCRIPTION
This is an effective port of [PR 393 in AAVE-UI](https://github.com/aave/aave-ui/pull/393).

We've thrown together a preview page for you guys so you can see it in action.
https://aave-interface-with-pve-qp51q5ug4-reputation.vercel.app
(Go to Ethereum Mainnet market; select a reserve)
|Light|Dark|
|:-:|:-:|
|<img width="1186" alt="Screen Shot 2022-03-18 at 8 58 28 pm" src="https://user-images.githubusercontent.com/35418916/158987638-92a98a47-e494-4a68-9cc3-11d27b49ba31.png">|<img width="1186" alt="Screen Shot 2022-03-18 at 8 58 35 pm" src="https://user-images.githubusercontent.com/35418916/158987318-79c510a0-3ce1-4821-8a5b-46e91e38f1cc.png">|

If videos are your style I give a guide to the changes here.
https://www.loom.com/share/3e0eef7b9beb4453907731e6c96b2837

Big changes are we're using your theme data to theme the widget.
Got any alterations? Feel free to reach out.