### PR TITLE
Fix assets sorting by symbol

### DIFF
--- a/src/modules/markets/AssetsList.tsx
+++ b/src/modules/markets/AssetsList.tsx
@@ -40,7 +40,7 @@ export default function AssetsList() {
 
   if (sortDesc) {
     if (sortName === 'symbol') {
-      filteredData.sort((a, b) => (b.symbol.toUpperCase() < a.symbol.toUpperCase() ? -1 : 1));
+      filteredData.sort((a, b) => (a.symbol.toUpperCase() < b.symbol.toUpperCase() ? -1 : 1));
     } else {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -48,7 +48,7 @@ export default function AssetsList() {
     }
   } else {
     if (sortName === 'symbol') {
-      filteredData.sort((a, b) => (a.symbol.toUpperCase() < b.symbol.toUpperCase() ? -1 : 1));
+      filteredData.sort((a, b) => (b.symbol.toUpperCase() < a.symbol.toUpperCase() ? -1 : 1));
     } else {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/modules/markets/AssetsList.tsx
+++ b/src/modules/markets/AssetsList.tsx
@@ -40,7 +40,7 @@ export default function AssetsList() {
 
   if (sortDesc) {
     if (sortName === 'symbol') {
-      filteredData.sort((a, b) => (b.symbol.toUpperCase() < a.symbol.toUpperCase() ? -1 : 0));
+      filteredData.sort((a, b) => (b.symbol.toUpperCase() < a.symbol.toUpperCase() ? -1 : 1));
     } else {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -48,7 +48,7 @@ export default function AssetsList() {
     }
   } else {
     if (sortName === 'symbol') {
-      filteredData.sort((a, b) => (a.symbol.toUpperCase() < b.symbol.toUpperCase() ? -1 : 0));
+      filteredData.sort((a, b) => (a.symbol.toUpperCase() < b.symbol.toUpperCase() ? -1 : 1));
     } else {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore


### PR DESCRIPTION
This PR:
1. Fixes assets sorting by symbol in Firefox. Currently, it doesn't work. For some reason, this code behaves differently in Chrome/Safari and Firefox:
    ```js
    ["DAI", "EURS", "USDC", "USDT", "sUSD", "AAVE", "RAI", "xSUSHI", "UNI"].sort(function(a, b ) { return b.toUpperCase() < a.toUpperCase() ? -1 : 0;})
    ```
    To make it work in Firefox, I changed `0` to `1`. Chrome/Safari are not affected.
1. Fixes the order of sorting by symbol: ascending order is A to Z, descending is Z to A. Currently, it's the opposite.