### PR TITLE
fix: -100% as calcs from contract is 0 instead of 10000

### DIFF
--- a/src/modules/reserve-overview/ReserveConfiguration.tsx
+++ b/src/modules/reserve-overview/ReserveConfiguration.tsx
@@ -226,81 +226,79 @@ export const ReserveConfiguration: React.FC<{ reserve: ComputedReserveData }> = 
                 </Box>
               )}
             </div>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: { xs: 'column', sm: 'row' },
-                alignItems: { xs: 'flex-start', sm: 'center' },
-                flexWrap: 'wrap',
-                mt: '16px',
-                '& > :not(:last-child)': {
-                  mr: 4,
-                },
-              }}
-            >
-              <Typography sx={{ display: 'inline-flex' }}>
-                <Typography sx={{ color: 'text.muted' }} component="span">
-                  <Trans>Max LTV</Trans>
-                </Typography>
-                <FormattedNumber
-                  value={reserve.formattedBaseLTVasCollateral}
-                  percent
-                  variant="secondary14"
-                  sx={{ ml: 2 }}
-                  visibleDecimals={2}
-                />
-              </Typography>
-              <Typography sx={{ display: 'inline-flex' }}>
-                <Typography sx={{ color: 'text.muted' }} component="span">
-                  <Trans>Liquidation threshold</Trans>
-                </Typography>
-                <FormattedNumber
-                  value={reserve.formattedReserveLiquidationThreshold}
-                  percent
-                  variant="secondary14"
-                  sx={{ ml: 2 }}
-                  visibleDecimals={2}
-                />
-              </Typography>
-              <Typography sx={{ display: 'inline-flex' }}>
-                <Typography sx={{ color: 'text.muted' }} component="span">
-                  <Trans>Liquidation penalty</Trans>
-                </Typography>
-                <FormattedNumber
-                  value={
-                    Number(reserve.formattedReserveLiquidationBonus) < 0
-                      ? '0'
-                      : reserve.formattedReserveLiquidationBonus
-                  }
-                  percent
-                  variant="secondary14"
-                  sx={{ ml: 2 }}
-                  visibleDecimals={2}
-                />
-              </Typography>
-              {reserve.isIsolated && (
+            {reserve.usageAsCollateralEnabled && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: { xs: 'column', sm: 'row' },
+                  alignItems: { xs: 'flex-start', sm: 'center' },
+                  flexWrap: 'wrap',
+                  mt: '16px',
+                  '& > :not(:last-child)': {
+                    mr: 4,
+                  },
+                }}
+              >
                 <Typography sx={{ display: 'inline-flex' }}>
                   <Typography sx={{ color: 'text.muted' }} component="span">
-                    <Trans>Debt ceiling</Trans>
+                    <Trans>Max LTV</Trans>
                   </Typography>
                   <FormattedNumber
-                    value={reserve.isolationModeTotalDebtUSD}
+                    value={reserve.formattedBaseLTVasCollateral}
+                    percent
                     variant="secondary14"
                     sx={{ ml: 2 }}
-                    symbol="USD"
-                    visibleDecimals={2}
-                  />
-                  &nbsp;of
-                  <FormattedNumber
-                    value={reserve.debtCeilingUSD}
-                    variant="secondary14"
-                    sx={{ ml: 2 }}
-                    symbol="USD"
                     visibleDecimals={2}
                   />
                 </Typography>
-              )}
-            </Box>
+                <Typography sx={{ display: 'inline-flex' }}>
+                  <Typography sx={{ color: 'text.muted' }} component="span">
+                    <Trans>Liquidation threshold</Trans>
+                  </Typography>
+                  <FormattedNumber
+                    value={reserve.formattedReserveLiquidationThreshold}
+                    percent
+                    variant="secondary14"
+                    sx={{ ml: 2 }}
+                    visibleDecimals={2}
+                  />
+                </Typography>
+                <Typography sx={{ display: 'inline-flex' }}>
+                  <Typography sx={{ color: 'text.muted' }} component="span">
+                    <Trans>Liquidation penalty</Trans>
+                  </Typography>
+                  <FormattedNumber
+                    value={reserve.formattedReserveLiquidationBonus}
+                    percent
+                    variant="secondary14"
+                    sx={{ ml: 2 }}
+                    visibleDecimals={2}
+                  />
+                </Typography>
+                {reserve.isIsolated && (
+                  <Typography sx={{ display: 'inline-flex' }}>
+                    <Typography sx={{ color: 'text.muted' }} component="span">
+                      <Trans>Debt ceiling</Trans>
+                    </Typography>
+                    <FormattedNumber
+                      value={reserve.isolationModeTotalDebtUSD}
+                      variant="secondary14"
+                      sx={{ ml: 2 }}
+                      symbol="USD"
+                      visibleDecimals={2}
+                    />
+                    &nbsp;of
+                    <FormattedNumber
+                      value={reserve.debtCeilingUSD}
+                      variant="secondary14"
+                      sx={{ ml: 2 }}
+                      symbol="USD"
+                      visibleDecimals={2}
+                    />
+                  </Typography>
+                )}
+              </Box>
+            )}
             {reserve.eModeCategoryId !== 0 && (
               <Box
                 sx={{
@@ -343,11 +341,7 @@ export const ReserveConfiguration: React.FC<{ reserve: ComputedReserveData }> = 
                     <Trans>E-Mode liquidation penalty</Trans>
                   </Typography>
                   <FormattedNumber
-                    value={
-                      Number(reserve.formattedEModeLiquidationBonus) < 0
-                        ? '0'
-                        : reserve.formattedEModeLiquidationBonus
-                    }
+                    value={reserve.formattedEModeLiquidationBonus}
                     percent
                     variant="secondary14"
                     sx={{ ml: 2 }}

--- a/src/modules/reserve-overview/ReserveConfiguration.tsx
+++ b/src/modules/reserve-overview/ReserveConfiguration.tsx
@@ -267,7 +267,11 @@ export const ReserveConfiguration: React.FC<{ reserve: ComputedReserveData }> = 
                   <Trans>Liquidation penalty</Trans>
                 </Typography>
                 <FormattedNumber
-                  value={reserve.formattedReserveLiquidationBonus}
+                  value={
+                    Number(reserve.formattedReserveLiquidationBonus) < 0
+                      ? '0'
+                      : reserve.formattedReserveLiquidationBonus
+                  }
                   percent
                   variant="secondary14"
                   sx={{ ml: 2 }}
@@ -319,7 +323,7 @@ export const ReserveConfiguration: React.FC<{ reserve: ComputedReserveData }> = 
                     percent
                     variant="secondary14"
                     sx={{ ml: 2 }}
-                    visibleDecimals={0}
+                    visibleDecimals={2}
                   />
                 </Typography>
                 <Typography sx={{ display: 'inline-flex' }}>
@@ -331,7 +335,7 @@ export const ReserveConfiguration: React.FC<{ reserve: ComputedReserveData }> = 
                     percent
                     variant="secondary14"
                     sx={{ ml: 2 }}
-                    visibleDecimals={0}
+                    visibleDecimals={2}
                   />
                 </Typography>
                 <Typography sx={{ display: 'inline-flex' }}>
@@ -339,11 +343,15 @@ export const ReserveConfiguration: React.FC<{ reserve: ComputedReserveData }> = 
                     <Trans>E-Mode liquidation penalty</Trans>
                   </Typography>
                   <FormattedNumber
-                    value={reserve.formattedEModeLiquidationBonus}
+                    value={
+                      Number(reserve.formattedEModeLiquidationBonus) < 0
+                        ? '0'
+                        : reserve.formattedEModeLiquidationBonus
+                    }
                     percent
                     variant="secondary14"
                     sx={{ ml: 2 }}
-                    visibleDecimals={0}
+                    visibleDecimals={2}
                   />
                 </Typography>
               </Box>


### PR DESCRIPTION
Maybe it makes more sense to just hide row if reserve is not enabled as collateral to not show the 0%