### PR TITLE
fix: ability to claim rewards for supply/borrow positions that are withdrawn

### DIFF
--- a/cypress/integration/1-v3-markets/2-avalanche-v3-market/reward.avalanche-v3.spec.ts
+++ b/cypress/integration/1-v3-markets/2-avalanche-v3-market/reward.avalanche-v3.spec.ts
@@ -1,0 +1,33 @@
+import { skipState } from '../../../support/steps/common';
+import { configEnvWithTenderlyAvalancheFork } from '../../../support/steps/configuration.steps';
+import { claimReward, supply, withdraw } from '../../../support/steps/main.steps';
+import { rewardIsNotAvailable } from '../../../support/steps/verification.steps';
+import assets from '../../../fixtures/assets.json';
+
+const testData = {
+  deposit: {
+    asset: assets.avalancheMarket.AVAX,
+    amount: 1000,
+    hasApproval: true,
+  },
+  withdraw: {
+    asset: assets.avalancheMarket.AVAX,
+    isCollateral: true,
+    amount: 2000,
+    hasApproval: false,
+  },
+  claimReward: {
+    asset: assets.avalancheMarket.WAVAX,
+  },
+};
+
+describe('REWARD, AVALANCHE V3 MARKET, INTEGRATION SPEC', () => {
+  const skipTestState = skipState(false);
+  configEnvWithTenderlyAvalancheFork({ market: 'fork_proto_avalanche_v3', v3: true });
+
+  supply(testData.deposit, skipTestState, true);
+  claimReward(testData.claimReward, skipTestState, true);
+  withdraw(testData.withdraw, skipTestState, true);
+  claimReward(testData.claimReward, skipTestState, true);
+  rewardIsNotAvailable(skipTestState);
+});

--- a/src/components/transactions/ClaimRewards/ClaimRewardsActions.tsx
+++ b/src/components/transactions/ClaimRewards/ClaimRewardsActions.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro';
 import { Reward } from 'src/helpers/types';
 import { useTransactionHandler } from 'src/helpers/useTransactionHandler';
+import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
 import { useProtocolDataContext } from 'src/hooks/useProtocolDataContext';
 import { useTxBuilderContext } from 'src/hooks/useTxBuilder';
 import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
@@ -21,22 +22,36 @@ export const ClaimRewardsActions = ({
   const { incentivesTxBuilderV2, incentivesTxBuilder } = useTxBuilderContext();
   const { currentMarketData } = useProtocolDataContext();
   const { currentAccount } = useWeb3Context();
+  const { reserves } = useAppDataContext();
 
   const { action, loadingTxns, mainTxState, requiresApproval } = useTransactionHandler({
     tryPermit: false,
     handleGetTxns: async () => {
       if (currentMarketData.v3) {
+        const allReserves: string[] = [];
+        reserves.forEach((reserve) => {
+          if (reserve.aIncentivesData && reserve.aIncentivesData.length > 0) {
+            allReserves.push(reserve.aTokenAddress);
+          }
+          if (reserve.vIncentivesData && reserve.vIncentivesData.length > 0) {
+            allReserves.push(reserve.variableDebtTokenAddress);
+          }
+          if (reserve.sIncentivesData && reserve.sIncentivesData.length > 0) {
+            allReserves.push(reserve.stableDebtTokenAddress);
+          }
+        });
+
         if (selectedReward.symbol === 'all') {
           return incentivesTxBuilderV2.claimAllRewards({
             user: currentAccount,
-            assets: selectedReward.assets,
+            assets: allReserves,
             to: currentAccount,
             incentivesControllerAddress: selectedReward.incentiveControllerAddress,
           });
         } else {
           return incentivesTxBuilderV2.claimRewards({
             user: currentAccount,
-            assets: selectedReward.assets,
+            assets: allReserves,
             to: currentAccount,
             incentivesControllerAddress: selectedReward.incentiveControllerAddress,
             reward: selectedReward.rewardTokenAddress,


### PR DESCRIPTION
In V2, when a user closes a supply or borrow position that is earning rewards, the IncentivesController contract stores these rewards in a separate variable and allows for claiming without passing this asset as a parameter

In V3, this variable was removed and now *all* assets must be passed regardless if the position is active or not.

There's no way to track previous supply/borrow positions, so for v3, all a/s/v tokens with incentives must be passed as the `assets` parameter to `claimRewards`.