### PR TITLE
fix: calculation of max withdrawable amount

### DIFF
--- a/src/components/transactions/Withdraw/WithdrawModalContent.tsx
+++ b/src/components/transactions/Withdraw/WithdrawModalContent.tsx
@@ -75,7 +75,9 @@ export const WithdrawModalContent = ({
     const maxSelected = value === '-1';
     amountRef.current = maxSelected ? maxAmountToWithdraw.toString(10) : value;
     setAmount(value);
-    if (maxSelected) {
+    if (maxSelected && maxAmountToWithdraw.eq(underlyingBalance)) {
+      setWithdrawMax('-1');
+    } else {
       setWithdrawMax(maxAmountToWithdraw.toString(10));
     }
   };

--- a/src/components/transactions/Withdraw/WithdrawModalContent.tsx
+++ b/src/components/transactions/Withdraw/WithdrawModalContent.tsx
@@ -55,15 +55,12 @@ export const WithdrawModalContent = ({
     poolReserve.usageAsCollateralEnabled &&
     user.totalBorrowsMarketReferenceCurrency !== '0'
   ) {
-    // if we have any borrowings we should check how much we can withdraw without liquidation
-    // with 0.5% gap to avoid reverting of tx
-    const excessHF = valueToBigNumber(user.healthFactor).minus('1');
+    // if we have any borrowings we should check how much we can withdraw to a minimum HF of 1.07
+    const excessHF = valueToBigNumber(user.healthFactor).minus('1.07');
     if (excessHF.gt('0')) {
       maxCollateralToWithdrawInETH = excessHF
         .multipliedBy(user.totalBorrowsMarketReferenceCurrency)
-        // because of the rounding issue on the contracts side this value still can be incorrect
-        .div(Number(reserveLiquidationThreshold) + 0.01)
-        .multipliedBy('0.99');
+        .div(reserveLiquidationThreshold);
     }
     maxAmountToWithdraw = BigNumber.min(
       maxAmountToWithdraw,
@@ -78,10 +75,8 @@ export const WithdrawModalContent = ({
     const maxSelected = value === '-1';
     amountRef.current = maxSelected ? maxAmountToWithdraw.toString(10) : value;
     setAmount(value);
-    if (maxSelected && maxAmountToWithdraw.eq(underlyingBalance)) {
-      setWithdrawMax('-1');
-    } else {
-      setWithdrawMax(maxAmountToWithdraw.multipliedBy(0.995).toString(10));
+    if (maxSelected) {
+      setWithdrawMax(maxAmountToWithdraw.toString(10));
     }
   };
 


### PR DESCRIPTION
Currently when the max withdraw button is pressed, the amount is calculated by requiring that collateral * (liquidationThreshold + cushion) is remaining. This results in users being forced to keep a large amount of collateral to cover a small borrow position as shown below.

This changes the calculation to require a minimum health factor of 1.07 (to be consistent with borrow logic), which allows users to withdraw a greater potion of their collateral (in scenario below user could now withdraw up to 14998.6 DAI).


![withdrawIssueStatus](https://user-images.githubusercontent.com/26660211/165195983-2ce28d5c-6e82-4d1a-8bb4-4be85623ac30.png)

![withdrawIssueModal](https://user-images.githubusercontent.com/26660211/165195985-c304c8cc-86bd-43e7-9d37-1719523daa8d.png)


