### PR TITLE
fix: removed reward token symbol from dashboard top pannel

### DIFF
--- a/src/components/transactions/ClaimRewards/ClaimRewardsModalContent.tsx
+++ b/src/components/transactions/ClaimRewards/ClaimRewardsModalContent.tsx
@@ -137,7 +137,6 @@ export const ClaimRewardsModalContent = () => {
   if (claimRewardsTxState.success)
     return <TxSuccessView action="Claimed" amount={selectedReward?.balanceUsd} />;
 
-  console.log('rewards: ', rewards);
 
   return (
     <>

--- a/src/components/transactions/ClaimRewards/ClaimRewardsModalContent.tsx
+++ b/src/components/transactions/ClaimRewards/ClaimRewardsModalContent.tsx
@@ -137,6 +137,8 @@ export const ClaimRewardsModalContent = () => {
   if (claimRewardsTxState.success)
     return <TxSuccessView action="Claimed" amount={selectedReward?.balanceUsd} />;
 
+  console.log('rewards: ', rewards);
+
   return (
     <>
       <TxModalTitle title="Claim rewards" />
@@ -203,6 +205,7 @@ export const ClaimRewardsModalContent = () => {
           {selectedRewardSymbol !== 'all' && (
             <DetailsNumberLineWithSub
               hideSymbolSuffix
+              showSymbolIcon
               symbol={selectedReward.symbol}
               futureValue={selectedReward.balance}
               futureValueUSD={selectedReward.balanceUsd}

--- a/src/components/transactions/FlowCommons/TxModalDetails.tsx
+++ b/src/components/transactions/FlowCommons/TxModalDetails.tsx
@@ -86,6 +86,7 @@ interface DetailsNumberLineWithSubProps {
   futureValue: string;
   futureValueUSD: string;
   hideSymbolSuffix?: boolean;
+  showSymbolIcon?: boolean;
   color?: string;
 }
 
@@ -98,6 +99,7 @@ export const DetailsNumberLineWithSub = ({
   futureValueUSD,
   hideSymbolSuffix,
   color,
+  showSymbolIcon,
 }: DetailsNumberLineWithSubProps) => {
   return (
     <Row caption={description} captionVariant="description" mb={4} align="flex-start">
@@ -121,6 +123,9 @@ export const DetailsNumberLineWithSub = ({
             <Typography ml={1} variant="secondary14">
               {symbol}
             </Typography>
+          )}
+          {symbol && showSymbolIcon && (
+            <TokenIcon symbol={symbol} fontSize="inherit" sx={{ ml: '2px' }} />
           )}
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -276,7 +281,12 @@ export const DetailsUnwrapSwitch = ({
       <FormControlLabel
         value="darkmode"
         control={
-          <Switch disableRipple checked={unwrapped} onClick={() => setUnWrapped(!unwrapped)} data-cy={"wrappedSwitcher"}/>
+          <Switch
+            disableRipple
+            checked={unwrapped}
+            onClick={() => setUnWrapped(!unwrapped)}
+            data-cy={'wrappedSwitcher'}
+          />
         }
         labelPlacement="end"
         label={''}

--- a/src/modules/dashboard/DashboardTopPanel.tsx
+++ b/src/modules/dashboard/DashboardTopPanel.tsx
@@ -3,7 +3,6 @@ import { Trans } from '@lingui/macro';
 import { Box, Button, useMediaQuery, useTheme } from '@mui/material';
 import * as React from 'react';
 import { useState } from 'react';
-import { MultiTokenIcon } from 'src/components/primitives/TokenIcon';
 import { useModalContext } from 'src/hooks/useModal';
 import { useProtocolDataContext } from 'src/hooks/useProtocolDataContext';
 import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';

--- a/src/modules/dashboard/DashboardTopPanel.tsx
+++ b/src/modules/dashboard/DashboardTopPanel.tsx
@@ -37,7 +37,7 @@ export const DashboardTopPanel = () => {
   const theme = useTheme();
   const downToSM = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const { claimableRewardsUsd, assets } = Object.keys(user.calculatedUserIncentives).reduce(
+  const { claimableRewardsUsd } = Object.keys(user.calculatedUserIncentives).reduce(
     (acc, rewardTokenAddress) => {
       const incentive: UserIncentiveData = user.calculatedUserIncentives[rewardTokenAddress];
       const rewardBalance = normalize(incentive.claimableRewards, incentive.rewardTokenDecimals);

--- a/src/modules/dashboard/DashboardTopPanel.tsx
+++ b/src/modules/dashboard/DashboardTopPanel.tsx
@@ -184,9 +184,6 @@ export const DashboardTopPanel = () => {
                   symbolsVariant={noDataTypographyVariant}
                   data-cy={'Claim_Value'}
                 />
-                {assets && (
-                  <MultiTokenIcon symbols={assets} sx={{ fontSize: { xs: '16px', xsm: '20px' } }} />
-                )}
               </Box>
 
               <Button


### PR DESCRIPTION
Removed reward token symbol from dashboard top panel and moved it inside reward claim modal token info row
![image](https://user-images.githubusercontent.com/6848271/165286755-b32b38c3-5743-4e25-ac82-c4c01bf8bbf9.png)
![image](https://user-images.githubusercontent.com/6848271/165286792-10e87124-0cb1-426c-bc66-7b26d76e64a5.png)
