### PR TITLE
fix: hf pointer not going less than 1 if hf > 1

### DIFF
--- a/src/modules/dashboard/LiquidationRiskParametresModal/components/HFContent.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/components/HFContent.tsx
@@ -40,6 +40,8 @@ export const HFContent = ({ healthFactor }: HFContentProps) => {
     dotPosition = 15;
   } else if (+healthFactor < 1.2 && +healthFactor > 1.1) {
     dotPosition = 10;
+  } else if (+healthFactor < 1.1 && +healthFactor > 1) {
+    dotPosition = 9;
   } else if (+healthFactor === 1) {
     dotPosition = 0;
   }


### PR DESCRIPTION
Updates hf progress var so hf bigger than 1 will always be on the right of the 1 pointer
![image](https://user-images.githubusercontent.com/6848271/165292034-82edb00d-cf9a-4d38-b187-df3be799faa7.png)
