### PR TITLE
fix: show skeleton instead of stale data while loading

### DIFF
--- a/src/components/primitives/CheckBadge.tsx
+++ b/src/components/primitives/CheckBadge.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/solid';
+import { CheckCircleIcon, XCircleIcon, QuestionMarkCircleIcon } from '@heroicons/react/solid';
 import { Box, BoxProps, Typography, TypographyProps, useTheme } from '@mui/material';
 import { ReactNode } from 'react';
 
@@ -6,16 +6,25 @@ interface CheckBadgeProps extends BoxProps {
   checked?: boolean;
   text: ReactNode;
   variant?: TypographyProps['variant'];
+  loading?: boolean;
 }
 
-export function CheckBadge({ checked, text, variant = 'subheader2', ...rest }: CheckBadgeProps) {
+export function CheckBadge({
+  checked,
+  text,
+  variant = 'subheader2',
+  loading,
+  ...rest
+}: CheckBadgeProps) {
   const { palette } = useTheme();
   return (
     <Box {...rest} sx={{ display: 'flex', alignItems: 'center', ...rest.sx }}>
       <Typography variant={variant} component="span" sx={{ mr: 1 }}>
         {text}
       </Typography>
-      {checked ? (
+      {loading ? (
+        <QuestionMarkCircleIcon height={16} />
+      ) : checked ? (
         <CheckCircleIcon height={16} color={palette.success.main} />
       ) : (
         <XCircleIcon height={16} color={palette.error.main} />

--- a/src/modules/governance/ProposalListItem.tsx
+++ b/src/modules/governance/ProposalListItem.tsx
@@ -7,6 +7,7 @@ import { Link, ROUTES } from 'src/components/primitives/Link';
 import { FormattedProposalTime } from './FormattedProposalTime';
 import { StateBadge } from './StateBadge';
 import { formatProposal } from './utils/formatProposal';
+import { isProposalStateImmutable } from './utils/immutableStates';
 import { VoteBar } from './VoteBar';
 
 export function ProposalListItem({
@@ -16,6 +17,8 @@ export function ProposalListItem({
 }: GovernancePageProps['proposals'][0]) {
   const { nayPercent, yaePercent, nayVotes, yaeVotes, quorumReached, diffReached } =
     formatProposal(proposal);
+
+  const mightBeStale = prerendered && !isProposalStateImmutable(proposal);
   return (
     <Box
       sx={{
@@ -47,15 +50,19 @@ export function ProposalListItem({
           {ipfs.title}
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <StateBadge state={proposal.state} />
+          <StateBadge state={proposal.state} loading={mightBeStale} />
           <FormattedProposalTime
             state={proposal.state}
             executionTime={proposal.executionTime}
             expirationTimestamp={proposal.expirationTimestamp}
             executionTimeWithGracePeriod={proposal.executionTimeWithGracePeriod}
           />
-          <CheckBadge text={<Trans>Quorum</Trans>} checked={quorumReached} />
-          <CheckBadge text={<Trans>Differential</Trans>} checked={diffReached} />
+          <CheckBadge text={<Trans>Quorum</Trans>} checked={quorumReached} loading={mightBeStale} />
+          <CheckBadge
+            text={<Trans>Differential</Trans>}
+            checked={diffReached}
+            loading={mightBeStale}
+          />
         </Box>
       </Box>
       <Box
@@ -65,8 +72,8 @@ export function ProposalListItem({
           mt: { xs: 7, lg: 0 },
         }}
       >
-        <VoteBar yae percent={yaePercent} votes={yaeVotes} sx={{ mb: 4 }} />
-        <VoteBar percent={nayPercent} votes={nayVotes} />
+        <VoteBar yae percent={yaePercent} votes={yaeVotes} sx={{ mb: 4 }} loading={mightBeStale} />
+        <VoteBar percent={nayPercent} votes={nayVotes} loading={mightBeStale} />
       </Box>
     </Box>
   );

--- a/src/modules/governance/ProposalsList.tsx
+++ b/src/modules/governance/ProposalsList.tsx
@@ -71,6 +71,7 @@ export function ProposalsList({ proposals: initialProposals }: GovernancePagePro
             proposalId: proposal.id,
           });
           copy[proposal.id].proposal = await enhanceProposalWithTimes(rest);
+          copy[proposal.id].prerendered = false;
         }
         setProposals(copy);
       }

--- a/src/modules/governance/StateBadge.tsx
+++ b/src/modules/governance/StateBadge.tsx
@@ -1,8 +1,9 @@
 import { ProposalState } from '@aave/contract-helpers';
-import { alpha, experimental_sx, styled } from '@mui/material';
+import { alpha, experimental_sx, Skeleton, styled } from '@mui/material';
 
 interface StateBadgeProps {
   state: ProposalState;
+  loading?: boolean;
 }
 
 const Badge = styled('span')<StateBadgeProps>(({ theme, state }) => {
@@ -39,6 +40,7 @@ const Badge = styled('span')<StateBadgeProps>(({ theme, state }) => {
   });
 });
 
-export function StateBadge({ state }: StateBadgeProps) {
+export function StateBadge({ state, loading }: StateBadgeProps) {
+  if (loading) return <Skeleton width={70} />;
   return <Badge state={state}>{state}</Badge>;
 }

--- a/src/modules/governance/VoteBar.tsx
+++ b/src/modules/governance/VoteBar.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro';
-import { Box, BoxProps, experimental_sx, styled, Typography } from '@mui/material';
+import { Box, BoxProps, experimental_sx, Skeleton, styled, Typography } from '@mui/material';
 import { FormattedNumber } from 'src/components/primitives/FormattedNumber';
 
 const OuterBar = styled('div')(
@@ -33,25 +33,43 @@ interface VoteBarProps extends BoxProps {
   votes: number;
   percent: number;
   yae?: boolean;
+  loading?: boolean;
 }
-export function VoteBar({ percent, yae, votes, ...rest }: VoteBarProps) {
+
+export function VoteBar({ percent, yae, votes, loading, ...rest }: VoteBarProps) {
   return (
     <Box {...rest}>
       <Box sx={{ display: 'flex' }}>
         <Typography variant="description" sx={{ mr: 2 }}>
           {yae ? <Trans>YAE</Trans> : <Trans>NAY</Trans>}
         </Typography>
-        <FormattedNumber
-          value={votes}
-          sx={{ flexGrow: 1 }}
-          visibleDecimals={2}
-          variant="secondary14"
-        />
-        <FormattedNumber value={percent} percent variant="caption" color="text.secondary" />
+        {loading ? (
+          <Typography variant="secondary14" sx={{ flexGrow: 1, lineHeight: '1rem' }}>
+            <Skeleton width={40} />
+          </Typography>
+        ) : (
+          <FormattedNumber
+            value={votes}
+            sx={{ flexGrow: 1 }}
+            visibleDecimals={2}
+            variant="secondary14"
+          />
+        )}
+        {loading ? (
+          <Typography variant="caption">
+            <Skeleton width={40} />
+          </Typography>
+        ) : (
+          <FormattedNumber value={percent} percent variant="caption" color="text.secondary" />
+        )}
       </Box>
-      <OuterBar>
-        <InnerBar percent={percent} yae={yae} />
-      </OuterBar>
+      {loading ? (
+        <Skeleton variant="rectangular" height={8} sx={{ borderRadius: '6px' }} />
+      ) : (
+        <OuterBar>
+          <InnerBar percent={percent} yae={yae} />
+        </OuterBar>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
Currently aave governance shows a stale state on initial load and updates a few seconds after.
Some people in the community reported that this is dangerously misleading as it's showing wrong vote numbers at al before updating them which might lead to wrong conclusions.

This pr changes the ui to render a loading state where relevant to be less misleading.

https://www.awesomescreenshot.com/video/8694531?key=7035a86f0ffaa80b321ce57bd120daf6