### PR TITLE
fix: allow dynamic proposal fetching for proposal 0

### DIFF
--- a/pages/governance/proposal/index.governance.tsx
+++ b/pages/governance/proposal/index.governance.tsx
@@ -38,7 +38,7 @@ export default function DynamicProposal() {
   usePolling(
     updateProposal,
     20000,
-    (proposal ? isProposalStateImmutable(proposal) : false) || !id,
+    (proposal ? isProposalStateImmutable(proposal) : false) || id === undefined,
     [id]
   );
 


### PR DESCRIPTION
Fixes a funky edge case on `http://localhost:3000/governance/proposal/?proposalId=0` which would never load as `!0` evaluates to `true` leading to a `skip`


This fix works around that issue by increasing specificity on the comparison