### PR TITLE
fix: disable voting after vote was casted

### DIFF
--- a/src/modules/governance/proposal/VoteInfo.tsx
+++ b/src/modules/governance/proposal/VoteInfo.tsx
@@ -111,14 +111,13 @@ export function VoteInfo({ id, state, strategy, startBlock }: CustomProposalType
           <Trans>Not enough voting power to participate in this proposal</Trans>
         </Alert>
       )}
-      {currentAccount && voteOngoing && Number(power) !== 0 && (
+      {!didVote && currentAccount && voteOngoing && Number(power) !== 0 && (
         <>
           <Button
             color="success"
             variant="contained"
             fullWidth
             onClick={() => openGovVote(id, true, power)}
-            disabled={support === true}
           >
             <Trans>Vote YAE</Trans>
           </Button>
@@ -127,7 +126,6 @@ export function VoteInfo({ id, state, strategy, startBlock }: CustomProposalType
             variant="contained"
             fullWidth
             onClick={() => openGovVote(id, false, power)}
-            disabled={support === false}
             sx={{ mt: 2 }}
           >
             <Trans>Vote NAY</Trans>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4396533/167013247-2f766354-f9f4-42ed-8645-ec9c2000dcd2.png)
You can only vote once per address & proposal.
Flipping your vote is not possible as you could swing elections that way & mislead other participants.

- closes https://github.com/aave/interface/issues/742