### PR TITLE
fix: use correct decimals when adding token to wallet

### DIFF
--- a/src/components/transactions/FlowCommons/Success.tsx
+++ b/src/components/transactions/FlowCommons/Success.tsx
@@ -111,7 +111,7 @@ export const TxSuccessView = ({
               onClick={() => {
                 addERC20Token({
                   address: addToken.address,
-                  decimals: 18,
+                  decimals: addToken.decimals,
                   symbol: addToken.aToken ? `a${addToken.symbol}` : addToken.symbol,
                   image: !/_/.test(addToken.symbol) ? base64 : undefined,
                 });


### PR DESCRIPTION
After a tx, there's a modal that allows users to add tokens to their wallet which currently has the decimals for this token hardcoded to 18.