### PR TITLE
fix: replace mumbai rpc with alchemy demo

### DIFF
--- a/src/ui-config/networksConfig.ts
+++ b/src/ui-config/networksConfig.ts
@@ -122,8 +122,8 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   },
   [ChainId.mumbai]: {
     name: 'Mumbai',
-    publicJsonRPCUrl: ['https://rpc-mumbai.maticvigil.com'],
-    publicJsonRPCWSUrl: 'wss://rpc-mumbai.maticvigil.com',
+    publicJsonRPCUrl: ['https://polygon-mumbai.g.alchemy.com/v2/demo'],
+    publicJsonRPCWSUrl: 'wss://polygon-mumbai.g.alchemy.com/v2/demo',
     // protocolDataUrl: 'https://api.thegraph.com/subgraphs/name/aave/aave-v2-polygon-mumbai',
     baseAssetSymbol: 'MATIC',
     wrappedBaseAssetSymbol: 'WMATIC',


### PR DESCRIPTION
The maticvigil mumbai rpc has been down for days. Adding the alchemy as a fallback doesn't work either, so just replacing it entirely with alchemy. 