### PR TITLE
feat: always use mainnet for staking data source

### DIFF
--- a/cypress/integration/1-v3-markets/5-fantom-v3-market/0-assets/weth.fantom-v3.spec.ts
+++ b/cypress/integration/1-v3-markets/5-fantom-v3-market/0-assets/weth.fantom-v3.spec.ts
@@ -18,7 +18,7 @@ const testData = {
     borrow: [
       {
         asset: assets.fantomMarket.WETH,
-        amount: 0.5,
+        amount: 0.2,
         apyType: constants.borrowAPYType.default,
         hasApproval: true,
       },
@@ -68,7 +68,7 @@ const testData = {
       {
         type: constants.dashboardTypes.borrow,
         assetName: assets.fantomMarket.WETH.shortName,
-        amount: 0.46,
+        amount: 0.16,
         apyType: constants.borrowAPYType.variable,
       },
     ],

--- a/src/ui-config/stakeConfig.ts
+++ b/src/ui-config/stakeConfig.ts
@@ -1,5 +1,4 @@
 import { ChainId, Stake } from '@aave/contract-helpers';
-import { NEXT_PUBLIC_ENABLE_TESTNET } from 'src/utils/marketsAndNetworksConfig';
 
 export interface StakeConfig {
   chainId: ChainId;
@@ -51,8 +50,5 @@ export const kovanStakeConfig: StakeConfig = {
 };
 
 export const getStakeConfig = () => {
-  if (NEXT_PUBLIC_ENABLE_TESTNET) {
-    return kovanStakeConfig;
-  }
   return mainnetStakeConfig;
 };


### PR DESCRIPTION
Currently when testnet mode is enabled, the staking page switches the data source to Kovan which is confusing and leads people to believe their staked assets are missing.

This switches the staking page to always use data from Eth Mainnet