### PR TITLE
ci: fix cypress tests launch conditions

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -176,6 +176,7 @@ jobs:
           YARN_TEST_COMMAND: npx cypress-repeat run -n 2 --rerun-failed-only --config-file ./cypress/configs/v3-markets/${{ matrix.market }}-v3-full.config.json
 
   cypress_additional_v2:
+    if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
     runs-on: ubuntu-latest
     needs:
       - deploy
@@ -200,6 +201,7 @@ jobs:
           YARN_TEST_COMMAND: npx cypress-repeat run -n 2 --rerun-failed-only --config-file ./cypress/configs/v2-markets/${{ matrix.market }}-v2-additional.config.json
 
   cypress_additional_v3:
+    if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
     runs-on: ubuntu-latest
     needs:
       - deploy

--- a/.github/workflows/test-deploy-fork.yml
+++ b/.github/workflows/test-deploy-fork.yml
@@ -60,7 +60,7 @@ jobs:
 
   cypress_smoke_v2:
     runs-on: ubuntu-latest
-    needs: build
+    needs: ["prepare_jobs"]
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +82,7 @@ jobs:
 
   cypress_smoke_v3:
     runs-on: ubuntu-latest
-    needs: build
+    needs: ["prepare_jobs"]
     strategy:
       fail-fast: false
       matrix:
@@ -147,10 +147,7 @@ jobs:
 
   cypress_full_v2:
     runs-on: ubuntu-latest
-    needs:
-      - deploy
-      - cypress_smoke_v2
-      - cypress_smoke_v3
+    needs: ["deploy_fork"]
     strategy:
       fail-fast: false
       matrix:
@@ -172,10 +169,7 @@ jobs:
 
   cypress_full_v3:
     runs-on: ubuntu-latest
-    needs:
-      - deploy
-      - cypress_smoke_v2
-      - cypress_smoke_v3
+    needs: ["deploy_fork"]
     strategy:
       fail-fast: false
       matrix:
@@ -197,10 +191,7 @@ jobs:
 
   cypress_additional_v2:
     runs-on: ubuntu-latest
-    needs:
-      - deploy
-      - cypress_smoke_v2
-      - cypress_smoke_v3
+    needs: ["deploy_fork"]
     strategy:
       fail-fast: false
       matrix:
@@ -221,10 +212,7 @@ jobs:
 
   cypress_additional_v3:
     runs-on: ubuntu-latest
-    needs:
-      - deploy
-      - cypress_smoke_v2
-      - cypress_smoke_v3
+    needs: ["deploy_fork"]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
1. Skip `additional` tests on `main` branch entirely
2. Fix issue in workflow for forks introduced by https://github.com/aave/interface/pull/771