### PR TITLE
ci: create GH release on deploy to prod

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -1,0 +1,6 @@
+### Links to the latest release
+
+https://app.aave.com/
+https://<ipfs-hash>.ipfs.cf-ipfs.com/
+https://<ipfs-hash>.ipfs.dweb.link/
+https://<ipfs-hash>.ipfs.infura-ipfs.io/

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -224,7 +224,6 @@ jobs:
           YARN_TEST_COMMAND: npx cypress-repeat run -n 2 --rerun-failed-only --config-file ./cypress/configs/v3-markets/${{ matrix.market }}-v3-additional.config.json
 
   deploy_production:
-    runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main'
@@ -232,64 +231,19 @@ jobs:
       - deploy
       - cypress_full_v2
       - cypress_full_v3
-    steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
-
-      - name: crust
-        uses: crustio/ipfs-crust-action@18f5ab4e8496351cfaca10a55ced7119cb0fe677 # v2.0.6
-        continue-on-error: true
-        timeout-minutes: 3
-        with:
-          cid: '${{ needs.deploy.outputs.pinata_hash }}'
-          seeds: ${{ secrets.CRUST_SEEDS }}
-
-      - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # v3.0.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: install
-        run: yarn add axios
-
-      - name: Update prod DNS
-        id: deploy
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
-          HASH: '${{ needs.deploy.outputs.pinata_hash }}'
-          CF_DEPLOYMENT_DOMAIN: app.aave.com
-        run: node scripts/update-cloudflare.js
+    uses: ./.github/workflows/deploy-prod.yml
+    with:
+      PINATA_HASH: '${{ needs.deploy.outputs.pinata_hash }}'
+    secrets: inherit
 
   deploy_production_no_cypress:
-    runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       contains(github.event.head_commit.message, '[skip cypress]')
     needs:
       - deploy
-    steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
-
-      - name: crust
-        uses: crustio/ipfs-crust-action@18f5ab4e8496351cfaca10a55ced7119cb0fe677 # v2.0.6
-        continue-on-error: true
-        timeout-minutes: 3
-        with:
-          cid: '${{ needs.deploy.outputs.pinata_hash }}'
-          seeds: ${{ secrets.CRUST_SEEDS }}
-
-      - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # v3.0.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: install
-        run: yarn add axios
-
-      - name: Update prod DNS
-        id: deploy
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
-          HASH: '${{ needs.deploy.outputs.pinata_hash }}'
-          CF_DEPLOYMENT_DOMAIN: app.aave.com
-        run: node scripts/update-cloudflare.js
+    uses: ./.github/workflows/deploy-prod.yml
+    with:
+      PINATA_HASH: '${{ needs.deploy.outputs.pinata_hash }}'
+    secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,63 @@
+name: Reusable workflow for deploying to production
+
+on:
+  workflow_call:
+    inputs:
+      PINATA_HASH:
+        type: string
+        description: IPFS hash to pin and use in release description
+        required: true
+
+jobs: 
+  deploy_production:
+    runs-on: ubuntu-latest
+    environment:
+      name: Production
+      url: 'https://app.aave.com'
+    steps:
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+
+      - name: download build
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+        with:
+          name: out
+          path: out
+
+      - name: crust
+        uses: crustio/ipfs-crust-action@18f5ab4e8496351cfaca10a55ced7119cb0fe677 # v2.0.6
+        continue-on-error: true
+        timeout-minutes: 3
+        with:
+          cid: '${{ inputs.PINATA_HASH }}'
+          seeds: '${{ secrets.CRUST_SEEDS }}'
+
+      - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # v3.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: install
+        run: yarn add axios
+
+      - name: Update prod DNS
+        env:
+          CF_API_TOKEN: '${{ secrets.CF_API_TOKEN }}'
+          CF_ZONE_ID: '${{ secrets.CF_ZONE_ID }}'
+          HASH: '${{ inputs.PINATA_HASH }}'
+          CF_DEPLOYMENT_DOMAIN: app.aave.com
+        run: node scripts/update-cloudflare.js
+    
+      - name: prepare release
+        run: |
+          cp .github/release-template.md ./release-notes.md
+          sed -i 's|<ipfs-hash>|${{ inputs.PINATA_HASH }}|g' ./release-notes.md
+          tar -czf app-build.tar.gz out/
+          echo "TAG=release-$(date '+%Y-%m-%d_%H-%M')" >> ${GITHUB_ENV}
+
+      - name: Create GH release
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
+        with:
+          name: Production release
+          artifacts: app-build.tar.gz
+          bodyFile: release-notes.md
+          commit: '${{ github.sha }}'
+          tag: '${{ env.TAG }}'


### PR DESCRIPTION
Closes https://github.com/aave/interface/issues/723

On every deploy to production:
  * Create git tag `release-YYYY-MM-DD_HH-mm`
  * Create Github release with up-to-date IPFS links
  * Attach built app files to release as and artifact

Would look something like this: 
![image](https://user-images.githubusercontent.com/2317358/168288683-9b47d228-4c0d-46bf-81ab-53670fad8b61.png)

Example draft release (not visible publicly): https://github.com/aave/interface/releases/tag/untagged-4d812ba21369d74f0141
