### PR TITLE
Ambire Wallet batch transaction integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:open": "DOTENV_CONFIG_PATH='.env.local' cypress open"
   },
   "dependencies": {
-    "@aave/contract-helpers": "1.2.1",
+    "@aave/contract-helpers": "npm:@ambiretest/aave-contract-helpers@1.3.1",
     "@aave/math-utils": "1.2.1",
     "@apollo/client": "^3.5.10",
     "@emotion/cache": "latest",

--- a/src/hooks/useAmbireWC.ts
+++ b/src/hooks/useAmbireWC.ts
@@ -1,0 +1,10 @@
+import { useWeb3React } from '@web3-react/core';
+import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
+
+export default function useIsAmbireWC(): boolean {
+  const res = useWeb3React();
+  const wcConnector = res?.connector as WalletConnectConnector;
+  return (
+    wcConnector?.walletConnectProvider?.signer?.connection?.wc?._peerMeta?.name === 'Ambire Wallet'
+  );
+}

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -18,6 +18,7 @@ import { API_ETH_MOCK_ADDRESS, transactionType } from '@aave/contract-helpers';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { TorusConnector } from '@web3-react/torus-connector';
+import WalletConnectProvider from '@walletconnect/ethereum-provider';
 
 export type ERC20TokenType = {
   address: string;
@@ -38,6 +39,7 @@ export type Web3Data = {
   switchNetwork: (chainId: number) => Promise<void>;
   getTxError: (txHash: string) => Promise<string>;
   sendTx: (txData: transactionType) => Promise<TransactionResponse>;
+  sendBatchTx: (txData: transactionType[]) => Promise<TransactionResponse>;
   addERC20Token: (args: ERC20TokenType) => Promise<boolean>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   signTxData: (unsignedData: string) => Promise<SignatureLike>;
@@ -215,6 +217,17 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     throw new Error('Error sending transaction. Provider not found');
   };
 
+  const sendBatchTx = async (txData: transactionType[]): Promise<TransactionResponse> => {
+    if (provider) {
+      const wcProvider = provider.provider as WalletConnectProvider;
+      return await wcProvider.connector.sendCustomRequest({
+        method: 'ambire_sendBatchTransaction',
+        params: txData,
+      });
+    }
+    throw new Error('Error sending transaction. Provider not found');
+  };
+
   // TODO: recheck that it works on all wallets
   const signTxData = async (unsignedData: string): Promise<SignatureLike> => {
     if (provider && account) {
@@ -329,6 +342,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
           switchNetwork,
           getTxError,
           sendTx,
+          sendBatchTx,
           signTxData,
           currentAccount: mockAddress || account?.toLowerCase() || '',
           addERC20Token,


### PR DESCRIPTION
This PR implements batching for ERC20 approvals with Ambire, which is a smart wallet that allows for transaction batching, smart recovery, gas abstractions and others. Rather than having to sign & send the ERC20 approval transaction separately, with this PR, it will be batched together with the specific action when the wallet used is Ambire.

The UX impact is immense, as the approval step is essentially permanently eliminated, without compromising security (the same calls are being done, just in one tx).

While this PR implements some logic custom to Ambire, this logic can be easily modified into an implementation of the batching EIP that’s currently being worked on by Gnosis Safe and Ambire, turning the code into a general implementation of txn batching.

This implementation mainly adds the function sendBatchTx, similar to sendTx, that uses WalletConnect. Also, the PR for [aave-utilities](https://github.com/aave/aave-utilities/pull/348) is required to properly complete this PR.
At the moment, a npm version of modified aave-utilities is used to make this PR work but will have to be changed with the official npm package of @aave/contracts-helper, that adds an argument to skip the gas estimation (that would make for example the swap tx gas estimation fail if the approval is not done yet)

Please advise if there's a better way