### PR TITLE
fix: account for difficulty increase

### DIFF
--- a/src/modules/governance/FormattedProposalTime.tsx
+++ b/src/modules/governance/FormattedProposalTime.tsx
@@ -21,6 +21,7 @@ export function FormattedProposalTime({
   executionTimeWithGracePeriod,
 }: FormattedProposalTimeProps) {
   const timestamp = useCurrentTimestamp(30);
+
   if ([ProposalState.Active, ProposalState.Pending].includes(state)) {
     return (
       <Typography component="span" variant="caption">


### PR DESCRIPTION
https://ycharts.com/indicators/ethereum_average_block_time#:~:text=Ethereum%20Average%20Block%20Time%20is,from%2013.25%20one%20year%20ago.