### PR TITLE
refactor: make ropsten config more consistent with other markets

### DIFF
--- a/src/components/MarketSwitcher.tsx
+++ b/src/components/MarketSwitcher.tsx
@@ -212,15 +212,6 @@ export const MarketSwitcher = () => {
               <ListItemText sx={{ mr: 0 }}>
                 {marketNaming.name} {market.isFork ? 'Fork' : ''}
               </ListItemText>
-
-              {/*               {currentMarket === marketId && (
-                <ListItemIcon sx={{ m: 0 }}>
-                  <SvgIcon>
-                    <CheckIcon />
-                  </SvgIcon>
-                </ListItemIcon>
-              )} */}
-
               <ListItemText sx={{ textAlign: 'right' }}>
                 <Typography color="text.muted" variant="description">
                   {marketNaming.testChainName}
@@ -257,15 +248,6 @@ export const MarketSwitcher = () => {
               <ListItemText sx={{ mr: 0 }}>
                 {marketNaming.name} {market.isFork ? 'Fork' : ''}
               </ListItemText>
-
-              {/*               {currentMarket === marketId && (
-                <ListItemIcon sx={{ m: 0 }}>
-                  <SvgIcon>
-                    <CheckIcon />
-                  </SvgIcon>
-                </ListItemIcon>
-              )} */}
-
               <ListItemText sx={{ textAlign: 'right' }}>
                 <Typography color="text.muted" variant="description">
                   {marketNaming.testChainName}

--- a/src/components/MarketSwitcher.tsx
+++ b/src/components/MarketSwitcher.tsx
@@ -36,9 +36,13 @@ const getMarketHelpData = (marketName: string) => {
   const testChains = ['Kovan', 'Rinkeby', 'Ropsten', 'Mumbai', 'Fuji', 'Testnet'];
   const arrayName = marketName.split(' ');
   const testChainName = arrayName.filter((el) => testChains.indexOf(el) > -1);
-  const formattedMarketTitle = arrayName.filter((el) => !testChainName.includes(el));
+  const marketTitle = arrayName.filter((el) => !testChainName.includes(el)).join(' ');
+  // Instead of calling all Eth testnets 'Ethereum', display as market name instead
+  const formattedMarketTitle =
+    marketTitle === 'Ethereum' && testChainName[0] ? testChainName[0] : marketTitle;
+
   return {
-    name: formattedMarketTitle.join(' '),
+    name: formattedMarketTitle,
     testChainName: testChainName[0],
   };
 };

--- a/src/components/MarketSwitcher.tsx
+++ b/src/components/MarketSwitcher.tsx
@@ -1,9 +1,8 @@
-import { CheckIcon, ChevronDownIcon } from '@heroicons/react/outline';
+import { ChevronDownIcon } from '@heroicons/react/outline';
 import { Trans } from '@lingui/macro';
 import {
   Box,
   Divider,
-  ListItemIcon,
   ListItemText,
   MenuItem,
   SvgIcon,
@@ -37,12 +36,8 @@ const getMarketHelpData = (marketName: string) => {
   const arrayName = marketName.split(' ');
   const testChainName = arrayName.filter((el) => testChains.indexOf(el) > -1);
   const marketTitle = arrayName.filter((el) => !testChainName.includes(el)).join(' ');
-  // Instead of calling all Eth testnets 'Ethereum', display as market name instead
-  const formattedMarketTitle =
-    marketTitle === 'Ethereum' && testChainName[0] ? testChainName[0] : marketTitle;
-
   return {
-    name: formattedMarketTitle,
+    name: marketTitle,
     testChainName: testChainName[0],
   };
 };
@@ -178,7 +173,7 @@ export const MarketSwitcher = () => {
           },
           PaperProps: {
             style: {
-              minWidth: 240,
+              minWidth: 280,
             },
             variant: 'outlined',
             elevation: 0,
@@ -200,7 +195,7 @@ export const MarketSwitcher = () => {
       )}
       {availableMarkets.map((marketId: CustomMarket) => {
         const { market, network } = getMarketInfoById(marketId);
-
+        const marketNaming = getMarketHelpData(market.marketTitle);
         return (
           market.v3 && (
             <MenuItem
@@ -212,19 +207,25 @@ export const MarketSwitcher = () => {
               <MarketLogo
                 size={32}
                 logo={network.networkLogoPath}
-                testChainName={getMarketHelpData(market.marketTitle).testChainName}
+                testChainName={marketNaming.testChainName}
               />
-              <ListItemText sx={{ mr: 3 }}>
-                {getMarketHelpData(market.marketTitle).name} {market.isFork ? 'Fork' : ''}
+              <ListItemText sx={{ mr: 0 }}>
+                {marketNaming.name} {market.isFork ? 'Fork' : ''}
               </ListItemText>
 
-              {currentMarket === marketId && (
+              {/*               {currentMarket === marketId && (
                 <ListItemIcon sx={{ m: 0 }}>
                   <SvgIcon>
                     <CheckIcon />
                   </SvgIcon>
                 </ListItemIcon>
-              )}
+              )} */}
+
+              <ListItemText sx={{ textAlign: 'right' }}>
+                <Typography color="text.muted" variant="description">
+                  {marketNaming.testChainName}
+                </Typography>
+              </ListItemText>
             </MenuItem>
           )
         );
@@ -239,7 +240,7 @@ export const MarketSwitcher = () => {
       )}
       {availableMarkets.map((marketId: CustomMarket) => {
         const { market, network } = getMarketInfoById(marketId);
-
+        const marketNaming = getMarketHelpData(market.marketTitle);
         return (
           !market.v3 && (
             <MenuItem
@@ -251,19 +252,25 @@ export const MarketSwitcher = () => {
               <MarketLogo
                 size={32}
                 logo={network.networkLogoPath}
-                testChainName={getMarketHelpData(market.marketTitle).testChainName}
+                testChainName={marketNaming.testChainName}
               />
-              <ListItemText sx={{ mr: 3 }}>
-                {getMarketHelpData(market.marketTitle).name} {market.isFork ? 'Fork' : ''}
+              <ListItemText sx={{ mr: 0 }}>
+                {marketNaming.name} {market.isFork ? 'Fork' : ''}
               </ListItemText>
 
-              {currentMarket === marketId && (
+              {/*               {currentMarket === marketId && (
                 <ListItemIcon sx={{ m: 0 }}>
                   <SvgIcon>
                     <CheckIcon />
                   </SvgIcon>
                 </ListItemIcon>
-              )}
+              )} */}
+
+              <ListItemText sx={{ textAlign: 'right' }}>
+                <Typography color="text.muted" variant="description">
+                  {marketNaming.testChainName}
+                </Typography>
+              </ListItemText>
             </MenuItem>
           )
         );

--- a/src/components/MarketSwitcher.tsx
+++ b/src/components/MarketSwitcher.tsx
@@ -33,13 +33,12 @@ export const getMarketInfoById = (marketId: CustomMarket) => {
 };
 
 const getMarketHelpData = (marketName: string) => {
-  const testChains = ['Kovan', 'Rinkeby', 'Mumbai', 'Fuji', 'Testnet'];
+  const testChains = ['Kovan', 'Rinkeby', 'Ropsten', 'Mumbai', 'Fuji', 'Testnet'];
   const arrayName = marketName.split(' ');
   const testChainName = arrayName.filter((el) => testChains.indexOf(el) > -1);
-  const formattedMarketTittle = arrayName.filter((el) => !testChainName.includes(el));
-
+  const formattedMarketTitle = arrayName.filter((el) => !testChainName.includes(el));
   return {
-    name: formattedMarketTittle.join(' '),
+    name: formattedMarketTitle.join(' '),
     testChainName: testChainName[0],
   };
 };

--- a/src/ui-config/marketsConfig.tsx
+++ b/src/ui-config/marketsConfig.tsx
@@ -61,6 +61,7 @@ export enum CustomMarket {
   proto_harmony_testnet_v3 = 'proto_harmony_testnet_v3',
   proto_fuji_v3 = 'proto_fuji_v3',
   proto_optimism_kovan_v3 = 'proto_optimism_kovan_v3',
+  proto_ropsten_v3 = 'proto_ropsten_v3',
   // v3 mainnets
   proto_optimism_v3 = 'proto_optimism_v3',
   proto_fantom_v3 = 'proto_fantom_v3',
@@ -68,8 +69,6 @@ export enum CustomMarket {
   proto_avalanche_v3 = 'proto_avalanche_v3',
   proto_polygon_v3 = 'proto_polygon_v3',
   proto_arbitrum_v3 = 'proto_arbitrum_v3',
-  proto_ropsten_v3 = 'proto_ropsten_v3',
-
   // v2
   proto_kovan = 'proto_kovan',
   proto_mainnet = 'proto_mainnet',
@@ -294,6 +293,28 @@ export const marketsData: {
       UI_INCENTIVE_DATA_PROVIDER: '0x2c9f31b1F9838Bb8781bb61a0d0a4615f6530207',
     },
   },
+  [CustomMarket.proto_ropsten_v3]: {
+    marketTitle: 'Ethereum Ropsten',
+    v3: true,
+    chainId: ChainId.ropsten,
+    enabledFeatures: {
+      // Note: We should remove this based on the addresses that you provide in the addresses below
+      faucet: true,
+      // governance: true,
+      // staking: true,
+      // incentives: true,
+    },
+    rpcOnly: true,
+    addresses: {
+      LENDING_POOL_ADDRESS_PROVIDER: '0x303a4B174663A6201Da77782413B4b54EFa3E97e'.toLowerCase(),
+      LENDING_POOL: '0x23a85024f54A19e243bA7a74E339a5C80998c7a4',
+      WETH_GATEWAY: '0x96A4fd1f289888cCa772298f7BDCF41C02122c01',
+      FAUCET: '0xb7263ADfB7C094aa24b91A51b297A278e105584a',
+      WALLET_BALANCE_PROVIDER: '0xEEac3ad1b3f4c43A782a951348c5387506B9AB06',
+      UI_POOL_DATA_PROVIDER: '0xb815B9EE078Dab098965D8e52dD5C747d70bb481',
+      UI_INCENTIVE_DATA_PROVIDER: '0x2526D407F722C0D1e0326eC1840A235bf173b9Ca',
+    },
+  },
   [CustomMarket.proto_arbitrum_v3]: {
     marketTitle: 'Arbitrum',
     v3: true,
@@ -359,28 +380,6 @@ export const marketsData: {
     halIntegration: {
       URL: 'https://app.hal.xyz/recipes/aave-v3-track-health-factor',
       marketName: 'avalanche',
-    },
-  },
-  [CustomMarket.proto_ropsten_v3]: {
-    marketTitle: 'Ethereum Ropsten',
-    v3: true,
-    chainId: ChainId.ropsten,
-    enabledFeatures: {
-      // Note: We should remove this based on the addresses that you provide in the addresses below
-      faucet: true,
-      // governance: true,
-      // staking: true,
-      // incentives: true,
-    },
-    rpcOnly: true,
-    addresses: {
-      LENDING_POOL_ADDRESS_PROVIDER: '0x303a4B174663A6201Da77782413B4b54EFa3E97e'.toLowerCase(),
-      LENDING_POOL: '0x23a85024f54A19e243bA7a74E339a5C80998c7a4',
-      WETH_GATEWAY: '0x96A4fd1f289888cCa772298f7BDCF41C02122c01',
-      FAUCET: '0xb7263ADfB7C094aa24b91A51b297A278e105584a',
-      WALLET_BALANCE_PROVIDER: '0xEEac3ad1b3f4c43A782a951348c5387506B9AB06',
-      UI_POOL_DATA_PROVIDER: '0xb815B9EE078Dab098965D8e52dD5C747d70bb481',
-      UI_INCENTIVE_DATA_PROVIDER: '0x2526D407F722C0D1e0326eC1840A235bf173b9Ca',
     },
   },
   [CustomMarket.proto_fuji_v3]: {

--- a/src/ui-config/networksConfig.ts
+++ b/src/ui-config/networksConfig.ts
@@ -66,7 +66,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     networkLogoPath: '/icons/networks/ethereum.svg',
   },
   [ChainId.rinkeby]: {
-    name: 'Rinkeby',
+    name: 'Ethereum Rinkeby',
     publicJsonRPCUrl: [
       // 'https://eth-rinkeby.alchemyapi.io/v2/demo',
       'https://rinkeby-light.eth.linkpool.io/',
@@ -82,7 +82,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     networkLogoPath: '/icons/networks/ethereum.svg',
   },
   [ChainId.ropsten]: {
-    name: 'Ropsten Testnet',
+    name: 'Ethereum Ropsten',
     // Public RPC found at https://rpc.info/
     publicJsonRPCUrl: ['https://ropsten.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161'],
     publicJsonRPCWSUrl: '',


### PR DESCRIPTION
- Display testnet icon
- Make market names consistent
- Change ordering to place ETH testnets together

Old

![oldswitcher](https://user-images.githubusercontent.com/26660211/173663243-3143146b-a95b-40b4-8468-d04b6fa8144b.PNG)


New

![newswitcher](https://user-images.githubusercontent.com/26660211/173663258-9f5058fe-666f-41ce-9a82-42ef3c310de4.PNG)
