### PR TITLE
chore: Updated link for Optimism bridge

### DIFF
--- a/src/ui-config/networksConfig.ts
+++ b/src/ui-config/networksConfig.ts
@@ -285,7 +285,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     bridge: {
       icon: '/icons/bridge/optimism.svg',
       name: 'Optimism Bridge',
-      url: 'https://gateway.optimism.io',
+      url: 'https://app.optimism.io/bridge',
     },
   },
   [ChainId.optimism_kovan]: {
@@ -305,7 +305,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     bridge: {
       icon: '/icons/bridge/optimism.svg',
       name: 'Optimism Bridge',
-      url: 'https://gateway.optimism.io',
+      url: 'https://app.optimism.io/bridge',
     },
   },
   [ChainId.fantom]: {


### PR DESCRIPTION
The current link for the Optimism bridge is for their legacy bridge. I updated it with the latest version.