### PR TITLE
fix: exit render loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "*.js": "eslint --cache --fix",
     "*.jsx": "eslint --cache --fix",
     "*.ts": "eslint --cache --fix",
-    "*.tsx": "eslint --cache --fix"
+    "*.tsx": "eslint --cache --fix",
+    "*.svg": "npx svgo"
   },
   "nextBundleAnalysis": {
     "budget": null,

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1978,7 +1978,6 @@ msgstr "withdrew"
 #: src/components/transactions/StakeCooldown/StakeCooldownModalContent.tsx
 #: src/components/transactions/StakeCooldown/StakeCooldownModalContent.tsx
 #: src/modules/dashboard/DashboardEModeButton.tsx
-#: src/modules/reserve-overview/ReserveTopDetails.tsx
 msgid "{0}"
 msgstr "{0}"
 

--- a/src/modules/reserve-overview/ReserveTopDetails.tsx
+++ b/src/modules/reserve-overview/ReserveTopDetails.tsx
@@ -40,22 +40,20 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
   const valueTypographyVariant = downToSM ? 'main16' : 'main21';
   const symbolsTypographyVariant = downToSM ? 'secondary16' : 'secondary21';
 
-  const ReserveIcon = () => {
-    return (
-      <Box mr={3} sx={{ mr: 3, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        {loading ? (
-          <Skeleton variant="circular" width={40} height={40} sx={{ background: '#383D51' }} />
-        ) : (
-          <img
-            src={`/icons/tokens/${poolReserve.iconSymbol.toLowerCase()}.svg`}
-            width="40px"
-            height="40px"
-            alt=""
-          />
-        )}
-      </Box>
-    );
-  };
+  const ReserveIcon = (
+    <Box mr={3} sx={{ mr: 3, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {loading ? (
+        <Skeleton variant="circular" width={40} height={40} sx={{ background: '#383D51' }} />
+      ) : (
+        <img
+          src={`/icons/tokens/${poolReserve.iconSymbol.toLowerCase()}.svg`}
+          width="40px"
+          height="40px"
+          alt=""
+        />
+      )}
+    </Box>
+  );
 
   const ReserveName = () => {
     return loading ? (
@@ -121,7 +119,7 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
 
           {downToSM && (
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 6 }}>
-              <ReserveIcon />
+              {ReserveIcon}
               <Box>
                 {!loading && (
                   <Typography sx={{ color: '#A5A8B6' }} variant="caption">
@@ -153,9 +151,9 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
     >
       {!downToSM && (
         <TopInfoPanelItem
-          title={!loading && <Trans>{poolReserve.symbol}</Trans>}
+          title={!loading && poolReserve.symbol}
           withoutIconWrapper
-          icon={<ReserveIcon />}
+          icon={ReserveIcon}
           loading={loading}
         >
           <Box sx={{ display: 'inline-flex' }}>

--- a/src/modules/reserve-overview/ReserveTopDetails.tsx
+++ b/src/modules/reserve-overview/ReserveTopDetails.tsx
@@ -55,13 +55,11 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
     </Box>
   );
 
-  const ReserveName = () => {
-    return loading ? (
-      <Skeleton width={60} height={28} sx={{ background: '#383D51' }} />
-    ) : (
-      <Typography variant={valueTypographyVariant}>{poolReserve.name}</Typography>
-    );
-  };
+  const ReserveName = loading ? (
+    <Skeleton width={60} height={28} sx={{ background: '#383D51' }} />
+  ) : (
+    <Typography variant={valueTypographyVariant}>{poolReserve.name}</Typography>
+  );
 
   return (
     <TopInfoPanel
@@ -127,7 +125,7 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
                   </Typography>
                 )}
                 <Box sx={{ display: 'inline-flex' }}>
-                  <ReserveName />
+                  {ReserveName}
                   {loading ? (
                     <Skeleton width={16} height={16} sx={{ ml: 1, background: '#383D51' }} />
                   ) : (
@@ -157,7 +155,7 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
           loading={loading}
         >
           <Box sx={{ display: 'inline-flex' }}>
-            <ReserveName />
+            {ReserveName}
             {loading ? (
               <Skeleton width={16} height={16} sx={{ ml: 1, background: '#383D51' }} />
             ) : (

--- a/src/ui-config/reservePatches.ts
+++ b/src/ui-config/reservePatches.ts
@@ -87,7 +87,7 @@ export function fetchIconSymbolAndName({
     const rawSymbol = symbol.replace('.e', '');
     return {
       iconSymbol: rawSymbol || symbol,
-      name: NAME_MAP[rawSymbol] || rawSymbol,
+      name: NAME_MAP[rawSymbol.toUpperCase()] || rawSymbol,
       symbol,
     };
   }
@@ -95,7 +95,7 @@ export function fetchIconSymbolAndName({
     const rawSymbol = symbol.replace('1', '');
     return {
       iconSymbol: rawSymbol || symbol,
-      name: NAME_MAP[rawSymbol] || rawSymbol,
+      name: NAME_MAP[rawSymbol.toUpperCase()] || rawSymbol,
       symbol,
     };
   }
@@ -104,13 +104,13 @@ export function fetchIconSymbolAndName({
     const rawSymbol = symbol.replace('f', '');
     return {
       iconSymbol: rawSymbol || symbol,
-      name: NAME_MAP[rawSymbol] || rawSymbol,
+      name: NAME_MAP[rawSymbol.toUpperCase()] || rawSymbol,
       symbol,
     };
   }
   return {
     iconSymbol: SYMBOL_MAP[symbol] || symbol,
-    name: NAME_MAP[symbol] || symbol,
+    name: NAME_MAP[symbol.toUpperCase()] || symbol,
     symbol,
   };
 }


### PR DESCRIPTION
using parameterless render functions like `  const ReserveIcon = () => {` results in a complete remount on every state dispatch (1x per second). It's completely unnecessary here.

- adds svg optimization to lint-staged
- fixes issue with mixed case symbol names