### PR TITLE
Fix/908 emode

### DIFF
--- a/cypress/integration/1-v3-markets/2-avalanche-v3-market/e-mode.avalanche-v3.spec.ts
+++ b/cypress/integration/1-v3-markets/2-avalanche-v3-market/e-mode.avalanche-v3.spec.ts
@@ -63,7 +63,7 @@ describe('E-MODE SPEC, AVALANCHE V3 MARKET', () => {
     verifyCountOfBorrowAssets({ assets: testData.testCases.eModeAssets }, skipTestState);
   });
   describe('Turn off E-mode and verify decrease of health factor', () => {
-    emodeActivating({ turnOn: false }, skipTestState, true);
+    emodeActivating({ turnOn: false, multipleEmodes: true }, skipTestState, true);
     checkDashboardHealthFactor({ valueFrom: 1.0, valueTo: 1.07 }, skipTestState);
   });
   describe('Turn off E-mode blocked with low health factor', () => {

--- a/cypress/support/steps/main.steps.ts
+++ b/cypress/support/steps/main.steps.ts
@@ -487,8 +487,10 @@ export const changeCollateralNegative = (
 export const emodeActivating = (
   {
     turnOn,
+    multipleEmodes,
   }: {
     turnOn: boolean;
+    multipleEmodes?: boolean;
   },
   skip: SkipType,
   updateSkipStatus = false
@@ -500,6 +502,11 @@ export const emodeActivating = (
       cy.get('[data-cy=emode-open]').click();
       if (turnOn) cy.get(`[data-cy="emode-enable"]`).click();
       else cy.get(`[data-cy="emode-disable"]`).click();
+
+      if (!turnOn && multipleEmodes) {
+        cy.get('[data-cy=EmodeSelect]').click();
+        cy.get(`[data-cy="disableEmode"]`).click();
+      }
     });
     it(`${turnOn ? 'Turn on E-mode' : 'Turn off E-mode'}`, () => {
       const actionName = turnOn ? 'Enable E-Mode' : 'Disable E-Mode';

--- a/src/components/transactions/Emode/EmodeModalContent.tsx
+++ b/src/components/transactions/Emode/EmodeModalContent.tsx
@@ -191,7 +191,7 @@ export const EmodeModalContent = () => {
         </Alert>
       )}
 
-      {Object.keys(emodeCategories).length > 2 && user.userEmodeCategoryId === 0 && (
+      {Object.keys(emodeCategories).length > 2 && (
         <EmodeSelect
           emodeCategories={emodeCategories}
           selectedEmode={selectedEmode?.id || 0}

--- a/src/components/transactions/Emode/EmodeSelect.tsx
+++ b/src/components/transactions/Emode/EmodeSelect.tsx
@@ -31,6 +31,7 @@ export const EmodeSelect = ({
         value={selectedEmode}
         onChange={(e) => setSelectedEmode(emodeCategories[Number(e.target.value)])}
         className="EmodeSelect"
+        data-cy="EmodeSelect"
         sx={{
           width: '100%',
           height: '44px',
@@ -79,7 +80,7 @@ export const EmodeSelect = ({
             }}
           >
             {emodeCategories[Number(categoryKey)].id === 0 ? (
-              <Typography color="text.primary">
+              <Typography color="text.primary" data-cy="disableEmode">
                 E-Mode <Trans>disabled</Trans>
               </Typography>
             ) : (


### PR DESCRIPTION
The [governance proposal](https://governance.aave.com/t/arc-add-support-for-savax-benqi-liquid-staking-avax-token-on-aave-v3/7892) for adding sAVAX included a change for adding an additional e-mode category for AVAX related assets. It seems like this is the first market to have more than 2 e-mode categories (Stablecoins and E-mode disabled). Normally, the UI will just toggle between the two categories, either on or off when opening up the e-mode modal. But with a third category, there should be a dropdown to pick which one the user wants to select. The dropdown was only showing if e-mode was disabled, this fix will show the dropdown whenever there is more than 2 e-mode categories.