### PR TITLE
ci: run fork ci on dependabot prs

### DIFF
--- a/.github/workflows/build-fork.yml
+++ b/.github/workflows/build-fork.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: | # check if PR opened from fork
-      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name || contains(github.head_ref, 'dependabot')
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
         with:


### PR DESCRIPTION
dependabot prs are the ones most responsible for irregular bundle size increase. yet, the analyzer ci does not run on these prs.
This pr changes the ci to run the fork workflow on dependabot prs.