### PR TITLE
fix: don't break on md ipfs [skip cypress]

### DIFF
--- a/src/modules/governance/utils/getProposalMetadata.ts
+++ b/src/modules/governance/utils/getProposalMetadata.ts
@@ -26,16 +26,26 @@ export async function getProposalMetadata(
   if (!ipfsResponse.ok) {
     throw Error('Fetch not working');
   }
+  const clone = await ipfsResponse.clone();
+  try {
+    const response: ProposalMetadata = await ipfsResponse.json();
 
-  const response: ProposalMetadata = await ipfsResponse.json();
+    const { content, data } = matter(response.description);
 
-  const { content, data } = matter(response.description);
-
-  MEMORIZE[ipfsHash] = {
-    ...response,
-    ipfsHash,
-    description: content,
-    ...data,
-  };
+    MEMORIZE[ipfsHash] = {
+      ...response,
+      ipfsHash,
+      description: content,
+      ...data,
+    };
+  } catch (e) {
+    const text = await clone.text();
+    const { content, data } = matter(text);
+    MEMORIZE[ipfsHash] = {
+      ...(data as ProposalMetadata),
+      ipfsHash,
+      description: content,
+    };
+  }
   return MEMORIZE[ipfsHash];
 }


### PR DESCRIPTION
In the 1inch proposal https://gateway.pinata.cloud/ipfs/QmPccptdeMjEAUbJLEXRw8s8dnWq6aVdigaqMUJGQJQBGV is referenced as ipfs instead of https://gateway.pinata.cloud/ipfs/QmeGHtzBASPj2tQyMZnBpiFghbZvawgx4kJ6HJMNUM4EY4 so the json() parser breaks as it's not a json.
This pr will clone the stream (as you can only read it once) and first try to parse it to json, if it's not successfull it will parse it as text.

Late night fix, but this fixes the ui