### PR TITLE
fix: disable caching server for eth mainnet v2 market

### DIFF
--- a/src/ui-config/marketsConfig.tsx
+++ b/src/ui-config/marketsConfig.tsx
@@ -129,7 +129,7 @@ export const marketsData: {
       collateralRepay: true,
       incentives: true,
     },
-    rpcOnly: false,
+    rpcOnly: true,
     cachingServerUrl: 'https://cache-api-1.aave.com/graphql',
     cachingWSServerUrl: 'wss://cache-api-1.aave.com/graphql',
     addresses: {


### PR DESCRIPTION
#937 removed the caching server from usage with staking data. This appears to have caused an error with the ETH Mainnet reserves data cache. 

Reserves and user reserves data are returned successfully, but incentives fail to load causing a blank screen. By disabling the caching server for ETH Mainnet and fetching all data via RPC queries, the issue is resolved.