### PR TITLE
cleanup: disable caching on amm

### DIFF
--- a/src/ui-config/marketsConfig.tsx
+++ b/src/ui-config/marketsConfig.tsx
@@ -130,8 +130,6 @@ export const marketsData: {
       incentives: true,
     },
     rpcOnly: true,
-    cachingServerUrl: 'https://cache-api-1.aave.com/graphql',
-    cachingWSServerUrl: 'wss://cache-api-1.aave.com/graphql',
     addresses: {
       LENDING_POOL_ADDRESS_PROVIDER: '0xB53C1a33016B2DC2fF3653530bfF1848a515c8c5'.toLowerCase(),
       LENDING_POOL: '0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9',
@@ -189,9 +187,7 @@ export const marketsData: {
   [CustomMarket.amm_mainnet]: {
     marketTitle: 'Ethereum AMM',
     chainId: ChainId.mainnet,
-    cachingServerUrl: 'https://cache-api-1.aave.com/graphql',
-    cachingWSServerUrl: 'wss://cache-api-1.aave.com/graphql',
-    rpcOnly: false,
+    rpcOnly: true,
     addresses: {
       LENDING_POOL_ADDRESS_PROVIDER: '0xacc030ef66f9dfeae9cbb0cd1b25654b82cfa8d5'.toLowerCase(),
       LENDING_POOL: '0x7937d4799803fbbe595ed57278bc4ca21f3bffcb',

--- a/src/utils/apolloClient.ts
+++ b/src/utils/apolloClient.ts
@@ -97,11 +97,12 @@ export const getApolloClient = () => {
   );
 
   const combinedLink = marketsWithCaching.reduce((acc, [key, cfg]) => {
-    const condition = (operation: Operation) =>
+    const condition = (operation: Operation): boolean =>
       operation.getContext().target === APOLLO_QUERY_TARGET.MARKET(key);
     const http = new HttpLink({ uri: cfg.cachingServerUrl });
     const ws = createWsLink(cfg.cachingWSServerUrl as string);
-    if (!acc) return split((operation) => condition(operation) && isSubscription(operation), ws);
+    if (!acc)
+      return split((operation) => condition(operation) && isSubscription(operation), ws, http);
     return split(
       (operation) => condition(operation) && isSubscription(operation),
       ws,


### PR DESCRIPTION
- contains the actual fix for the problem quickfixed in #971 (forgot to pass the http handler to split) which lead to the first graphql endpoint to fail
- disables caching on amm