### PR TITLE
fix: prevent remaining debt from being negative in hf calculation

### DIFF
--- a/src/utils/hfUtils.ts
+++ b/src/utils/hfUtils.ts
@@ -124,9 +124,11 @@ export const calculateHFAfterRepay = ({
   )
     .multipliedBy(toAssetData.priceInUSD)
     .toString(10);
-  const debtLeftInMarketReference = valueToBigNumber(user.totalBorrowsUSD).minus(
+  let debtLeftInMarketReference = valueToBigNumber(user.totalBorrowsUSD).minus(
     fromAmountInMarketReferenceCurrency
   );
+
+  debtLeftInMarketReference = BigNumber.max(debtLeftInMarketReference, valueToBigNumber('0'));
 
   const hfAfterRepayBeforeWithdraw = calculateHealthFactorFromBalancesBigUnits({
     collateralBalanceMarketReferenceCurrency: user.totalCollateralUSD,


### PR DESCRIPTION
Ensure that the calculated remaining debt is never less than 0 when determining new health factor. Fixes a bug where the new health factor in the repay modal was showing as a large negative number when repaying full debt.

closes #763 