### PR TITLE
Fix/950 phantom rewards

### DIFF
--- a/src/ui-config/networksConfig.ts
+++ b/src/ui-config/networksConfig.ts
@@ -83,11 +83,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   [ChainId.mainnet]: {
     name: 'Ethereum',
     privateJsonRPCUrl: 'https://eth-mainnet.gateway.pokt.network/v1/lb/62b3314e123e6f00397f19ca',
-    publicJsonRPCUrl: [
-      'https://cloudflare-eth.com',
-      'https://rpc.flashbots.net/',
-      // 'https://eth-mainnet.alchemyapi.io/v2/demo',
-    ],
+    publicJsonRPCUrl: ['https://cloudflare-eth.com/v1/mainnet'],
     publicJsonRPCWSUrl: 'wss://eth-mainnet.alchemyapi.io/v2/demo',
     // cachingServerUrl: 'https://cache-api-1.aave.com/graphql',
     // cachingWSServerUrl: 'wss://cache-api-1.aave.com/graphql',

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -47,6 +47,8 @@ export const networkConfigs = Object.keys(_networkConfigs).reduce((acc, value) =
       isFork: true,
       privateJsonRPCUrl: FORK_RPC_URL,
       privateJsonRPCWSUrl: FORK_WS_RPC_URL,
+      publicJsonRPCUrl: [],
+      publicJsonRPCWSUrl: '',
       underlyingChainId: FORK_BASE_CHAIN_ID,
     };
   }
@@ -159,7 +161,7 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
         weight: 2,
       });
     }
-    if (config.publicJsonRPCUrl.length && !config.isFork) {
+    if (config.publicJsonRPCUrl.length) {
       config.publicJsonRPCUrl.map((rpc, ix) =>
         chainProviders.push({
           provider: new ethersProviders.StaticJsonRpcProvider(rpc, chainId),

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -158,7 +158,6 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
       chainProviders.push({
         provider: new ethersProviders.StaticJsonRpcProvider(config.privateJsonRPCUrl, chainId),
         priority: 0,
-        weight: 2,
       });
     }
     if (config.publicJsonRPCUrl.length) {
@@ -166,7 +165,6 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
         chainProviders.push({
           provider: new ethersProviders.StaticJsonRpcProvider(rpc, chainId),
           priority: ix + 1,
-          weight: 1,
         })
       );
     }

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -156,6 +156,7 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
       chainProviders.push({
         provider: new ethersProviders.StaticJsonRpcProvider(config.privateJsonRPCUrl, chainId),
         priority: 0,
+        weight: 2,
       });
     }
     if (config.publicJsonRPCUrl.length && !config.isFork) {
@@ -163,6 +164,7 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
         chainProviders.push({
           provider: new ethersProviders.StaticJsonRpcProvider(rpc, chainId),
           priority: ix + 1,
+          weight: 1,
         })
       );
     }
@@ -172,7 +174,7 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
     if (chainProviders.length === 1) {
       providers[chainId] = chainProviders[0].provider;
     } else {
-      providers[chainId] = new ethersProviders.FallbackProvider(chainProviders, 1);
+      providers[chainId] = new ethersProviders.FallbackProvider(chainProviders);
     }
   }
   return providers[chainId];

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -174,7 +174,7 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
     if (chainProviders.length === 1) {
       providers[chainId] = chainProviders[0].provider;
     } else {
-      providers[chainId] = new ethersProviders.FallbackProvider(chainProviders);
+      providers[chainId] = new ethersProviders.FallbackProvider(chainProviders, 1);
     }
   }
   return providers[chainId];

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -158,7 +158,7 @@ export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
         priority: 0,
       });
     }
-    if (config.publicJsonRPCUrl.length) {
+    if (config.publicJsonRPCUrl.length && !config.isFork) {
       config.publicJsonRPCUrl.map((rpc, ix) =>
         chainProviders.push({
           provider: new ethersProviders.StaticJsonRpcProvider(rpc, chainId),


### PR DESCRIPTION
I believe the root cause for users seeing rewards that don't actually exist is from stale data from the public rpc's configured. This PR will add a higher weight for the private rpc, and also removes the quorum of 1, in favor of the default, which is half the sum of the weights of the providers.

What I was able to reproduce on a fork, was data from a public rpc being used over the private one, because the quorum was set to 1. I also added a condition in the case of forks, to not add any of the configured public rpc's because it doesn't make sense if we're on a fork, it'd be wrong data anyway. With this change, if the responses are different from the private vs. public, the private would take precedence.

It looks like the quorum config was changed recently in this commit: https://github.com/aave/interface/commit/0b6b04f6b379eb1b6c5191204973160a55b48779
so pinging @sakulstra to see if these changes make sense