### PR TITLE
fix: ordering and available amounts in repay modal

### DIFF
--- a/src/components/transactions/Repay/RepayModalContent.tsx
+++ b/src/components/transactions/Repay/RepayModalContent.tsx
@@ -127,8 +127,7 @@ export const RepayModalContent = ({
     // set possible repay tokens
     // if wrapped reserve push both wrapped / native
     if (poolReserve.symbol === networkConfig.wrappedBaseAssetSymbol) {
-      // we substract a bit so user can still pay for the tx
-      const nativeTokenWalletBalance = valueToBigNumber(nativeBalance).minus('0.004');
+      const nativeTokenWalletBalance = valueToBigNumber(nativeBalance);
       const maxNativeToken = BigNumber.max(
         nativeTokenWalletBalance,
         BigNumber.min(nativeTokenWalletBalance, debt)
@@ -163,7 +162,7 @@ export const RepayModalContent = ({
         balance: maxBalance.toString(10),
       });
     }
-    setAssets(repayTokens);
+    setAssets(repayTokens.sort((a, b) => Number(a.balance) - Number(b.balance)));
     setTokenToRepayWith(repayTokens[0]);
   }, []);
 

--- a/src/components/transactions/Repay/RepayModalContent.tsx
+++ b/src/components/transactions/Repay/RepayModalContent.tsx
@@ -162,7 +162,7 @@ export const RepayModalContent = ({
         balance: maxBalance.toString(10),
       });
     }
-    setAssets(repayTokens.sort((a, b) => Number(a.balance) - Number(b.balance)));
+    setAssets(repayTokens);
     setTokenToRepayWith(repayTokens[0]);
   }, []);
 


### PR DESCRIPTION
- [x] Do not allow negative values in repay modal -  Removed the condition that 0.004 base asset be subtracted. This isn't relevant for most non-ETH networks and will show an error in tx confirmation if this is reached. Additionally, the max balance is confusing for users who think their assets are missing.