### PR TITLE
Feat: added clear button for asset input

### DIFF
--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -150,7 +150,7 @@ export const AssetInput = <T extends Asset = Asset>({
               {value !== '' && (
                 <Button
                   size="small"
-                  sx={{ minWidth: 0, ml: '7px', p: 0 }}
+                  sx={{ minWidth: 0, ml: '7px', p: 0, left: 8 }}
                   onClick={() => {
                     onChange && onChange('');
                   }}
@@ -162,7 +162,7 @@ export const AssetInput = <T extends Asset = Asset>({
               <TokenIcon
                 aToken={asset.aToken}
                 symbol={asset.iconSymbol || asset.symbol}
-                sx={{ mr: 2, ml: 2 }}
+                sx={{ mr: 2, ml: 4 }}
               />
               <Typography variant="h3" sx={{ lineHeight: '28px' }} data-cy={'inputAsset'}>
                 {symbol}

--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/macro';
 import {
   Box,
   Button,
+  IconButton,
   FormControl,
   InputBase,
   ListItemText,
@@ -9,8 +10,9 @@ import {
   Select,
   SelectChangeEvent,
   Typography,
+  useTheme,
 } from '@mui/material';
-import CancelIcon from '@mui/icons-material/Cancel';
+import { XCircleIcon } from '@heroicons/react/solid';
 import React, { ReactNode } from 'react';
 import NumberFormat, { NumberFormatProps } from 'react-number-format';
 
@@ -89,6 +91,7 @@ export const AssetInput = <T extends Asset = Asset>({
   inputTitle,
   isMaxSelected,
 }: AssetInputProps<T>) => {
+  const { palette } = useTheme();
   const handleSelect = (event: SelectChangeEvent) => {
     const newAsset = assets.find((asset) => asset.symbol === event.target.value) as T;
     onSelect && onSelect(newAsset);
@@ -148,16 +151,16 @@ export const AssetInput = <T extends Asset = Asset>({
           {!onSelect || assets.length === 1 ? (
             <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
               {value !== '' && (
-                <Button
+                <IconButton
                   size="small"
-                  sx={{ minWidth: 0, ml: '7px', p: 0, left: 8 }}
+                  sx={{ minWidth: 0, p: 0, left: 8 }}
                   onClick={() => {
                     onChange && onChange('');
                   }}
                   disabled={disabled || isMaxSelected}
                 >
-                  <CancelIcon sx={{ fontSize: 16, fill: 'silver' }} />
-                </Button>
+                  <XCircleIcon height={16} color={palette.grey[500]} />
+                </IconButton>
               )}
               <TokenIcon
                 aToken={asset.aToken}

--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -10,6 +10,7 @@ import {
   SelectChangeEvent,
   Typography,
 } from '@mui/material';
+import CancelIcon from '@mui/icons-material/Cancel';
 import React, { ReactNode } from 'react';
 import NumberFormat, { NumberFormatProps } from 'react-number-format';
 
@@ -146,10 +147,22 @@ export const AssetInput = <T extends Asset = Asset>({
 
           {!onSelect || assets.length === 1 ? (
             <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+              {value !== '' && (
+                <Button
+                  size="small"
+                  sx={{ minWidth: 0, ml: '7px', p: 0 }}
+                  onClick={() => {
+                    onChange && onChange('');
+                  }}
+                  disabled={disabled || isMaxSelected}
+                >
+                  <CancelIcon sx={{ fontSize: 16, fill: 'silver' }} />
+                </Button>
+              )}
               <TokenIcon
                 aToken={asset.aToken}
                 symbol={asset.iconSymbol || asset.symbol}
-                sx={{ mr: 2, ml: 4 }}
+                sx={{ mr: 2, ml: 2 }}
               />
               <Typography variant="h3" sx={{ lineHeight: '28px' }} data-cy={'inputAsset'}>
                 {symbol}

--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -10,7 +10,6 @@ import {
   Select,
   SelectChangeEvent,
   Typography,
-  useTheme,
 } from '@mui/material';
 import { XCircleIcon } from '@heroicons/react/solid';
 import React, { ReactNode } from 'react';
@@ -91,7 +90,6 @@ export const AssetInput = <T extends Asset = Asset>({
   inputTitle,
   isMaxSelected,
 }: AssetInputProps<T>) => {
-  const { palette } = useTheme();
   const handleSelect = (event: SelectChangeEvent) => {
     const newAsset = assets.find((asset) => asset.symbol === event.target.value) as T;
     onSelect && onSelect(newAsset);
@@ -142,6 +140,9 @@ export const AssetInput = <T extends Asset = Asset>({
                 lineHeight: '28,01px',
                 padding: 0,
                 height: '28px',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
               },
             }}
             // eslint-disable-next-line

--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -152,13 +152,21 @@ export const AssetInput = <T extends Asset = Asset>({
             <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
               {value !== '' && (
                 <IconButton
-                  sx={{ minWidth: 0, p: 0, left: 8 }}
+                  sx={{
+                    minWidth: 0,
+                    p: 0,
+                    left: 8,
+                    color: 'text.muted',
+                    '&:hover': {
+                      color: 'text.secondary',
+                    },
+                  }}
                   onClick={() => {
                     onChange && onChange('');
                   }}
                   disabled={disabled}
                 >
-                  <XCircleIcon height={16} color={palette.grey[500]} />
+                  <XCircleIcon height={16} />
                 </IconButton>
               )}
               <TokenIcon

--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -156,7 +156,7 @@ export const AssetInput = <T extends Asset = Asset>({
                   onClick={() => {
                     onChange && onChange('');
                   }}
-                  disabled={disabled || isMaxSelected}
+                  disabled={disabled}
                 >
                   <XCircleIcon height={16} color={palette.grey[500]} />
                 </IconButton>

--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -152,7 +152,6 @@ export const AssetInput = <T extends Asset = Asset>({
             <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
               {value !== '' && (
                 <IconButton
-                  size="small"
                   sx={{ minWidth: 0, p: 0, left: 8 }}
                   onClick={() => {
                     onChange && onChange('');


### PR DESCRIPTION
- Resolves https://github.com/aave/interface/issues/836
- Added clear button for asset input through `CancelIcon`
- Render button when value is present
- On click, clears value

![image](https://user-images.githubusercontent.com/25493955/184818426-65def135-120d-427f-a80e-67950de4bc14.png)