### PR TITLE
ci: pin to self-hosted IPFS cluster

### DIFF
--- a/.github/actions/private-ipfs-pin/action.yml
+++ b/.github/actions/private-ipfs-pin/action.yml
@@ -1,0 +1,58 @@
+name: Pin to private cluster
+description: Upload build to ipfs nodes runnning in GKE
+inputs:
+  DOMAIN:
+    description: Domain to unpin 
+    required: true
+  GCP_SA_KEY:
+    description: ''
+    required: true
+  GKE_CLUSTER:
+    description: ''
+    required: true
+  GKE_CLUSTER_REGION:
+    description: ''
+    required: true
+  BUILD_PATH:
+    description: path to the build directory
+    required: true
+  PINATA_HASH: 
+    description: ''
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: GCP Auth
+      uses: google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955 # v0.8.0
+      with:
+        credentials_json: '${{ inputs.GCP_SA_KEY }}'
+    - name: Get GKE credentials
+      uses: google-github-actions/get-gke-credentials@054fdb05e32039f72764f03e69e6acb20caa6f56 # v0.8.0
+      with:
+        cluster_name: '${{ inputs.GKE_CLUSTER }}'
+        location: '${{ inputs.GKE_CLUSTER_REGION }}'
+    - uses: azure/setup-kubectl@7f7e5ba5ea3e491b92e6e8e5819963f8f3a1f076 # v3
+      with:
+        version: 'v1.22.13'
+
+    - name: ipfs cluster pin
+      shell: bash
+      run: |
+        export POD_NAME="ipfs-cluster-$(($RANDOM % 3))"
+        tar -czf app.tar.gz './${{ inputs.BUILD_PATH }}'
+        kubectl -n ipfs-cluster cp -c ipfs ./app.tar.gz ${POD_NAME}:/root/
+
+        IPFS_HASH="$(kubectl -n ipfs-cluster exec -i ${POD_NAME} -c ipfs -- sh -c \
+          'cd /root/ && tar -zxf app.tar.gz && \
+          ipfs add -rQ --cid-version=1 --pin=false ./${{ inputs.BUILD_PATH }}/ && \
+          rm -rf ./app.tar.gz ./${{ inputs.BUILD_PATH }}')"
+
+        test "${IPFS_HASH}" = '${{ inputs.PINATA_HASH }}' || \
+          { echo -e "Hashes differ, aborting pinning\nPINATA: ${{ inputs.PINATA_HASH }}\nLOCAL: ${IPFS_HASH}" && exit 1; }
+
+        kubectl -n ipfs-cluster exec -i ${POD_NAME} -c ipfs-cluster -- \
+          ipfs-cluster-ctl pin rm '/ipns/${{ inputs.DOMAIN }}' || true
+        kubectl -n ipfs-cluster exec -i ${POD_NAME} -c ipfs-cluster -- \
+          ipfs-cluster-ctl pin add --wait --wait-timeout=120s \
+          --replication-min=3 --name='app-aave-${{ github.ref }}' --expire-in=72h \
+          "${IPFS_HASH}"

--- a/.github/workflows/update-prod-staging.yml
+++ b/.github/workflows/update-prod-staging.yml
@@ -23,6 +23,17 @@ jobs:
           name: out
           path: out
 
+      - name: Pin to sefl-hosted cluster
+        uses: ./.github/actions/private-ipfs-pin
+        continue-on-error: true
+        with:
+          DOMAIN: app.aave.com
+          GCP_SA_KEY: '${{ secrets.GCP_SA_KEY }}'
+          GKE_CLUSTER: '${{ secrets.GKE_CLUSTER }}'
+          GKE_CLUSTER_REGION: '${{ secrets.GKE_CLUSTER_REGION }}'
+          BUILD_PATH: 'out'
+          PINATA_HASH: '${{ inputs.PINATA_HASH }}'
+
       - name: crust
         uses: crustio/ipfs-crust-action@18f5ab4e8496351cfaca10a55ced7119cb0fe677 # v2.0.6
         continue-on-error: true
@@ -42,14 +53,13 @@ jobs:
         run: |
           cp .github/release-template.md ./release-notes.md
           sed -i 's|<ipfs-hash>|${{ inputs.PINATA_HASH }}|g' ./release-notes.md
-          tar -czf app-build.tar.gz out/
           echo "TAG=release-$(date '+%Y-%m-%d_%H-%M')" >> ${GITHUB_ENV}
 
       - name: Create GH release
         uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           name: Production release
-          artifacts: app-build.tar.gz
+          artifacts: app.tar.gz
           bodyFile: release-notes.md
           commit: '${{ github.sha }}'
           tag: '${{ env.TAG }}'
@@ -76,7 +86,18 @@ jobs:
           BUILD_LOCATION: './out_staging'
           CID_VERSION: 1
 
-      - uses: aave/cloudflare-update-action@5c1b528c9c6e0aed18a7dbdd7f957e0b8815a75e
+      - name: Pin to sefl-hosted cluster
+        uses: ./.github/actions/private-ipfs-pin
+        continue-on-error: true
+        with:
+          DOMAIN: staging.aave.com
+          GCP_SA_KEY: '${{ secrets.GCP_SA_KEY }}'
+          GKE_CLUSTER: '${{ secrets.GKE_CLUSTER }}'
+          GKE_CLUSTER_REGION: '${{ secrets.GKE_CLUSTER_REGION }}'
+          BUILD_PATH: 'out_staging'
+          PINATA_HASH: '${{ inputs.PINATA_HASH }}'
+
+      - uses: aave/cloudflare-update-action@ca32db9938b08e0e1814f57d098a7dcc733e12db
         with:
           CF_API_TOKEN: '${{ secrets.CF_API_TOKEN }}'
           CF_ZONE_ID: '${{ secrets.CF_ZONE_ID }}'


### PR DESCRIPTION
This addition to worklow:

1. Authenticates to Google Kubernetes cluster (GKE)
2. Uploads the build there
3. Invokes the command to pin the build to IPFS Cluster running inside the GKE

This way we avoid exposing IPFS cluster API to the outside world. Also this is much faster than uploading build directly via exposed IPFS cluster API.