### PR TITLE
Fix: added space before FAQ

### DIFF
--- a/src/components/infoModalContents/ApprovalInfoContent.tsx
+++ b/src/components/infoModalContents/ApprovalInfoContent.tsx
@@ -10,7 +10,7 @@ export const ApprovalInfoContent = () => {
       <Typography>
         <Trans>
           Before supplying, you need to approve its usage by the Aave protocol. You can learn more
-          in our
+          in our{' '}
           <Link fontWeight={500} href={'https://docs.aave.com/faq/'}>
             FAQ
           </Link>


### PR DESCRIPTION
- Fixes https://github.com/aave/interface/issues/746
- Added space character before FAQ button

![image](https://user-images.githubusercontent.com/25493955/185699926-4c80976f-4055-49b6-b49a-ebcd5e48c61e.png)

Note - once this has been merged, we can close the stale PR https://github.com/aave/interface/pull/938