### PR TITLE
Fix: fixes clear button not visible on asset input

### DIFF
--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -148,7 +148,7 @@ export const AssetInput = <T extends Asset = Asset>({
             // eslint-disable-next-line
             inputComponent={NumberFormatCustom as any}
           />
-          {value !== '' && !disabled && (
+          {value !== '' && !disableInput && (
             <IconButton
               sx={{
                 minWidth: 0,

--- a/src/components/transactions/AssetInput.tsx
+++ b/src/components/transactions/AssetInput.tsx
@@ -148,28 +148,28 @@ export const AssetInput = <T extends Asset = Asset>({
             // eslint-disable-next-line
             inputComponent={NumberFormatCustom as any}
           />
-
+          {value !== '' && !disabled && (
+            <IconButton
+              sx={{
+                minWidth: 0,
+                p: 0,
+                left: 8,
+                zIndex: 1,
+                color: 'text.muted',
+                '&:hover': {
+                  color: 'text.secondary',
+                },
+              }}
+              onClick={() => {
+                onChange && onChange('');
+              }}
+              disabled={disabled}
+            >
+              <XCircleIcon height={16} />
+            </IconButton>
+          )}
           {!onSelect || assets.length === 1 ? (
             <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
-              {value !== '' && (
-                <IconButton
-                  sx={{
-                    minWidth: 0,
-                    p: 0,
-                    left: 8,
-                    color: 'text.muted',
-                    '&:hover': {
-                      color: 'text.secondary',
-                    },
-                  }}
-                  onClick={() => {
-                    onChange && onChange('');
-                  }}
-                  disabled={disabled}
-                >
-                  <XCircleIcon height={16} />
-                </IconButton>
-              )}
               <TokenIcon
                 aToken={asset.aToken}
                 symbol={asset.iconSymbol || asset.symbol}


### PR DESCRIPTION
- Fixes https://github.com/aave/interface/issues/1050
- Simply render the `IconButton` component i.e. the clear button right after the `InputBase` component
- Update its `z-index` to ensure it is clickable when rendering next to the asset dropdown
- Update its rendering condition to not render if `disabled` is truthy

Screenshot 👇 
![image](https://user-images.githubusercontent.com/25493955/186481429-778a3bba-bd3f-4b3d-91c8-a0f7e0830caf.png)