### PR TITLE
fix: liquidation risk colors

### DIFF
--- a/src/modules/dashboard/LiquidationRiskParametresModal/LiquidationRiskParametresModal.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/LiquidationRiskParametresModal.tsx
@@ -26,6 +26,26 @@ export const LiquidationRiskParametresInfoModal = ({
   currentLoanToValue,
   currentLiquidationThreshold,
 }: LiquidationRiskParametresInfoModalProps) => {
+  let healthFactorColor: 'error' | 'warning' | 'success' = 'success';
+  if (+healthFactor <= 3 && +healthFactor > 1.1) {
+    healthFactorColor = 'warning';
+  } else if (+healthFactor <= 1.1) {
+    healthFactorColor = 'error';
+  }
+
+  let ltvColor: 'error' | 'warning' | 'success' = 'success';
+  const ltvPercent = Number(loanToValue) * 100;
+  const currentLtvPercent = Number(currentLoanToValue) * 100;
+  const liquidationThresholdPercent = Number(currentLiquidationThreshold) * 100;
+  if (
+    (ltvPercent > currentLtvPercent / 2 && ltvPercent <= currentLtvPercent) ||
+    (ltvPercent > currentLtvPercent && ltvPercent < liquidationThresholdPercent)
+  ) {
+    ltvColor = 'warning';
+  } else if (ltvPercent >= liquidationThresholdPercent) {
+    ltvColor = 'error';
+  }
+
   return (
     <BasicModal open={open} setOpen={setOpen}>
       <Typography variant="h2" mb={6}>
@@ -67,8 +87,7 @@ export const LiquidationRiskParametresInfoModal = ({
             triggered.
           </Trans>
         }
-        isWarning={+healthFactor <= 3 && +healthFactor > 1.1}
-        isError={+healthFactor <= 1.1}
+        color={healthFactorColor}
       >
         <HFContent healthFactor={healthFactor} />
       </InfoWrapper>
@@ -93,16 +112,13 @@ export const LiquidationRiskParametresInfoModal = ({
             be liquidated.
           </Trans>
         }
-        isWarning={
-          +loanToValue * 100 < +currentLoanToValue * 100 &&
-          +loanToValue * 100 > +currentLoanToValue * 100 - (+currentLoanToValue * 100) / 2
-        }
-        isError={+loanToValue * 100 > +currentLiquidationThreshold * 100}
+        color={ltvColor}
       >
         <LTVContent
           loanToValue={loanToValue}
           currentLoanToValue={currentLoanToValue}
           currentLiquidationThreshold={currentLiquidationThreshold}
+          color={ltvColor}
         />
       </InfoWrapper>
     </BasicModal>

--- a/src/modules/dashboard/LiquidationRiskParametresModal/LiquidationRiskParametresModal.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/LiquidationRiskParametresModal.tsx
@@ -27,9 +27,10 @@ export const LiquidationRiskParametresInfoModal = ({
   currentLiquidationThreshold,
 }: LiquidationRiskParametresInfoModalProps) => {
   let healthFactorColor: AlertColor = 'success';
-  if (+healthFactor <= 3 && +healthFactor > 1.1) {
+  const hf = Number(healthFactor);
+  if (hf > 1.1 && hf <= 3) {
     healthFactorColor = 'warning';
-  } else if (+healthFactor <= 1.1) {
+  } else if (hf <= 1.1) {
     healthFactorColor = 'error';
   }
 
@@ -37,13 +38,10 @@ export const LiquidationRiskParametresInfoModal = ({
   const ltvPercent = Number(loanToValue) * 100;
   const currentLtvPercent = Number(currentLoanToValue) * 100;
   const liquidationThresholdPercent = Number(currentLiquidationThreshold) * 100;
-  if (
-    (ltvPercent > currentLtvPercent / 2 && ltvPercent <= currentLtvPercent) ||
-    (ltvPercent > currentLtvPercent && ltvPercent < liquidationThresholdPercent)
-  ) {
-    ltvColor = 'warning';
-  } else if (ltvPercent >= liquidationThresholdPercent) {
+  if (ltvPercent >= Math.min(currentLtvPercent, liquidationThresholdPercent)) {
     ltvColor = 'error';
+  } else if (ltvPercent > currentLtvPercent / 2 && ltvPercent < currentLtvPercent) {
+    ltvColor = 'warning';
   }
 
   return (

--- a/src/modules/dashboard/LiquidationRiskParametresModal/LiquidationRiskParametresModal.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/LiquidationRiskParametresModal.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro';
-import { Typography } from '@mui/material';
+import { AlertColor, Typography } from '@mui/material';
 
 import { HealthFactorNumber } from '../../../components/HealthFactorNumber';
 import { BasicModal } from '../../../components/primitives/BasicModal';
@@ -26,14 +26,14 @@ export const LiquidationRiskParametresInfoModal = ({
   currentLoanToValue,
   currentLiquidationThreshold,
 }: LiquidationRiskParametresInfoModalProps) => {
-  let healthFactorColor: 'error' | 'warning' | 'success' = 'success';
+  let healthFactorColor: AlertColor = 'success';
   if (+healthFactor <= 3 && +healthFactor > 1.1) {
     healthFactorColor = 'warning';
   } else if (+healthFactor <= 1.1) {
     healthFactorColor = 'error';
   }
 
-  let ltvColor: 'error' | 'warning' | 'success' = 'success';
+  let ltvColor: AlertColor = 'success';
   const ltvPercent = Number(loanToValue) * 100;
   const currentLtvPercent = Number(currentLoanToValue) * 100;
   const liquidationThresholdPercent = Number(currentLiquidationThreshold) * 100;

--- a/src/modules/dashboard/LiquidationRiskParametresModal/components/InfoWrapper.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/components/InfoWrapper.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material';
+import { AlertColor, Box, Typography } from '@mui/material';
 import { ReactNode } from 'react';
 
 interface InfoWrapperProps {
@@ -7,7 +7,7 @@ interface InfoWrapperProps {
   topDescription: ReactNode;
   children: ReactNode;
   bottomText: ReactNode;
-  color: 'error' | 'warning' | 'success';
+  color: AlertColor;
 }
 
 export const InfoWrapper = ({

--- a/src/modules/dashboard/LiquidationRiskParametresModal/components/InfoWrapper.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/components/InfoWrapper.tsx
@@ -7,8 +7,7 @@ interface InfoWrapperProps {
   topDescription: ReactNode;
   children: ReactNode;
   bottomText: ReactNode;
-  isWarning?: boolean;
-  isError?: boolean;
+  color: 'error' | 'warning' | 'success';
 }
 
 export const InfoWrapper = ({
@@ -17,8 +16,7 @@ export const InfoWrapper = ({
   topDescription,
   children,
   bottomText,
-  isWarning,
-  isError,
+  color,
 }: InfoWrapperProps) => {
   return (
     <Box
@@ -52,7 +50,7 @@ export const InfoWrapper = ({
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            bgcolor: isError ? 'error.main' : isWarning ? 'warning.main' : 'success.main',
+            bgcolor: `${color}.main`,
           }}
         >
           {topValue}

--- a/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
@@ -179,22 +179,24 @@ export const LTVContent = ({
             borderRadius: '1px',
             width: `${LTVLineWidth > 100 ? 100 : LTVLineWidth}%`,
             maxWidth: '100%',
-            background: `${palette[color].main}`,
+            bgcolor: `${color}.main`,
             zIndex: 2,
           }}
         />
 
-        <Box
-          sx={{
-            position: 'absolute',
-            left: 0,
-            height: '4px',
-            borderRadius: '1px',
-            width: `${CurrentLTVLineWidth > 100 ? 100 : CurrentLTVLineWidth}%`,
-            maxWidth: '100%',
-            background: `repeating-linear-gradient(-45deg, ${palette.divider}, ${palette.divider} 4px, ${palette[color].main} 4px, ${palette[color].main} 7px)`,
-          }}
-        />
+        {LTVLineWidth < CurrentLTVLineWidth && (
+          <Box
+            sx={{
+              position: 'absolute',
+              left: 0,
+              height: '4px',
+              borderRadius: '1px',
+              width: `${CurrentLTVLineWidth > 100 ? 100 : CurrentLTVLineWidth}%`,
+              maxWidth: '100%',
+              background: `repeating-linear-gradient(-45deg, ${palette.divider}, ${palette.divider} 4px, ${palette[color].main} 4px, ${palette[color].main} 7px)`,
+            }}
+          />
+        )}
       </Box>
     </Box>
   );

--- a/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
@@ -1,6 +1,6 @@
 import { valueToBigNumber } from '@aave/math-utils';
 import { Trans } from '@lingui/macro';
-import { Box, Typography, useTheme } from '@mui/material';
+import { AlertColor, Box, Typography, useTheme } from '@mui/material';
 import BigNumber from 'bignumber.js';
 import React from 'react';
 
@@ -10,7 +10,7 @@ interface LTVContentProps {
   loanToValue: string;
   currentLoanToValue: string;
   currentLiquidationThreshold: string;
-  color: 'error' | 'warning' | 'success';
+  color: AlertColor;
 }
 
 export const LTVContent = ({

--- a/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
@@ -179,7 +179,7 @@ export const LTVContent = ({
             borderRadius: '1px',
             width: `${LTVLineWidth > 100 ? 100 : LTVLineWidth}%`,
             maxWidth: '100%',
-            background: `${color}.main`,
+            background: `${palette[color].main}`,
             zIndex: 2,
           }}
         />
@@ -192,7 +192,7 @@ export const LTVContent = ({
             borderRadius: '1px',
             width: `${CurrentLTVLineWidth > 100 ? 100 : CurrentLTVLineWidth}%`,
             maxWidth: '100%',
-            background: `repeating-linear-gradient(-45deg, ${palette.divider}, ${palette.divider} 4px, ${color}.main 4px, ${color}.main 7px)`,
+            background: `repeating-linear-gradient(-45deg, ${palette.divider}, ${palette.divider} 4px, ${palette[color].main} 4px, ${palette[color].main} 7px)`,
           }}
         />
       </Box>

--- a/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
+++ b/src/modules/dashboard/LiquidationRiskParametresModal/components/LTVContent.tsx
@@ -10,12 +10,14 @@ interface LTVContentProps {
   loanToValue: string;
   currentLoanToValue: string;
   currentLiquidationThreshold: string;
+  color: 'error' | 'warning' | 'success';
 }
 
 export const LTVContent = ({
   loanToValue,
   currentLoanToValue,
   currentLiquidationThreshold,
+  color,
 }: LTVContentProps) => {
   const { palette } = useTheme();
 
@@ -34,15 +36,7 @@ export const LTVContent = ({
     .precision(20, BigNumber.ROUND_UP)
     .toNumber();
 
-  let LTVLineColor = palette.success.main;
-  if (
-    +loanToValue * 100 < +currentLoanToValue * 100 &&
-    +loanToValue * 100 > +currentLoanToValue * 100 - (+currentLoanToValue * 100) / 2
-  ) {
-    LTVLineColor = palette.warning.main;
-  } else if (+loanToValue * 100 > +currentLiquidationThreshold * 100) {
-    LTVLineColor = palette.error.main;
-  }
+  const liquidationThresholdPercent = Number(currentLiquidationThreshold) * 100;
 
   return (
     <Box sx={{ position: 'relative', margin: '45px 0 55px' }}>
@@ -65,10 +59,9 @@ export const LTVContent = ({
             '&:after': {
               content: "''",
               position: 'absolute',
-              left: +currentLiquidationThreshold * 100 > 75 ? 'auto' : '50%',
-              transform:
-                +currentLiquidationThreshold * 100 > 75 ? 'translateX(0)' : 'translateX(-50%)',
-              right: +currentLiquidationThreshold * 100 > 75 ? 0 : 'auto',
+              left: liquidationThresholdPercent > 75 ? 'auto' : '50%',
+              transform: liquidationThresholdPercent > 75 ? 'translateX(0)' : 'translateX(-50%)',
+              right: liquidationThresholdPercent > 75 ? 0 : 'auto',
               bottom: '100%',
               height: '10px',
               width: '2px',
@@ -80,13 +73,12 @@ export const LTVContent = ({
             sx={{
               display: 'flex',
               position: 'absolute',
-              left: +currentLiquidationThreshold * 100 > 75 ? 'auto' : '50%',
-              transform:
-                +currentLiquidationThreshold * 100 > 75 ? 'translateX(0)' : 'translateX(-50%)',
-              right: +currentLiquidationThreshold * 100 > 75 ? 0 : 'auto',
+              left: liquidationThresholdPercent > 75 ? 'auto' : '50%',
+              transform: liquidationThresholdPercent > 75 ? 'translateX(0)' : 'translateX(-50%)',
+              right: liquidationThresholdPercent > 75 ? 0 : 'auto',
               flexDirection: 'column',
-              alignItems: +currentLiquidationThreshold * 100 > 75 ? 'flex-end' : 'center',
-              textAlign: +currentLiquidationThreshold * 100 > 75 ? 'right' : 'center',
+              alignItems: liquidationThresholdPercent > 75 ? 'flex-end' : 'center',
+              textAlign: liquidationThresholdPercent > 75 ? 'right' : 'center',
             }}
           >
             <FormattedNumber
@@ -187,7 +179,7 @@ export const LTVContent = ({
             borderRadius: '1px',
             width: `${LTVLineWidth > 100 ? 100 : LTVLineWidth}%`,
             maxWidth: '100%',
-            background: LTVLineColor,
+            background: `${color}.main`,
             zIndex: 2,
           }}
         />
@@ -200,7 +192,7 @@ export const LTVContent = ({
             borderRadius: '1px',
             width: `${CurrentLTVLineWidth > 100 ? 100 : CurrentLTVLineWidth}%`,
             maxWidth: '100%',
-            background: `repeating-linear-gradient(-45deg, ${palette.divider}, ${palette.divider} 4px, ${LTVLineColor} 4px, ${LTVLineColor} 7px)`,
+            background: `repeating-linear-gradient(-45deg, ${palette.divider}, ${palette.divider} 4px, ${color}.main 4px, ${color}.main 7px)`,
           }}
         />
       </Box>


### PR DESCRIPTION
If the LTV is grater than the Max LTV, then the line will show as red:
![image](https://user-images.githubusercontent.com/23554636/187463221-99fd8f33-0af6-4aff-9804-d2a95ac28c0e.png)

I cleaned up some of the logic while in here. I lifted the calculations up to the parent component and then just pass in the alert colors down to the child components.

closes #891 