### PR TITLE
fix: only show apy info for assets with borrowing enabled

### DIFF
--- a/src/modules/markets/AssetsListItem.tsx
+++ b/src/modules/markets/AssetsListItem.tsx
@@ -72,11 +72,7 @@ export const AssetsListItem = ({ ...reserve }: ComputedReserveData) => {
 
       <ListColumn>
         <IncentivesCard
-          value={
-            reserve.borrowingEnabled || Number(reserve.totalVariableDebtUSD) > 0
-              ? reserve.variableBorrowAPY
-              : '-1'
-          }
+          value={reserve.borrowingEnabled ? reserve.variableBorrowAPY : '-1'}
           incentives={reserve.vIncentivesData || []}
           symbol={reserve.symbol}
           variant="main16"
@@ -87,7 +83,7 @@ export const AssetsListItem = ({ ...reserve }: ComputedReserveData) => {
       <ListColumn>
         <IncentivesCard
           value={
-            reserve.stableBorrowRateEnabled || Number(reserve.totalStableDebtUSD) > 0
+            reserve.borrowingEnabled && reserve.stableBorrowRateEnabled
               ? reserve.stableBorrowAPY
               : -1
           }


### PR DESCRIPTION
For assets that have borrowing disabled, do not show the borrow APY info in the markets assets list