### PR TITLE
fix: only show stable borrow rate if borrowing is enabled

### DIFF
--- a/cypress/e2e/0-v2-markets/0-main-v2-market/critical-conditions.aave-v2.cy.ts
+++ b/cypress/e2e/0-v2-markets/0-main-v2-market/critical-conditions.aave-v2.cy.ts
@@ -18,12 +18,12 @@ const testData = {
       apyType: constants.borrowAPYType.variable,
       hasApproval: true,
       isRisk: true,
+      isMaxAmount: true,
     },
     deposit2: {
       asset: assets.aaveMarket.ETH,
       amount: 1,
       hasApproval: true,
-      isMaxAmount: true,
     },
     withdraw: {
       asset: assets.aaveMarket.ETH,

--- a/cypress/e2e/0-v2-markets/0-main-v2-market/critical-conditions.aave-v2.cy.ts
+++ b/cypress/e2e/0-v2-markets/0-main-v2-market/critical-conditions.aave-v2.cy.ts
@@ -23,6 +23,7 @@ const testData = {
       asset: assets.aaveMarket.ETH,
       amount: 1,
       hasApproval: true,
+      isMaxAmount: true,
     },
     withdraw: {
       asset: assets.aaveMarket.ETH,

--- a/src/modules/markets/AssetsListItem.tsx
+++ b/src/modules/markets/AssetsListItem.tsx
@@ -72,7 +72,11 @@ export const AssetsListItem = ({ ...reserve }: ComputedReserveData) => {
 
       <ListColumn>
         <IncentivesCard
-          value={reserve.borrowingEnabled ? reserve.variableBorrowAPY : '-1'}
+          value={
+            reserve.borrowingEnabled || Number(reserve.totalStableDebtUSD) > 0
+              ? reserve.variableBorrowAPY
+              : '-1'
+          }
           incentives={reserve.vIncentivesData || []}
           symbol={reserve.symbol}
           variant="main16"
@@ -83,7 +87,8 @@ export const AssetsListItem = ({ ...reserve }: ComputedReserveData) => {
       <ListColumn>
         <IncentivesCard
           value={
-            reserve.borrowingEnabled && reserve.stableBorrowRateEnabled
+            (reserve.borrowingEnabled && reserve.stableBorrowRateEnabled) ||
+            Number(reserve.totalStableDebtUSD) > 0
               ? reserve.stableBorrowAPY
               : -1
           }

--- a/src/modules/markets/AssetsListItem.tsx
+++ b/src/modules/markets/AssetsListItem.tsx
@@ -73,7 +73,7 @@ export const AssetsListItem = ({ ...reserve }: ComputedReserveData) => {
       <ListColumn>
         <IncentivesCard
           value={
-            reserve.borrowingEnabled || Number(reserve.totalStableDebtUSD) > 0
+            reserve.borrowingEnabled || Number(reserve.totalVariableDebtUSD) > 0
               ? reserve.variableBorrowAPY
               : '-1'
           }

--- a/src/modules/markets/AssetsListItem.tsx
+++ b/src/modules/markets/AssetsListItem.tsx
@@ -72,11 +72,7 @@ export const AssetsListItem = ({ ...reserve }: ComputedReserveData) => {
 
       <ListColumn>
         <IncentivesCard
-          value={
-            reserve.borrowingEnabled || Number(reserve.totalVariableDebtUSD) > 0
-              ? reserve.variableBorrowAPY
-              : '-1'
-          }
+          value={reserve.borrowingEnabled ? reserve.variableBorrowAPY : '-1'}
           incentives={reserve.vIncentivesData || []}
           symbol={reserve.symbol}
           variant="main16"
@@ -87,7 +83,7 @@ export const AssetsListItem = ({ ...reserve }: ComputedReserveData) => {
       <ListColumn>
         <IncentivesCard
           value={
-            reserve.stableBorrowRateEnabled || Number(reserve.totalStableDebtUSD) > 0
+            reserve.borrowingEnabled && reserve.stableBorrowRateEnabled
               ? reserve.stableBorrowAPY
               : -1
           }


### PR DESCRIPTION
Adds a check to make sure `borrowingEnabled` is true in addition `stableBorrowRateEnabled` in order to show the borrow apy.

It's possible that stable borrow could still be enabled, but borrowing is disabled on the asset, which takes precedence.