### PR TITLE
fix: switch to using public eth rpc for ens lookups

### DIFF
--- a/cypress/e2e/0-v2-markets/0-main-v2-market/critical-conditions.aave-v2.cy.ts
+++ b/cypress/e2e/0-v2-markets/0-main-v2-market/critical-conditions.aave-v2.cy.ts
@@ -18,6 +18,7 @@ const testData = {
       apyType: constants.borrowAPYType.variable,
       hasApproval: true,
       isRisk: true,
+      isMaxAmount: true,
     },
     deposit2: {
       asset: assets.aaveMarket.ETH,

--- a/src/libs/hooks/use-get-ens.tsx
+++ b/src/libs/hooks/use-get-ens.tsx
@@ -4,7 +4,7 @@ import { utils } from 'ethers';
 import { useEffect, useState } from 'react';
 import { getProvider } from 'src/utils/marketsAndNetworksConfig';
 
-const mainnetProvider = getProvider(ChainId.mainnet);
+const mainnetProvider = getProvider(ChainId.mainnet, true);
 
 interface EnsResponse {
   name?: string;

--- a/src/libs/hooks/use-get-ens.tsx
+++ b/src/libs/hooks/use-get-ens.tsx
@@ -1,10 +1,9 @@
-import { ChainId } from '@aave/contract-helpers';
 import makeBlockie from 'ethereum-blockies-base64';
 import { utils } from 'ethers';
 import { useEffect, useState } from 'react';
-import { getProvider } from 'src/utils/marketsAndNetworksConfig';
+import { getENSProvider } from 'src/utils/marketsAndNetworksConfig';
 
-const mainnetProvider = getProvider(ChainId.mainnet, true);
+const mainnetProvider = getENSProvider();
 
 interface EnsResponse {
   name?: string;

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -150,11 +150,11 @@ const providers: { [network: string]: ethersProviders.Provider } = {};
  * @param chainId
  * @returns provider or fallbackprovider in case multiple rpcs are configured
  */
-export const getProvider = (chainId: ChainId, ens?: boolean): ethersProviders.Provider => {
+export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
   if (!providers[chainId]) {
     const config = getNetworkConfig(chainId);
     const chainProviders: ethersProviders.FallbackProviderConfig[] = [];
-    if (config.privateJsonRPCUrl && !ens) {
+    if (config.privateJsonRPCUrl) {
       chainProviders.push({
         provider: new ethersProviders.StaticJsonRpcProvider(config.privateJsonRPCUrl, chainId),
         priority: 0,
@@ -178,6 +178,12 @@ export const getProvider = (chainId: ChainId, ens?: boolean): ethersProviders.Pr
     }
   }
   return providers[chainId];
+};
+
+export const getENSProvider = () => {
+  const chainId = 1;
+  const config = getNetworkConfig(chainId);
+  return new ethersProviders.StaticJsonRpcProvider(config.publicJsonRPCUrl[0], chainId);
 };
 
 const ammDisableProposal = 'https://app.aave.com/governance/proposal/?proposalId=44';

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -150,11 +150,11 @@ const providers: { [network: string]: ethersProviders.Provider } = {};
  * @param chainId
  * @returns provider or fallbackprovider in case multiple rpcs are configured
  */
-export const getProvider = (chainId: ChainId): ethersProviders.Provider => {
+export const getProvider = (chainId: ChainId, ens?: boolean): ethersProviders.Provider => {
   if (!providers[chainId]) {
     const config = getNetworkConfig(chainId);
     const chainProviders: ethersProviders.FallbackProviderConfig[] = [];
-    if (config.privateJsonRPCUrl) {
+    if (config.privateJsonRPCUrl && !ens) {
       chainProviders.push({
         provider: new ethersProviders.StaticJsonRpcProvider(config.privateJsonRPCUrl, chainId),
         priority: 0,


### PR DESCRIPTION
The primary RPCs used on the app are from POKT and have a customizable contract allowlist. Since it is not feasible to add all ENS resolvers to the allowlist, lookups return an error with the POKT rpc, so this PR switches to using the public rpc for ens lookups.

Addresses to test:

0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 - vitalik.eth
0x064Bd35c9064fC3e628a3BE3310a1cf65488103D - hello.eth