### PR TITLE
feat: switch governance gateway to cloudflare

### DIFF
--- a/src/ui-config/governanceConfig.ts
+++ b/src/ui-config/governanceConfig.ts
@@ -41,5 +41,5 @@ export const governanceConfig: GovernanceConfig = {
     AAVE_GOVERNANCE_V2_EXECUTOR_LONG: '0xEE56e2B3D491590B5b31738cC34d5232F378a8D5',
     AAVE_GOVERNANCE_V2_HELPER: '0x16ff7583ea21055bf5f929ec4b896d997ff35847',
   },
-  ipfsGateway: 'https://cf-ipfs.com/ipfs/',
+  ipfsGateway: 'https://cf-ipfs.com/ipfs',
 };

--- a/src/ui-config/governanceConfig.ts
+++ b/src/ui-config/governanceConfig.ts
@@ -41,5 +41,5 @@ export const governanceConfig: GovernanceConfig = {
     AAVE_GOVERNANCE_V2_EXECUTOR_LONG: '0xEE56e2B3D491590B5b31738cC34d5232F378a8D5',
     AAVE_GOVERNANCE_V2_HELPER: '0x16ff7583ea21055bf5f929ec4b896d997ff35847',
   },
-  ipfsGateway: 'https://gateway.pinata.cloud/ipfs',
+  ipfsGateway: 'https://cf-ipfs.com/ipfs/',
 };


### PR DESCRIPTION
Piñata public gateway has been getting frequent errors causing governance cache to not be updated.

This switches to the cloudflare public gateway which should hopefully be more reliable.