### PR TITLE
chore: add prettier to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,10 +139,10 @@
     "Diego Prudencio diego@aave.com"
   ],
   "lint-staged": {
-    "*.js": "eslint --cache --fix",
-    "*.jsx": "eslint --cache --fix",
-    "*.ts": "eslint --cache --fix",
-    "*.tsx": "eslint --cache --fix",
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix",
+      "prettier --write"
+    ],
     "*.svg": "npx svgo --final-newline"
   },
   "nextBundleAnalysis": {


### PR DESCRIPTION
Simplified some of the lint-staged config and also added a step to run prettier and write the changes to the file before committing. This should ensure that any files with changes will always get formatted according to our prettier config.