### PR TITLE
fix: rollback governance gateway change [skip cypress]

### DIFF
--- a/src/ui-config/governanceConfig.ts
+++ b/src/ui-config/governanceConfig.ts
@@ -41,5 +41,5 @@ export const governanceConfig: GovernanceConfig = {
     AAVE_GOVERNANCE_V2_EXECUTOR_LONG: '0xEE56e2B3D491590B5b31738cC34d5232F378a8D5',
     AAVE_GOVERNANCE_V2_HELPER: '0x16ff7583ea21055bf5f929ec4b896d997ff35847',
   },
-  ipfsGateway: 'https://cf-ipfs.com/ipfs',
+  ipfsGateway: 'https://gateway.pinata.cloud/ipfs',
 };


### PR DESCRIPTION
Roll back changes from #1115 due to CORS errors