### PR TITLE
fix: remove duplicate debt ceiling warning

### DIFF
--- a/src/components/transactions/Borrow/BorrowModalContent.tsx
+++ b/src/components/transactions/Borrow/BorrowModalContent.tsx
@@ -220,7 +220,6 @@ export const BorrowModalContent = ({
   return (
     <>
       {borrowCap.determineWarningDisplay({ borrowCap })}
-      {debtCeiling.determineWarningDisplay({ debtCeiling })}
       {poolReserve.isIsolated && debtCeiling.determineWarningDisplay({ debtCeiling })}
 
       <AssetInput


### PR DESCRIPTION
## General Changes

Remove duplicate warning in borrow modal about debt ceiling

## Author Checklist

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

## Reviewer Checklist

- [x]  End-to-end tests are passing without any errors
- [x]  Code style generally follows existing patterns
- [x]  Code changes do not significantly increase the application bundle size
- [x]  New third-party packages, if any, do not introduce potential security threats
- [x]  There are no CI changes, or they have been OK’d by the devops team
- [x]  Code changes have been quality checked in the ephemeral URL
- [x]  There are two or more approvals from the core team
- [x]  Squash and merge has been checked
