### PR TITLE
fix: use gateway retry logic anywhere we fetch ipfs data

### DIFF
--- a/pages/governance/ipfs-preview.governance.tsx
+++ b/pages/governance/ipfs-preview.governance.tsx
@@ -15,10 +15,11 @@ export default function IpfsPreview() {
   const [ipfs, setIpfs] = useState<IpfsType>();
 
   async function fetchIpfs() {
+    const proposalMetadata = await getProposalMetadata(ipfsHash, governanceConfig.ipfsGateway);
     const newIpfs = {
       id: -1,
       originalHash: ipfsHash,
-      ...(await getProposalMetadata(ipfsHash, governanceConfig.ipfsGateway)),
+      ...proposalMetadata,
     };
     setIpfs(newIpfs);
   }

--- a/pages/governance/proposal/index.governance.tsx
+++ b/pages/governance/proposal/index.governance.tsx
@@ -19,7 +19,7 @@ export default function DynamicProposal() {
   const [ipfs, setIpfs] = useState<IpfsType>();
   const [fetchMetadataError, setFetchMetadataError] = useState(false);
 
-  async function initialize(_ipfsGateway: string, _useFallback: boolean) {
+  async function initialize(_ipfsGateway: string) {
     const { values, ...rest } = await governanceContract.getProposal({ proposalId: id });
     const proposal = await enhanceProposalWithTimes(rest);
     setProposal(proposal);
@@ -38,7 +38,7 @@ export default function DynamicProposal() {
   }
 
   useEffect(() => {
-    id && initialize(governanceConfig.ipfsGateway, false);
+    id && initialize(governanceConfig.ipfsGateway);
   }, [id]);
 
   return <ProposalPage ipfs={ipfs} proposal={proposal} metadataError={fetchMetadataError} />;

--- a/src/modules/governance/ProposalsList.tsx
+++ b/src/modules/governance/ProposalsList.tsx
@@ -39,11 +39,15 @@ export function ProposalsList({ proposals: initialProposals }: GovernancePagePro
         for (let i = proposals.length; i < count; i++) {
           const { values, ...rest } = await governanceContract.getProposal({ proposalId: i });
           const proposal = await enhanceProposalWithTimes(rest);
+          const proposalMetadata = await getProposalMetadata(
+            proposal.ipfsHash,
+            governanceConfig.ipfsGateway
+          );
           nextProposals.push({
             ipfs: {
               id: i,
               originalHash: proposal.ipfsHash,
-              ...(await getProposalMetadata(proposal.ipfsHash, governanceConfig.ipfsGateway)),
+              ...proposalMetadata,
             },
             proposal: proposal,
             prerendered: false,

--- a/src/modules/governance/utils/getProposalMetadata.ts
+++ b/src/modules/governance/utils/getProposalMetadata.ts
@@ -18,11 +18,7 @@ export async function getProposalMetadata(
     ? base58.encode(Buffer.from(`1220${hash.slice(2)}`, 'hex'))
     : hash;
   if (MEMORIZE[ipfsHash]) return MEMORIZE[ipfsHash];
-  const ipfsResponse: Response = await fetch(getLink(ipfsHash, gateway), {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+  const ipfsResponse: Response = await fetch(getLink(ipfsHash, gateway));
   if (!ipfsResponse.ok) {
     throw Error('Fetch not working');
   }

--- a/src/modules/governance/utils/getProposalMetadata.ts
+++ b/src/modules/governance/utils/getProposalMetadata.ts
@@ -4,13 +4,27 @@ import matter from 'gray-matter';
 import fetch from 'isomorphic-unfetch';
 import { governanceConfig } from 'src/ui-config/governanceConfig';
 
+type MemorizeMetadata = Record<string, ProposalMetadata>;
+const MEMORIZE: MemorizeMetadata = {};
+
+/**
+ * Composes a URI based off of a given IPFS CID hash and gateway
+ * @param  {string} hash - The IPFS CID hash
+ * @param  {string} gateway - The IPFS gateway host
+ * @returns string
+ */
 export function getLink(hash: string, gateway: string): string {
   return `${gateway}/${hash}`;
 }
-type MemorizeMetadata = Record<string, ProposalMetadata>;
 
-const MEMORIZE: MemorizeMetadata = {};
-
+/**
+ * Fetches the IPFS metadata JSON from our preferred public gateway, once.
+ * If the gateway fails, attempt to fetch recursively with a fallback gateway, once.
+ * If the fallback fails, throw an error.
+ * @param  {string} hash - The IPFS CID hash to query
+ * @param  {string} gateway - The IPFS gateway host
+ * @returns Promise
+ */
 export async function getProposalMetadata(
   hash: string,
   gateway: string
@@ -20,12 +34,16 @@ export async function getProposalMetadata(
   } catch (e) {
     console.groupCollapsed('Fetching proposal metadata from IPFS...');
     console.info('failed with', gateway);
+
+    // Primary gateway failed, retry with fallback
     if (gateway === governanceConfig.ipfsGateway) {
       console.info('retrying with', governanceConfig.fallbackIpfsGateway);
       console.error(e);
       console.groupEnd();
       return getProposalMetadata(hash, governanceConfig.fallbackIpfsGateway);
     }
+
+    // Fallback gateway failed, exit
     console.info('exiting');
     console.error(e);
     console.groupEnd();
@@ -33,16 +51,27 @@ export async function getProposalMetadata(
   }
 }
 
+/**
+ * Fetches data from a provided IPFS gateway with a simple caching mechanism.
+ * Cache keys are the hashes, values are ProposalMetadata objects.
+ * The cache does not implement any invalidation mechanisms nor sets expiries.
+ * @param  {string} hash - The IPFS CID hash to query
+ * @param  {string} gateway - The IPFS gateway host
+ * @returns Promise
+ */
 async function fetchFromIpfs(hash: string, gateway: string): Promise<ProposalMetadata> {
+  // Read from cache
   const ipfsHash = hash.startsWith('0x')
     ? base58.encode(Buffer.from(`1220${hash.slice(2)}`, 'hex'))
     : hash;
   if (MEMORIZE[ipfsHash]) return MEMORIZE[ipfsHash];
+
+  // Fetch
   const ipfsResponse: Response = await fetch(getLink(ipfsHash, gateway));
-  if (!ipfsResponse.ok) {
-    throw Error('Fetch not working');
-  }
+  if (!ipfsResponse.ok) throw Error('Fetch not working');
   const clone = await ipfsResponse.clone();
+
+  // Store in cache
   try {
     const response: ProposalMetadata = await ipfsResponse.json();
     const { content, data } = matter(response.description);

--- a/src/ui-config/governanceConfig.ts
+++ b/src/ui-config/governanceConfig.ts
@@ -42,6 +42,6 @@ export const governanceConfig: GovernanceConfig = {
     AAVE_GOVERNANCE_V2_EXECUTOR_LONG: '0xEE56e2B3D491590B5b31738cC34d5232F378a8D5',
     AAVE_GOVERNANCE_V2_HELPER: '0x16ff7583ea21055bf5f929ec4b896d997ff35847',
   },
-  ipfsGateway: 'https://gateway.pinata.cloud/ipfs',
-  fallbackIpfsGateway: 'https://cloudflare-ipfs.com/ipfs',
+  ipfsGateway: 'https://cloudflare-ipfs.com/ipfs',
+  fallbackIpfsGateway: 'https://gateway.pinata.cloud/ipfs',
 };

--- a/src/ui-config/governanceConfig.ts
+++ b/src/ui-config/governanceConfig.ts
@@ -43,5 +43,5 @@ export const governanceConfig: GovernanceConfig = {
     AAVE_GOVERNANCE_V2_HELPER: '0x16ff7583ea21055bf5f929ec4b896d997ff35847',
   },
   ipfsGateway: 'https://cloudflare-ipfs.com/ipfs',
-  fallbackIpfsGateway: 'https://gateway.pinata.cloud/ipfs',
+  fallbackIpfsGateway: 'https://ipfs.io/ipfs',
 };


### PR DESCRIPTION
## General Changes

- Uses the retry logic anywhere we try to fetch proposal data from the public ipfs gateways
- Removes the piñata public gateway and adds ipfs.io gateway in its place

## Developer Notes

Having headers on the request to the gateway was giving a CORS error on ipfs.io, so I removed it. Both configured gateways are working without the header.

## Author Checklist

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]   The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

## Reviewer Checklist

- [x]  End-to-end tests are passing without any errors
- [x]  Code style generally follows existing patterns
- [x]  Code changes do not significantly increase the application bundle size
- [x]  New third-party packages, if any, do not introduce potential security threats
- [x]  There are no CI changes, or they have been OK’d by the devops team
- [x]  Code changes have been quality checked in the ephemeral URL
- [x]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
