### PR TITLE
chore: add dependency scanning for PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+      - 'Ready for Dev Review'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v2


### PR DESCRIPTION
## General Changes

- Adds in a Github action to scan for dependency vulnerabilities in PRs
- Add deliberate labels for Dependabot PRs
  - `dependencies`
  - `Ready for Dev Review`

## Developer Notes

After this housekeeping PR is merged, we should remove the `javascript` label.

## Author Checklist

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

## Reviewer Checklist

- [x]  End-to-end tests are passing without any errors
- [x]  Code style generally follows existing patterns
- [x]  Code changes do not significantly increase the application bundle size
- [x]  New third-party packages, if any, do not introduce potential security threats
- [ ]  There are no CI changes, or they have been OK’d by the devops team
- [x]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [x]  There are two or more approvals from the core team
- [x]  Squash and merge has been checked
