### PR TITLE
fix: made connecting with watch mode on page load more reliable

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@web3-react/frame-connector": "^6.0.9",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/torus-connector": "^6.2.9",
+    "@web3-react/types": "^6.0.7",
     "@web3-react/walletconnect-connector": "^7.0.2-alpha.0",
     "@web3-react/walletlink-connector": "^6.2.14",
     "d3-array": "^3.2.0",

--- a/src/components/WalletConnection/WalletSelector.tsx
+++ b/src/components/WalletConnection/WalletSelector.tsx
@@ -100,7 +100,7 @@ export enum ErrorType {
 }
 
 export const WalletSelector = () => {
-  const { error, updateWatchModeOnlyAddress } = useWeb3Context();
+  const { error, connectWatchModeOnly } = useWeb3Context();
   const [inputMockWalletAddress, setInputMockWalletAddress] = useState('');
   const [validAddressError, setValidAddressError] = useState<boolean>(false);
   const { breakpoints } = useTheme();
@@ -138,7 +138,7 @@ export const WalletSelector = () => {
   const handleWatchAddress = async (inputMockWalletAddress: string): Promise<void> => {
     if (validAddressError) setValidAddressError(false);
     if (utils.isAddress(inputMockWalletAddress)) {
-      updateWatchModeOnlyAddress(inputMockWalletAddress);
+      connectWatchModeOnly(inputMockWalletAddress);
     } else {
       // Check if address could be valid ENS before trying to resolve
       if (inputMockWalletAddress.slice(-4) !== '.eth') {
@@ -147,7 +147,7 @@ export const WalletSelector = () => {
         // Attempt to resolve ENS name and use resolved address if valid
         const resolvedAddress = await mainnetProvider.resolveName(inputMockWalletAddress);
         if (resolvedAddress && utils.isAddress(resolvedAddress)) {
-          updateWatchModeOnlyAddress(resolvedAddress);
+          connectWatchModeOnly(resolvedAddress);
         } else {
           setValidAddressError(true);
         }

--- a/src/layouts/WalletWidget.tsx
+++ b/src/layouts/WalletWidget.tsx
@@ -93,10 +93,9 @@ export default function WalletWidget({ open, setOpen, headerHeight }: WalletWidg
   };
 
   const handleDisconnect = () => {
-    if (connected || watchModeOnlyAddress) {
+    if (connected) {
       disconnectWallet();
       handleClose();
-      localStorage.removeItem('watchModeOnlyAddress');
     }
   };
 

--- a/src/libs/web3-data-provider/WalletOptions.ts
+++ b/src/libs/web3-data-provider/WalletOptions.ts
@@ -5,6 +5,7 @@ import { UnsupportedChainIdError } from '@web3-react/core';
 import { FrameConnector } from '@web3-react/frame-connector';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { TorusConnector } from '@web3-react/torus-connector';
+import { ConnectorUpdate } from '@web3-react/types';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { getNetworkConfig, getSupportedChainIds } from 'src/utils/marketsAndNetworksConfig';
@@ -18,10 +19,51 @@ export enum WalletType {
   FRAME = 'frame',
   GNOSIS = 'gnosis',
   LEDGER = 'ledger',
+  WATCH_MODE_ONLY = 'watch_mode_only',
 }
 
 const APP_NAME = 'Aave';
 const APP_LOGO_URL = 'https://aave.com/favicon.ico';
+
+const mockProvider = {
+  request: Promise.resolve(null),
+};
+export class WatchModeOnlyConnector extends AbstractConnector {
+  watchAddress = '';
+
+  activate(): Promise<ConnectorUpdate<string | number>> {
+    const address = localStorage.getItem('watchModeOnlyAddress');
+    if (!address || address === 'undefined') {
+      throw new Error('No address found in local storage for watch mode');
+    }
+
+    this.watchAddress = address;
+
+    return Promise.resolve({
+      provider: mockProvider,
+      chainId: ChainId.mainnet,
+      account: this.watchAddress,
+    });
+  }
+  getProvider(): Promise<unknown> {
+    return Promise.resolve(mockProvider);
+  }
+  getChainId(): Promise<string | number> {
+    return Promise.resolve(ChainId.mainnet);
+  }
+  getAccount(): Promise<string | null> {
+    return Promise.resolve(this.watchAddress);
+  }
+  deactivate(): void {
+    const storedWatchAddress = localStorage.getItem('watchModeOnlyAddress');
+    if (storedWatchAddress === this.watchAddress) {
+      // Only update local storage if the address is the same as the one this connector stored.
+      // This will be different if the user switches to another account to watch because
+      // the new connector gets iniatialzed before this one is deactivated.
+      localStorage.removeItem('watchModeOnlyAddress');
+    }
+  }
+}
 
 export const getWallet = (
   wallet: WalletType,
@@ -30,6 +72,8 @@ export const getWallet = (
   const supportedChainIds = getSupportedChainIds();
 
   switch (wallet) {
+    case WalletType.WATCH_MODE_ONLY:
+      return new WatchModeOnlyConnector();
     case WalletType.LEDGER:
       return new LedgerHQFrameConnector({});
     case WalletType.INJECTED:

--- a/src/libs/web3-data-provider/WalletOptions.ts
+++ b/src/libs/web3-data-provider/WalletOptions.ts
@@ -28,6 +28,12 @@ const APP_LOGO_URL = 'https://aave.com/favicon.ico';
 const mockProvider = {
   request: Promise.resolve(null),
 };
+
+/**
+ *  This is a connector to be used in watch mode only.
+ *  On activate, the connector expects a local storage item called `watchModeOnlyAddress` to be set, otherwise an error is thrown.
+ *  When the connector is deactivated (i.e. on disconnect, switching wallets), the local storage item is removed.
+ */
 export class WatchModeOnlyConnector extends AbstractConnector {
   watchAddress = '';
 

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -61,7 +61,6 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   } = useWeb3React<providers.Web3Provider>();
 
   // const [provider, setProvider] = useState<JsonRpcProvider>();
-  const [watchModeOnlyAddress, setWatchModeOnlyAddress] = useState<string>();
   const [connector, setConnector] = useState<AbstractConnector>();
   const [loading, setLoading] = useState(false);
   const [tried, setTried] = useState(false);


### PR DESCRIPTION
## General Changes

- Fixes an issue where the watch mode only address would not re-populate on page load in some cases

## Developer Notes

The main issue with treating the watch mode address different from other providers, is that the state wasn't getting cleared out. So for example, if you were connected MM, and then you enter in a watch address, we'd still keep around the provider info for MM in local storage. I think that's what was causing some issues on page load, there'd be a race condition with loading the provider and loading the watch mode address.

I did a little refactoring around how the watch mode address is handled. I ended up making a `WatchModeOnlyConnector`. The connector stubs out the required methods and takes care of setting and clearing local storage for the `watchModeOnlyAddress`. Going this route lets us hook into the existing connect and disconnect logic because we're just treating it like another wallet/provider type.

There's still some more refactoring/optimization around the provider connect/disconnect that we can do, but I think this is a good first step.

## Author Checklist

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

## Reviewer Checklist

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  New third-party packages, if any, do not introduce potential security threats
- [ ]  There are no CI changes, or they have been OK’d by the devops team
- [ ]  Code changes have been quality checked in the ephemeral URL
- [x]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
