### PR TITLE
fix: disable charts for broken assets

### DIFF
--- a/src/hooks/useReservesHistory.tsx
+++ b/src/hooks/useReservesHistory.tsx
@@ -69,7 +69,7 @@ export type FormattedReserveHistoryItem = {
   variableBorrowRate: number;
 };
 
-const BROKEN_ASSETS = [
+export const BROKEN_ASSETS = [
   // ampl https://governance.aave.com/t/arc-fix-ui-bugs-in-reserve-overview-for-ampl/5885/5?u=sakulstra
   '0xd46ba6d942050d489dbd938a2c909a5d5039a1610xb53c1a33016b2dc2ff3653530bff1848a515c8c5',
 ];

--- a/src/modules/reserve-overview/ReserveConfiguration.tsx
+++ b/src/modules/reserve-overview/ReserveConfiguration.tsx
@@ -22,6 +22,7 @@ import { getEmodeMessage } from 'src/components/transactions/Emode/EmodeNaming';
 import { ComputedReserveData } from 'src/hooks/app-data-provider/useAppDataProvider';
 import { useAssetCaps } from 'src/hooks/useAssetCaps';
 import { useProtocolDataContext } from 'src/hooks/useProtocolDataContext';
+import { BROKEN_ASSETS } from 'src/hooks/useReservesHistory';
 import { ReserveFactorOverview } from 'src/modules/reserve-overview/ReserveFactorOverview';
 
 import LightningBoltGradient from '/public/lightningBoltGradient.svg';
@@ -36,7 +37,10 @@ type ReserveConfigurationProps = {
 
 export const ReserveConfiguration: React.FC<ReserveConfigurationProps> = ({ reserve }) => {
   const { currentNetworkConfig, currentMarketData, currentMarket } = useProtocolDataContext();
-  const renderCharts = !!currentNetworkConfig.ratesHistoryApiUrl;
+  const reserveId =
+    reserve.underlyingAsset + currentMarketData.addresses.LENDING_POOL_ADDRESS_PROVIDER;
+  const renderCharts =
+    !!currentNetworkConfig.ratesHistoryApiUrl && !BROKEN_ASSETS.includes(reserveId);
   const { supplyCap, borrowCap, debtCeiling } = useAssetCaps();
   const showSupplyCapStatus = reserve.supplyCap && reserve.supplyCap !== '0';
   const showBorrowCapStatus = reserve.borrowCap && reserve.borrowCap !== '0';


### PR DESCRIPTION
## General Changes

Disabled charts for AMPL which does not have accurate subgraph data due to the rebasing events not being indexed

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [x]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
