### PR TITLE
fix: update pinata action

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: pinata
         id: pinata
-        uses: aave/pinata-action@b03be403ea86f79077ea9cc0b835c3295faa12dd
+        uses: aave/pinata-action@a3409e26f4cb859a2d9984109317caac53db5f68
         with:
           PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
           PINATA_SECRET_KEY: ${{ secrets.PINATA_SECRET_KEY }}

--- a/.github/workflows/test-deploy-fork.yml
+++ b/.github/workflows/test-deploy-fork.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: pinata
         id: pinata
-        uses: aave/pinata-action@b03be403ea86f79077ea9cc0b835c3295faa12dd
+        uses: aave/pinata-action@a3409e26f4cb859a2d9984109317caac53db5f68
         with:
           PINATA_API_KEY: '${{ secrets.PINATA_API_KEY }}'
           PINATA_SECRET_KEY: '${{ secrets.PINATA_SECRET_KEY }}'

--- a/.github/workflows/update-prod-staging.yml
+++ b/.github/workflows/update-prod-staging.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: pinata
         id: pinata
-        uses: aave/pinata-action@b03be403ea86f79077ea9cc0b835c3295faa12dd
+        uses: aave/pinata-action@a3409e26f4cb859a2d9984109317caac53db5f68
         with:
           PINATA_API_KEY: '${{ secrets.PINATA_API_KEY }}'
           PINATA_SECRET_KEY: '${{ secrets.PINATA_SECRET_KEY }}'


### PR DESCRIPTION
## General Changes

- Fixes pinning to Pinata IPFS in CI  

## Developer Notes

See this PR for changes to `pinata-action`:
https://github.com/aave/pinata-action/pull/6

In short: Pinata api had a breaking change that caused failures in pinata Github action 

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [x]  Code style generally follows existing patterns
- [x]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
