### PR TITLE
Skip BAT and REN on V2 ETH Market

### DIFF
--- a/cypress/e2e/0-v2-markets/0-main-v2-market/0-assets/bat.aave-v2.cy.ts
+++ b/cypress/e2e/0-v2-markets/0-main-v2-market/0-assets/bat.aave-v2.cy.ts
@@ -87,8 +87,8 @@ const testData = {
     ],
   },
 };
-
-describe('BAT INTEGRATION SPEC, AAVE V2 MARKET', () => {
+//skipped because it was disabled on ETH V2 Market
+describe.skip('BAT INTEGRATION SPEC, AAVE V2 MARKET', () => {
   const skipTestState = skipState(false);
   configEnvWithTenderlyMainnetFork({});
   supply(testData.depositETH, skipTestState, true);

--- a/cypress/e2e/0-v2-markets/0-main-v2-market/0-assets/ren.aave-v2.cy.ts
+++ b/cypress/e2e/0-v2-markets/0-main-v2-market/0-assets/ren.aave-v2.cy.ts
@@ -97,8 +97,8 @@ const testData = {
     ],
   },
 };
-
-describe('REN INTEGRATION SPEC, AAVE V2 MARKET', () => {
+//skipped because it was disabled on ETH V2 Market
+describe.skip('REN INTEGRATION SPEC, AAVE V2 MARKET', () => {
   const skipTestState = skipState(false);
   configEnvWithTenderlyMainnetFork({});
   supply(testData.depositETH, skipTestState, true);


### PR DESCRIPTION
Skipping bat.aave-v2.cy.ts test since it was disabled.

