### PR TITLE
fix: hide historical graphs for FEI USD on eth mainnet v2

### DIFF
--- a/src/hooks/useReservesHistory.tsx
+++ b/src/hooks/useReservesHistory.tsx
@@ -69,9 +69,17 @@ export type FormattedReserveHistoryItem = {
   variableBorrowRate: number;
 };
 
+/**
+ * Broken Assets:
+ * A list of assets that currently are broken in some way, i.e. has bad data from either the subgraph or backend server
+ * Each item represents the ID of the asset, not the underlying address it's deployed to, appended with LendingPoolAddressProvider
+ * contract address it is held in. So each item in the array is essentially [underlyingAssetId + LendingPoolAddressProvider address].
+ */
 export const BROKEN_ASSETS = [
   // ampl https://governance.aave.com/t/arc-fix-ui-bugs-in-reserve-overview-for-ampl/5885/5?u=sakulstra
   '0xd46ba6d942050d489dbd938a2c909a5d5039a1610xb53c1a33016b2dc2ff3653530bff1848a515c8c5',
+  // fei usd (v2 eth mainnet)
+  '0x956f47f50a910163d8bf957cf5846d573e7f87ca0xb53c1a33016b2dc2ff3653530bff1848a515c8c5',
 ];
 
 // TODO: api need to be altered to expect chainId underlying asset and poolConfig


### PR DESCRIPTION
## General Changes

- Hides graphs for the FEI USD frozen asset due to bad data coming from either the subgraph or backend

## Developer Notes

This is a temporary solution to just _not show bad data_ for this asset.  The longer term fix is investigating the data issues and writing code that will prevent it from happening further.  We can then decide if/when to turn the graphs back on for this reserve after and if that data has been fixed.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
