### PR TITLE
chore: add additional public rpcs to all networks

### DIFF
--- a/cypress/e2e/0-v2-markets/2-polygon-v2-market/0-assets/ghst.polygon-v2.cy.ts
+++ b/cypress/e2e/0-v2-markets/2-polygon-v2-market/0-assets/ghst.polygon-v2.cy.ts
@@ -57,7 +57,8 @@ const testData = {
   },
 };
 
-describe('GHST INTEGRATION SPEC, POLYGON V2 MARKET', () => {
+//temporary borrow unavailable
+describe.skip('GHST INTEGRATION SPEC, POLYGON V2 MARKET', () => {
   const skipTestState = skipState(false);
   configEnvWithTenderlyPolygonFork({});
 

--- a/cypress/e2e/1-v3-markets/4-optimism-v3-market/0-assets/usdt.optimism-v3.cy.ts
+++ b/cypress/e2e/1-v3-markets/4-optimism-v3-market/0-assets/usdt.optimism-v3.cy.ts
@@ -101,8 +101,7 @@ const testData = {
   },
 };
 
-//Debt Ceiling max
-describe.skip('USDT INTEGRATION SPEC, OPTIMISM V3 MARKET', () => {
+describe('USDT INTEGRATION SPEC, OPTIMISM V3 MARKET', () => {
   const skipTestState = skipState(false);
   configEnvWithTenderlyOptimismFork({ v3: true });
 

--- a/cypress/e2e/1-v3-markets/4-optimism-v3-market/e-mode.optimism-v3.cy.ts
+++ b/cypress/e2e/1-v3-markets/4-optimism-v3-market/e-mode.optimism-v3.cy.ts
@@ -40,7 +40,7 @@ const testData = {
     },
     eModeAssets: [
       assets.optimismMarket.DAI,
-      // assets.optimismMarket.USDT,
+      assets.optimismMarket.USDT,
       assets.optimismMarket.USDC,
       assets.optimismMarket.sUSD,
     ],

--- a/src/ui-config/networksConfig.ts
+++ b/src/ui-config/networksConfig.ts
@@ -54,8 +54,12 @@ export type BaseNetworkConfig = Omit<NetworkConfig, 'explorerLinkBuilder'>;
 export const networkConfigs: Record<string, BaseNetworkConfig> = {
   [ChainId.goerli]: {
     name: 'Ethereum Görli',
-    publicJsonRPCUrl: ['https://eth-goerli.alchemyapi.io/v2/demo', 'https://goerli.prylabs.net'],
-    publicJsonRPCWSUrl: 'wss://eth-goerli.alchemyapi.io/v2/demo',
+    publicJsonRPCUrl: [
+      'https://eth-goerli.public.blastapi.io',
+      'https://rpc.ankr.com/eth_goerli',
+      'https://goerli.prylabs.net',
+    ],
+    publicJsonRPCWSUrl: 'wss://eth-goerli.public.blastapi.io',
     // protocolDataUrl: '',
     baseUniswapAdapter: '0x0',
     baseAssetSymbol: 'ETH',
@@ -70,7 +74,12 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   [ChainId.mainnet]: {
     name: 'Ethereum',
     privateJsonRPCUrl: 'https://eth-mainnet.gateway.pokt.network/v1/lb/62b3314e123e6f00397f19ca',
-    publicJsonRPCUrl: ['https://cloudflare-eth.com/v1/mainnet'],
+    publicJsonRPCUrl: [
+      'https://rpc.ankr.com/eth',
+      'https://rpc.flashbots.net',
+      'https://eth-mainnet.public.blastapi.io',
+      'https://cloudflare-eth.com/v1/mainnet',
+    ],
     publicJsonRPCWSUrl: 'wss://eth-mainnet.alchemyapi.io/v2/demo',
     // cachingServerUrl: 'https://cache-api-1.aave.com/graphql',
     // cachingWSServerUrl: 'wss://cache-api-1.aave.com/graphql',
@@ -87,8 +96,12 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   [ChainId.polygon]: {
     name: 'Polygon POS',
     privateJsonRPCUrl: 'https://poly-mainnet.gateway.pokt.network/v1/lb/62b3314e123e6f00397f19ca',
-    publicJsonRPCUrl: [], // 'https://polygon-rpc.com'
-    // publicJsonRPCWSUrl: 'wss://polygon-rpc.com',
+    publicJsonRPCUrl: [
+      'https://polygon-rpc.com',
+      'https://polygon-mainnet.public.blastapi.io',
+      'https://rpc-mainnet.matic.quiknode.pro',
+    ],
+    publicJsonRPCWSUrl: 'wss://polygon-rpc.com',
     // cachingServerUrl: 'https://cache-api-137.aave.com/graphql',
     // cachingWSServerUrl: 'wss://cache-api-137.aave.com/graphql',
     // protocolDataUrl: 'https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic',
@@ -106,7 +119,12 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   },
   [ChainId.mumbai]: {
     name: 'Mumbai',
-    publicJsonRPCUrl: ['https://polygon-mumbai.g.alchemy.com/v2/demo'],
+    publicJsonRPCUrl: [
+      'https://rpc.ankr.com/polygon_mumbai',
+      'https://rpc-mumbai.maticvigil.com',
+      'https://polygon-testnet.public.blastapi.io',
+      'https://polygon-mumbai.g.alchemy.com/v2/demo',
+    ],
     publicJsonRPCWSUrl: 'wss://polygon-mumbai.g.alchemy.com/v2/demo',
     // protocolDataUrl: 'https://api.thegraph.com/subgraphs/name/aave/aave-v2-polygon-mumbai',
     baseAssetSymbol: 'MATIC',
@@ -119,7 +137,11 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   },
   [ChainId.fuji]: {
     name: 'Avalanche Fuji',
-    publicJsonRPCUrl: ['https://api.avax-test.network/ext/bc/C/rpc'],
+    publicJsonRPCUrl: [
+      'https://api.avax-test.network/ext/bc/C/rpc',
+      'https://rpc.ankr.com/avalanche_fuji',
+      'https://ava-testnet.public.blastapi.io/ext/bc/C/rpc',
+    ],
     publicJsonRPCWSUrl: 'wss://api.avax-test.network/ext/bc/C/rpc',
     // protocolDataUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2-fuji',
     baseUniswapAdapter: '0x0',
@@ -141,7 +163,11 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     name: 'Avalanche',
     privateJsonRPCUrl:
       'https://avax-mainnet.gateway.pokt.network/v1/lb/62b3314e123e6f00397f19ca/ext/bc/C/rpc',
-    publicJsonRPCUrl: ['https://api.avax.network/ext/bc/C/rpc'],
+    publicJsonRPCUrl: [
+      'https://api.avax.network/ext/bc/C/rpc',
+      'https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc',
+      'https://rpc.ankr.com/avalanche',
+    ],
     publicJsonRPCWSUrl: 'wss://api.avax.network/ext/bc/C/rpc',
     // protocolDataUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2-avalanche',
     // cachingServerUrl: 'https://cache-api-43114.aave.com/graphql',
@@ -163,7 +189,10 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   },
   [ChainId.arbitrum_goerli]: {
     name: 'Arbitrum Görli',
-    publicJsonRPCUrl: ['https://goerli-rollup.arbitrum.io/rpc'],
+    publicJsonRPCUrl: [
+      'https://goerli-rollup.arbitrum.io/rpc',
+      'https://arb-goerli.g.alchemy.com/v2/demo',
+    ],
     publicJsonRPCWSUrl: 'wss://goerli-rollup.arbitrum.io/rpc',
     baseUniswapAdapter: '0x0',
     baseAssetSymbol: 'ETH',
@@ -182,7 +211,11 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   },
   [ChainId.arbitrum_one]: {
     name: 'Arbitrum',
-    publicJsonRPCUrl: ['https://arb1.arbitrum.io/rpc'],
+    publicJsonRPCUrl: [
+      'https://arb1.arbitrum.io/rpc',
+      'https://rpc.ankr.com/arbitrum',
+      'https://1rpc.io/arb',
+    ],
     publicJsonRPCWSUrl: 'wss://arb1.arbitrum.io/rpc',
     // protocolDataUrl: '',
     baseUniswapAdapter: '0x0',
@@ -203,7 +236,11 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   [ChainId.harmony]: {
     name: 'Harmony',
     privateJsonRPCUrl: 'https://harmony-0.gateway.pokt.network/v1/lb/62b3314e123e6f00397f19ca',
-    publicJsonRPCUrl: ['https://api.s0.t.hmny.io', 'https://api.harmony.one'],
+    publicJsonRPCUrl: [
+      'https://api.s0.t.hmny.io',
+      'https://api.harmony.one',
+      'https://rpc.ankr.com/harmony',
+    ],
     publicJsonRPCWSUrl: 'wss://ws.s0.t.hmny.io',
     // protocolDataUrl: '',
     baseUniswapAdapter: '0x0',
@@ -225,7 +262,11 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     name: 'Optimism',
     privateJsonRPCUrl:
       'https://optimism-mainnet.gateway.pokt.network/v1/lb/62b3314e123e6f00397f19ca',
-    publicJsonRPCUrl: ['https://optimism-mainnet.public.blastapi.io'],
+    publicJsonRPCUrl: [
+      'https://optimism-mainnet.public.blastapi.io',
+      'https://1rpc.io/op',
+      'https://rpc.ankr.com/optimism',
+    ],
     publicJsonRPCWSUrl: 'wss://optimism-mainnet.public.blastapi.io',
     // protocolDataUrl: '',
     baseUniswapAdapter: '0x0',
@@ -245,7 +286,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   },
   [ChainId.optimism_goerli]: {
     name: 'Optimism Görli',
-    publicJsonRPCUrl: ['https://goerli.optimism.io'],
+    publicJsonRPCUrl: ['https://goerli.optimism.io', 'https://opt-goerli.g.alchemy.com/v2/demo'],
     publicJsonRPCWSUrl: 'wss://goerli.optimism.io',
     // protocolDataUrl: '',
     baseUniswapAdapter: '0x0',
@@ -266,7 +307,11 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   [ChainId.fantom]: {
     name: 'Fantom',
     privateJsonRPCUrl: 'https://fantom-mainnet.gateway.pokt.network/v1/lb/62b3314e123e6f00397f19ca',
-    publicJsonRPCUrl: [], // 'https://rpc.ftm.tools' compromised
+    publicJsonRPCUrl: [
+      'https://rpc.fantom.network',
+      'https://rpc.ankr.com/fantom',
+      'https://fantom-mainnet.public.blastapi.io',
+    ],
     // publicJsonRPCWSUrl: 'wss://wsapi.fantom.network',
     // protocolDataUrl: '',
     baseUniswapAdapter: '0x0',
@@ -286,7 +331,11 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
   },
   [ChainId.fantom_testnet]: {
     name: 'Fantom Testnet',
-    publicJsonRPCUrl: ['https://rpc.testnet.fantom.network'],
+    publicJsonRPCUrl: [
+      'https://rpc.testnet.fantom.network',
+      'https://fantom-testnet.public.blastapi.io',
+      'https://rpc.ankr.com/fantom_testnet',
+    ],
     publicJsonRPCWSUrl: '',
     // protocolDataUrl: '',
     baseUniswapAdapter: '0x0',


### PR DESCRIPTION
## General Changes

#1073 added a custom rotation provider which supports any number of fallback rpcs as opposed to ethers.FallbackProvider which was limited to 1

- Adds additional public rpc fallbacks from chainlist.org to all networks
- Specifically fixes issue with ETH Goerli RPCs

## Developer Notes

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [x]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
