### PR TITLE
fix: use next router for pushing route

### DIFF
--- a/src/store/utils/queryParams.ts
+++ b/src/store/utils/queryParams.ts
@@ -1,9 +1,8 @@
+import Router from 'next/router';
+
 export const setQueryParameter = (key: string, value: string) => {
-  if (typeof window !== 'undefined' && 'URLSearchParams' in window) {
-    const searchParams = new URLSearchParams(window.location.search);
-    searchParams.set(key, value);
-    const newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
-    history.pushState(null, '', newRelativePathQuery);
+  if (typeof window !== 'undefined') {
+    Router.push({ query: { [key]: value } }, undefined, { shallow: true });
   }
 };
 


### PR DESCRIPTION
- closes https://github.com/aave/interface/issues/1300

In zustand native browser apis are used to set and read query parameters.
This introduced some issues as some of next router logic is built around not only the browser history but also internal state which get out of sync. Apparently you can just use `Router` singleton exported by `next/router` for exactly that purpose.