### PR TITLE
fix: maintain query parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@visx/responsive": "^2.10.0",
     "@visx/scale": "^2.2.2",
     "@visx/shape": "^2.12.2",
-    "@visx/tooltip": "^2.15.0",
+    "@visx/tooltip": "^2.16.0",
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/core": "^6.1.9",
     "@web3-react/frame-connector": "^6.0.9",

--- a/src/hooks/useAssetCaps.tsx
+++ b/src/hooks/useAssetCaps.tsx
@@ -33,6 +33,80 @@ export type AssetCapUsageData = {
   debtCeiling: AssetCapHookData;
 };
 
+const getAssetCapData = (asset: ComputedReserveData): AssetCapUsageData => {
+  /*
+  Supply Cap Data
+    % of totalLiquidity / supplyCap
+    Set as zero if either is zero
+  */
+  let supplyCapUsage: number = asset
+    ? valueToBigNumber(asset.totalLiquidity).dividedBy(asset.supplyCap).toNumber() * 100
+    : 0;
+  supplyCapUsage = supplyCapUsage === Infinity ? 0 : supplyCapUsage;
+  const supplyCapReached = supplyCapUsage >= 99.99;
+
+  /*
+  Borrow Cap Data
+    % of totalDebt / borrowCap
+    Set as zero if either is zero
+  */
+  let borrowCapUsage: number = asset
+    ? valueToBigNumber(asset.totalDebt).dividedBy(asset.borrowCap).toNumber() * 100
+    : 0;
+  borrowCapUsage = borrowCapUsage === Infinity ? 0 : borrowCapUsage;
+  const borrowCapReached = borrowCapUsage >= 99.99;
+
+  /*
+    Debt Ceiling Data
+    % of isolationModeTotalDebt / debtCeiling
+    Set as zero if either is zero
+  */
+  let debtCeilingUsage: number = asset
+    ? valueToBigNumber(asset.isolationModeTotalDebt).dividedBy(asset.debtCeiling).toNumber() * 100
+    : 0;
+  debtCeilingUsage = debtCeilingUsage === Infinity ? 0 : debtCeilingUsage;
+  const debtCeilingReached = debtCeilingUsage >= 99.99;
+
+  /*
+    Aggregated Data
+  */
+  const assetCapUsageData: AssetCapUsageData = {
+    reserve: asset,
+    supplyCap: {
+      percentUsed: supplyCapUsage,
+      isMaxed: supplyCapReached,
+      // percentUsed: 99.9,
+      // isMaxed: true,
+      determineWarningDisplay: ({ supplyCap, icon }) =>
+        supplyCap ? <SupplyCapWarning supplyCap={supplyCap} icon={icon} /> : null,
+      displayMaxedTooltip: ({ supplyCap }) =>
+        supplyCap ? <SupplyCapMaxedTooltip supplyCap={supplyCap} /> : null,
+    },
+    borrowCap: {
+      percentUsed: borrowCapUsage,
+      isMaxed: borrowCapReached,
+      // percentUsed: 98.5,
+      // isMaxed: false,
+      determineWarningDisplay: ({ borrowCap, icon }) =>
+        borrowCap ? <BorrowCapWarning borrowCap={borrowCap} icon={icon} /> : null,
+      displayMaxedTooltip: ({ borrowCap }) =>
+        borrowCap ? <BorrowCapMaxedTooltip borrowCap={borrowCap} /> : null,
+    },
+    debtCeiling: {
+      percentUsed: debtCeilingUsage,
+      isMaxed: debtCeilingReached,
+      // percentUsed: 99.994,
+      // isMaxed: true,
+      determineWarningDisplay: ({ debtCeiling, icon }) =>
+        debtCeiling ? <DebtCeilingWarning debtCeiling={debtCeiling} icon={icon} /> : null,
+      displayMaxedTooltip: ({ debtCeiling }) =>
+        debtCeiling ? <DebtCeilingMaxedTooltip debtCeiling={debtCeiling} /> : null,
+    },
+  };
+
+  return assetCapUsageData;
+};
+
 /*
   Asset Caps Context
 */
@@ -48,80 +122,6 @@ export const AssetCapsProvider = ({
   children: ReactNode;
   asset: ComputedReserveData;
 }): JSX.Element | null => {
-  const getAssetCapData = (asset: ComputedReserveData): AssetCapUsageData => {
-    /*
-    Supply Cap Data
-      % of totalLiquidity / supplyCap
-      Set as zero if either is zero
-    */
-    let supplyCapUsage: number = asset
-      ? valueToBigNumber(asset.totalLiquidity).dividedBy(asset.supplyCap).toNumber() * 100
-      : 0;
-    supplyCapUsage = supplyCapUsage === Infinity ? 0 : supplyCapUsage;
-    const supplyCapReached = supplyCapUsage >= 99.99;
-
-    /*
-    Borrow Cap Data
-      % of totalDebt / borrowCap
-      Set as zero if either is zero
-    */
-    let borrowCapUsage: number = asset
-      ? valueToBigNumber(asset.totalDebt).dividedBy(asset.borrowCap).toNumber() * 100
-      : 0;
-    borrowCapUsage = borrowCapUsage === Infinity ? 0 : borrowCapUsage;
-    const borrowCapReached = borrowCapUsage >= 99.99;
-
-    /*
-      Debt Ceiling Data
-      % of isolationModeTotalDebt / debtCeiling
-      Set as zero if either is zero
-    */
-    let debtCeilingUsage: number = asset
-      ? valueToBigNumber(asset.isolationModeTotalDebt).dividedBy(asset.debtCeiling).toNumber() * 100
-      : 0;
-    debtCeilingUsage = debtCeilingUsage === Infinity ? 0 : debtCeilingUsage;
-    const debtCeilingReached = debtCeilingUsage >= 99.99;
-
-    /*
-      Aggregated Data
-    */
-    const assetCapUsageData: AssetCapUsageData = {
-      reserve: asset,
-      supplyCap: {
-        percentUsed: supplyCapUsage,
-        isMaxed: supplyCapReached,
-        // percentUsed: 99.9,
-        // isMaxed: true,
-        determineWarningDisplay: ({ supplyCap, icon }) =>
-          supplyCap ? <SupplyCapWarning supplyCap={supplyCap} icon={icon} /> : null,
-        displayMaxedTooltip: ({ supplyCap }) =>
-          supplyCap ? <SupplyCapMaxedTooltip supplyCap={supplyCap} /> : null,
-      },
-      borrowCap: {
-        percentUsed: borrowCapUsage,
-        isMaxed: borrowCapReached,
-        // percentUsed: 98.5,
-        // isMaxed: false,
-        determineWarningDisplay: ({ borrowCap, icon }) =>
-          borrowCap ? <BorrowCapWarning borrowCap={borrowCap} icon={icon} /> : null,
-        displayMaxedTooltip: ({ borrowCap }) =>
-          borrowCap ? <BorrowCapMaxedTooltip borrowCap={borrowCap} /> : null,
-      },
-      debtCeiling: {
-        percentUsed: debtCeilingUsage,
-        isMaxed: debtCeilingReached,
-        // percentUsed: 99.994,
-        // isMaxed: true,
-        determineWarningDisplay: ({ debtCeiling, icon }) =>
-          debtCeiling ? <DebtCeilingWarning debtCeiling={debtCeiling} icon={icon} /> : null,
-        displayMaxedTooltip: ({ debtCeiling }) =>
-          debtCeiling ? <DebtCeilingMaxedTooltip debtCeiling={debtCeiling} /> : null,
-      },
-    };
-
-    return assetCapUsageData;
-  };
-
   // Return if no reserve is provided
   if (!asset) {
     console.warn('<AssetCapsProvider /> was not given a valid reserve asset to parse');

--- a/src/store/protocolDataSlice.ts
+++ b/src/store/protocolDataSlice.ts
@@ -18,7 +18,7 @@ export interface ProtocolDataSlice {
   currentChainId: number;
   currentNetworkConfig: NetworkConfig;
   jsonRpcProvider: () => providers.Provider;
-  setCurrentMarket: (market: CustomMarket) => void;
+  setCurrentMarket: (market: CustomMarket, omitQueryParameterUpdate?: boolean) => void;
 }
 
 export const createProtocolDataSlice: StateCreator<
@@ -35,11 +35,13 @@ export const createProtocolDataSlice: StateCreator<
     currentChainId: initialMarketData.chainId,
     currentNetworkConfig: getNetworkConfig(initialMarketData.chainId),
     jsonRpcProvider: () => getProvider(get().currentChainId),
-    setCurrentMarket: (market) => {
+    setCurrentMarket: (market, omitQueryParameterUpdate) => {
       if (!availableMarkets.includes(market as CustomMarket)) return;
       const nextMarketData = marketsData[market];
-      setQueryParameter('marketName', market);
       localStorage.setItem('selectedMarket', market);
+      if (!omitQueryParameterUpdate) {
+        setQueryParameter('marketName', market);
+      }
       set({
         currentMarket: market,
         currentMarketData: nextMarketData,

--- a/src/store/root.ts
+++ b/src/store/root.ts
@@ -41,9 +41,13 @@ if (typeof document !== 'undefined') {
       const selectedMarket =
         getQueryParameter('marketName') || localStorage.getItem('selectedMarket');
 
-      const currentMarket = useRootStore.getState().currentMarket;
-      const setCurrentMarket = useRootStore.getState().setCurrentMarket;
-      if (selectedMarket !== currentMarket) setCurrentMarket(selectedMarket as CustomMarket);
+      if (selectedMarket) {
+        const currentMarket = useRootStore.getState().currentMarket;
+        const setCurrentMarket = useRootStore.getState().setCurrentMarket;
+        if (selectedMarket !== currentMarket) {
+          setCurrentMarket(selectedMarket as CustomMarket, true);
+        }
+      }
     }
   };
 }

--- a/src/store/root.ts
+++ b/src/store/root.ts
@@ -41,8 +41,9 @@ if (typeof document !== 'undefined') {
       const selectedMarket =
         getQueryParameter('marketName') || localStorage.getItem('selectedMarket');
 
+      const currentMarket = useRootStore.getState().currentMarket;
       const setCurrentMarket = useRootStore.getState().setCurrentMarket;
-      if (selectedMarket) setCurrentMarket(selectedMarket as CustomMarket);
+      if (selectedMarket !== currentMarket) setCurrentMarket(selectedMarket as CustomMarket);
     }
   };
 }

--- a/src/store/utils/queryParams.ts
+++ b/src/store/utils/queryParams.ts
@@ -2,7 +2,6 @@ import Router from 'next/router';
 
 export const setQueryParameter = (key: string, value: string) => {
   if (typeof window !== 'undefined') {
-    console.log('here');
     Router.push({ query: { ...getAllQueryParameters(), [key]: value } }, undefined, {
       shallow: true,
     });

--- a/src/store/utils/queryParams.ts
+++ b/src/store/utils/queryParams.ts
@@ -2,7 +2,9 @@ import Router from 'next/router';
 
 export const setQueryParameter = (key: string, value: string) => {
   if (typeof window !== 'undefined') {
-    Router.push({ query: { [key]: value } }, undefined, { shallow: true });
+    Router.push({ query: { ...getAllQueryParameters(), [key]: value } }, undefined, {
+      shallow: true,
+    });
   }
 };
 
@@ -12,5 +14,12 @@ export const getQueryParameter = (key: string) => {
       get: (searchParams, prop) => searchParams.get(prop as string),
     });
     return (proxy as unknown as { [key: string]: string })[key];
+  }
+};
+
+export const getAllQueryParameters = () => {
+  if (typeof window !== 'undefined' && 'URLSearchParams' in window) {
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    return Object.fromEntries(urlSearchParams.entries());
   }
 };

--- a/src/store/utils/queryParams.ts
+++ b/src/store/utils/queryParams.ts
@@ -2,6 +2,7 @@ import Router from 'next/router';
 
 export const setQueryParameter = (key: string, value: string) => {
   if (typeof window !== 'undefined') {
+    console.log('here');
     Router.push({ query: { ...getAllQueryParameters(), [key]: value } }, undefined, {
       shallow: true,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3614,10 +3614,10 @@
     classnames "^2.3.1"
     prop-types "^15.6.0"
 
-"@visx/bounds@2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-2.10.0.tgz#cd0bdd7db924a5a2151174edce09f867aaeaf3af"
-  integrity sha512-rY7WFTIjQaXA8tFL45O2qbtSRkyF4yF75HiWz06F7BVmJ9UjF2qlomB3Y1z6gk6ZiFhwQ4zxABjOVjAQPLn7nQ==
+"@visx/bounds@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-2.16.0.tgz#3a5d6b978cc0e5ed1211fd19c03c3555e7a1a668"
+  integrity sha512-KJoSSJt5SOLzprEbmsmdxR46PLudau0kWOgxavrah9D/49RsHwGdUdxHLKdXz4OdCruEfgGo4yxiuYLYmUWl4A==
   dependencies:
     "@types/react" "*"
     "@types/react-dom" "*"
@@ -3747,13 +3747,13 @@
     prop-types "^15.7.2"
     reduce-css-calc "^1.3.0"
 
-"@visx/tooltip@^2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@visx/tooltip/-/tooltip-2.15.0.tgz#c192e88a457e51fc92758b6e4c6087d6385d9035"
-  integrity sha512-rYRgpm7cCSJl0YFgj1MjZ2tqXdsakNqAxHlsHzY/24NWmiskyTb+3/xZUFwfZFnUsF6ml1ICUZ3xNJ4MrZhTuw==
+"@visx/tooltip@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@visx/tooltip/-/tooltip-2.16.0.tgz#b88caf9cd91c50c98b6ed60e59323060b77a28a2"
+  integrity sha512-kCjVtNGYpYm6AuMc1fT9cIwqpBivfQ8A5Qd7fQMC2xm4YVmehFdbyRr0nVft8zNXyUW3lDxbcq5bPIMRYhuhlA==
   dependencies:
     "@types/react" "*"
-    "@visx/bounds" "2.10.0"
+    "@visx/bounds" "2.16.0"
     classnames "^2.3.1"
     prop-types "^15.5.10"
     react-use-measure "^2.0.4"


### PR DESCRIPTION
- bump visx/tooltip: resolves strict mode error
- maintain current query parameters when adding a new query parameter: issue get's visible when e.g. directly going to https://app.aave.com/reserve-overview/?underlyingAsset=0x7f5c764cbc14f9669b88837ca1490cca17c31607&marketName=proto_optimism_v3
- optimize boot: only set the market from localStorage when it's different to the server rendered one
- "optimize" getAssetCapData: When you declare the function inside, every time the component is rendered the function will be defined again. That said, with this fix applied, the initial page load for this page is still crappy as it returns `null` and does not even render a layout. I don't understand why a context is used here, but also didn't have time to further clean this up.