### PR TITLE
fix: show debt values on mobile if there is any outstanding debt balances

### DIFF
--- a/src/modules/markets/MarketAssetsListMobileItem.tsx
+++ b/src/modules/markets/MarketAssetsListMobileItem.tsx
@@ -89,7 +89,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ComputedReserveData) 
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
           <IncentivesCard
             align="flex-end"
-            value={reserve.borrowingEnabled ? reserve.variableBorrowAPY : '-1'}
+            value={Number(reserve.totalVariableDebtUSD) > 0 ? reserve.variableBorrowAPY : '-1'}
             incentives={reserve.vIncentivesData || []}
             symbol={reserve.symbol}
             variant="secondary14"
@@ -114,12 +114,12 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ComputedReserveData) 
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
           <IncentivesCard
             align="flex-end"
-            value={reserve.stableBorrowRateEnabled ? reserve.stableBorrowAPY : -1}
+            value={Number(reserve.totalStableDebtUSD) > 0 ? reserve.stableBorrowAPY : '-1'}
             incentives={reserve.sIncentivesData || []}
             symbol={reserve.symbol}
             variant="secondary14"
           />
-          {!reserve.borrowingEnabled && Number(reserve.totalVariableDebt) > 0 && (
+          {!reserve.borrowingEnabled && Number(reserve.totalStableDebt) > 0 && (
             <ReserveSubheader value={'Disabled'} />
           )}
         </Box>


### PR DESCRIPTION
## General Changes

- Shows the variable and stable borrow amounts in the markets list if borrowing is disabled, but there is still outstanding debt.
- Fixes another issue on mobile where the wrong value was being used in the stable debt column

## Developer Notes

This was fixed on desktop in #1103 but the same fix did not get applied to mobile

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
