### PR TITLE
chore: replace rotationDelay with check on max retries

### DIFF
--- a/src/utils/rotationProvider.ts
+++ b/src/utils/rotationProvider.ts
@@ -1,11 +1,11 @@
 import { BaseProvider, Network, StaticJsonRpcProvider } from '@ethersproject/providers';
 import { logger } from 'ethers';
 
-const DEFAULT_ROTATION_DELAY = 5000;
 const DEFAULT_FALL_FORWARD_DELAY = 60000;
+const MAX_RETRIES = 2;
 
 interface RotationProviderConfig {
-  rotationDelay?: number;
+  maxRetries?: number;
   fallFowardDelay?: number;
 }
 
@@ -66,8 +66,9 @@ export class RotationProvider extends BaseProvider {
   readonly providers: StaticJsonRpcProvider[];
   private currentProviderIndex = 0;
   private firstRotationTimestamp = 0;
-  // after completing a full rotation of the RotationProvider, delay to avoid spamming rpcs with requests
-  private rotationDelay: number;
+  // number of full loops through provider array before throwing an error
+  private maxRetries = 0;
+  private retries = 0;
   // if we rotate away from first rpc, return back after this delay
   private fallForwardDelay: number;
 
@@ -75,7 +76,7 @@ export class RotationProvider extends BaseProvider {
     super(chainId);
     this.providers = urls.map((url) => new StaticJsonRpcProvider(url, chainId));
 
-    this.rotationDelay = config?.rotationDelay || DEFAULT_ROTATION_DELAY;
+    this.maxRetries = config?.maxRetries || MAX_RETRIES;
     this.fallForwardDelay = config?.fallFowardDelay || DEFAULT_FALL_FORWARD_DELAY;
   }
 
@@ -104,7 +105,11 @@ export class RotationProvider extends BaseProvider {
       this.firstRotationTimestamp = new Date().getTime();
       this.fallForwardRotation();
     } else if (this.currentProviderIndex === this.providers.length - 1) {
-      await sleep(this.rotationDelay);
+      this.retries += 1;
+      if (this.retries >= this.maxRetries) {
+        this.retries = 0;
+        throw new Error('RotationProvider exceeded max number of retries');
+      }
       this.currentProviderIndex = 0;
     } else {
       this.currentProviderIndex += 1;

--- a/src/utils/rotationProvider.ts
+++ b/src/utils/rotationProvider.ts
@@ -2,7 +2,7 @@ import { BaseProvider, Network, StaticJsonRpcProvider } from '@ethersproject/pro
 import { logger } from 'ethers';
 
 const DEFAULT_FALL_FORWARD_DELAY = 60000;
-const MAX_RETRIES = 2;
+const MAX_RETRIES = 1;
 
 interface RotationProviderConfig {
   maxRetries?: number;
@@ -106,7 +106,7 @@ export class RotationProvider extends BaseProvider {
       this.fallForwardRotation();
     } else if (this.currentProviderIndex === this.providers.length - 1) {
       this.retries += 1;
-      if (this.retries >= this.maxRetries) {
+      if (this.retries > this.maxRetries) {
         this.retries = 0;
         throw new Error('RotationProvider exceeded max number of retries');
       }


### PR DESCRIPTION
## General Changes

RotationProvider currently operates with no limitation on error callbacks, so if a transaction has failing gas estimation the provider will continue to retry and throw errors indefinitely. This adds a limit to the maximum number of loops through the array of rpc providers before throwing an error.


## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
