### PR TITLE
fix: show collateral as disabled if it is disabled on the reserve

### DIFF
--- a/src/components/transactions/Supply/SupplyModalContent.tsx
+++ b/src/components/transactions/Supply/SupplyModalContent.tsx
@@ -157,13 +157,13 @@ export const SupplyModalContent = ({
   };
 
   // collateralization state
-  let willBeUsedAsCollateral: CollateralType = poolReserve.usageAsCollateralEnabled
-    ? CollateralType.ENABLED
-    : CollateralType.DISABLED;
+  let willBeUsedAsCollateral: CollateralType = CollateralType.ENABLED;
   const userHasSuppliedReserve = userReserve && userReserve.scaledATokenBalance !== '0';
   const userHasCollateral = user.totalCollateralUSD !== '0';
 
-  if (poolReserve.isIsolated) {
+  if (!poolReserve.usageAsCollateralEnabled) {
+    willBeUsedAsCollateral = CollateralType.DISABLED;
+  } else if (poolReserve.isIsolated) {
     // Note: is debt ceiling only used for isolated assets?
     if (debtCeiling.isMaxed) {
       willBeUsedAsCollateral = CollateralType.UNAVAILABLE;


### PR DESCRIPTION
## General Changes

- Fixes a bug where an asset being supplied could show as enabled for being used as collateral, when it is disabled on the pool reserve 

## Developer Notes

I just expanded on the logic for detecting the collateral type, so if `poolReserve.usageAsCollateralEnabled` is false, it will take precedence over everything else.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
