### PR TITLE
fix: don't clear account in connect wallet callback

### DIFF
--- a/cypress/e2e/1-v3-markets/3-polygon-v3-market/e-mode.polygon-v3.cy.ts
+++ b/cypress/e2e/1-v3-markets/3-polygon-v3-market/e-mode.polygon-v3.cy.ts
@@ -45,6 +45,7 @@ const testData = {
       assets.polygonV3Market.EURS,
       assets.polygonV3Market.jEUR,
       assets.polygonV3Market.agEUR,
+      assets.polygonV3Market.miMATIC,
     ],
   },
 };

--- a/cypress/e2e/2-settings/wallet-connect.cy.ts
+++ b/cypress/e2e/2-settings/wallet-connect.cy.ts
@@ -41,7 +41,7 @@ describe('Manipulation on the wallet connect', () => {
 describe('CASE2:Connect and disconnect wallet over Coinbase', () => {
   it('step1:Connect wallet over Coinbase', () => {
     cy.wait(1000);
-    cy.get(walletButtonlocator).click();
+    //cy.get(walletButtonlocator).click();
     cy.wait(3000);
     optionOnConnectionModal('Coinbase');
     checkElementsOnModal('.-cbwsdk-extension-dialog-box', 'Try the Coinbase Wallet extension');

--- a/src/components/AddressBlocked.tsx
+++ b/src/components/AddressBlocked.tsx
@@ -9,7 +9,7 @@ export const AddressBlocked = ({ children }: { children: ReactNode }) => {
   const { currentAccount, disconnectWallet, watchModeOnly } = useWeb3Context();
   const screenAddress = watchModeOnly ? '' : currentAccount;
   const { isAllowed } = useAddressAllowed(screenAddress);
-  console.log('isAllowed', isAllowed);
+
   if (!isAllowed) {
     return (
       <MainLayout>

--- a/src/components/AddressBlocked.tsx
+++ b/src/components/AddressBlocked.tsx
@@ -9,7 +9,7 @@ export const AddressBlocked = ({ children }: { children: ReactNode }) => {
   const { currentAccount, disconnectWallet, watchModeOnly } = useWeb3Context();
   const screenAddress = watchModeOnly ? '' : currentAccount;
   const { isAllowed } = useAddressAllowed(screenAddress);
-
+  console.log('isAllowed', isAllowed);
   if (!isAllowed) {
     return (
       <MainLayout>

--- a/src/components/AddressBlocked.tsx
+++ b/src/components/AddressBlocked.tsx
@@ -6,8 +6,8 @@ import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { AddressBlockedModal } from './AddressBlockedModal';
 
 export const AddressBlocked = ({ children }: { children: ReactNode }) => {
-  const { currentAccount, disconnectWallet, watchModeOnly } = useWeb3Context();
-  const screenAddress = watchModeOnly ? '' : currentAccount;
+  const { currentAccount, disconnectWallet, watchModeOnly, loading } = useWeb3Context();
+  const screenAddress = watchModeOnly || loading ? '' : currentAccount;
   const { isAllowed } = useAddressAllowed(screenAddress);
 
   if (!isAllowed) {

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -440,8 +440,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
           error,
           switchNetworkError,
           setSwitchNetworkError,
-          watchModeOnlyAddress:
-            connector instanceof WatchModeOnlyConnector ? account?.toLowerCase() : undefined,
+          watchModeOnlyAddress: watchModeOnly ? account?.toLowerCase() : undefined,
           watchModeOnly,
         },
       }}

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -69,7 +69,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   const [deactivated, setDeactivated] = useState(false);
   const [triedGnosisSafe, setTriedGnosisSafe] = useState(false);
   const [triedCoinbase, setTriedCoinbase] = useState(false);
-  // const [watchModeOnly, setWatchModeOnly] = useState(false);
+  const [watchModeOnly, setWatchModeOnly] = useState(false);
   const [triedLedger, setTriedLedger] = useState(false);
   const [switchNetworkError, setSwitchNetworkError] = useState<Error>();
   const setAccount = useRootStore((store) => store.setAccount);
@@ -128,20 +128,23 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     async (wallet: WalletType) => {
       setLoading(true);
       try {
+        console.log('connecting wallet', wallet);
         const connector: AbstractConnector = getWallet(wallet, chainId);
 
-        // if (connector instanceof WatchModeOnlyConnector) {
-        //   setWatchModeOnly(true);
-        // } else {
-        //   setAccount('');
-        //   setWatchModeOnly(false);
-        // }
+        if (connector instanceof WatchModeOnlyConnector) {
+          setWatchModeOnly(true);
+        } else {
+          console.log('setting account to empty string');
+          setAccount('');
+          setWatchModeOnly(false);
+        }
 
         if (connector instanceof WalletConnectConnector) {
           connector.walletConnectProvider = undefined;
         }
 
         await activate(connector, undefined, true);
+        console.log('activated', connector);
         setConnector(connector);
         setSwitchNetworkError(undefined);
         localStorage.setItem('walletProvider', wallet.toString());
@@ -441,9 +444,8 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
           error,
           switchNetworkError,
           setSwitchNetworkError,
-          watchModeOnlyAddress:
-            connector instanceof WatchModeOnlyConnector ? account?.toLowerCase() : undefined,
-          watchModeOnly: false,
+          watchModeOnlyAddress: watchModeOnly ? account?.toLowerCase() : undefined,
+          watchModeOnly,
         },
       }}
     >

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -69,7 +69,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   const [deactivated, setDeactivated] = useState(false);
   const [triedGnosisSafe, setTriedGnosisSafe] = useState(false);
   const [triedCoinbase, setTriedCoinbase] = useState(false);
-  const [watchModeOnly, setWatchModeOnly] = useState(false);
+  // const [watchModeOnly, setWatchModeOnly] = useState(false);
   const [triedLedger, setTriedLedger] = useState(false);
   const [switchNetworkError, setSwitchNetworkError] = useState<Error>();
   const setAccount = useRootStore((store) => store.setAccount);
@@ -130,12 +130,12 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
       try {
         const connector: AbstractConnector = getWallet(wallet, chainId);
 
-        if (connector instanceof WatchModeOnlyConnector) {
-          setWatchModeOnly(true);
-        } else {
-          setAccount('');
-          setWatchModeOnly(false);
-        }
+        // if (connector instanceof WatchModeOnlyConnector) {
+        //   setWatchModeOnly(true);
+        // } else {
+        //   setAccount('');
+        //   setWatchModeOnly(false);
+        // }
 
         if (connector instanceof WalletConnectConnector) {
           connector.walletConnectProvider = undefined;
@@ -441,8 +441,9 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
           error,
           switchNetworkError,
           setSwitchNetworkError,
-          watchModeOnlyAddress: watchModeOnly ? account?.toLowerCase() : undefined,
-          watchModeOnly,
+          watchModeOnlyAddress:
+            connector instanceof WatchModeOnlyConnector ? account?.toLowerCase() : undefined,
+          watchModeOnly: false,
         },
       }}
     >

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -128,14 +128,11 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     async (wallet: WalletType) => {
       setLoading(true);
       try {
-        console.log('connecting wallet', wallet);
         const connector: AbstractConnector = getWallet(wallet, chainId);
 
         if (connector instanceof WatchModeOnlyConnector) {
           setWatchModeOnly(true);
         } else {
-          console.log('setting account to empty string');
-          setAccount('');
           setWatchModeOnly(false);
         }
 
@@ -144,7 +141,6 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
         }
 
         await activate(connector, undefined, true);
-        console.log('activated', connector);
         setConnector(connector);
         setSwitchNetworkError(undefined);
         localStorage.setItem('walletProvider', wallet.toString());
@@ -444,7 +440,8 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
           error,
           switchNetworkError,
           setSwitchNetworkError,
-          watchModeOnlyAddress: watchModeOnly ? account?.toLowerCase() : undefined,
+          watchModeOnlyAddress:
+            connector instanceof WatchModeOnlyConnector ? account?.toLowerCase() : undefined,
           watchModeOnly,
         },
       }}

--- a/src/modules/reserve-overview/ReserveActions.tsx
+++ b/src/modules/reserve-overview/ReserveActions.tsx
@@ -72,7 +72,9 @@ export const ReserveActions = ({ underlyingAsset }: ReserveActionsProps) => {
     market: { marketTitle: networkMarketName },
   } = getMarketInfoById(currentMarket);
   const { supplyCap, borrowCap, debtCeiling } = useAssetCaps();
-  const { poolComputed: { minRemainingBaseTokenBalance } } = useRootStore();
+  const {
+    poolComputed: { minRemainingBaseTokenBalance },
+  } = useRootStore();
 
   if (!currentAccount && !isPermissionsLoading)
     return (


### PR DESCRIPTION
## General Changes

- Fixes a bug where the app was not working inside of the gnosis safe UI

## Developer Notes

It's not clear exactly why this caused an issue, but calling `setAccount` (which changed global app state) inside of the connect wallet callback was causing the connect logic to fire multiple times.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
