### PR TITLE
fix: remove borrow button when borrowing is disabled for asset on overview page

### DIFF
--- a/src/modules/reserve-overview/ReserveActions.tsx
+++ b/src/modules/reserve-overview/ReserveActions.tsx
@@ -302,40 +302,42 @@ const SupplyAction = ({ value, usdValue, symbol, disable, onActionClicked }: Act
 
 const BorrowAction = ({ value, usdValue, symbol, disable, onActionClicked }: ActionProps) => {
   return (
-    <Stack>
-      <AvailableTooltip
-        variant="description"
-        text={<Trans>Available to borrow</Trans>}
-        capType={CapType.borrowCap}
-      />
-      <Stack
-        sx={{ height: '44px' }}
-        direction="row"
-        justifyContent="space-between"
-        alignItems="center"
-      >
-        <Box>
-          <ValueWithSymbol value={value} symbol={symbol} />
-          <FormattedNumber
-            value={usdValue}
-            variant="subheader2"
-            color="text.muted"
-            symbolsColor="text.muted"
-            symbol="USD"
-          />
-        </Box>
-        <Button
-          sx={{ height: '36px', width: '96px' }}
-          onClick={onActionClicked}
-          disabled={disable}
-          fullWidth={false}
-          variant="contained"
-          data-cy="borrowButton"
+    !disable && (
+      <Stack>
+        <AvailableTooltip
+          variant="description"
+          text={<Trans>Available to borrow</Trans>}
+          capType={CapType.borrowCap}
+        />
+        <Stack
+          sx={{ height: '44px' }}
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
         >
-          <Trans>Borrow</Trans>
-        </Button>
+          <Box>
+            <ValueWithSymbol value={value} symbol={symbol} />
+            <FormattedNumber
+              value={usdValue}
+              variant="subheader2"
+              color="text.muted"
+              symbolsColor="text.muted"
+              symbol="USD"
+            />
+          </Box>
+          <Button
+            sx={{ height: '36px', width: '96px' }}
+            onClick={onActionClicked}
+            disabled={disable}
+            fullWidth={false}
+            variant="contained"
+            data-cy="borrowButton"
+          >
+            <Trans>Borrow</Trans>
+          </Button>
+        </Stack>
       </Stack>
-    </Stack>
+    )
   );
 };
 

--- a/src/modules/reserve-overview/ReserveActions.tsx
+++ b/src/modules/reserve-overview/ReserveActions.tsx
@@ -301,44 +301,42 @@ const SupplyAction = ({ value, usdValue, symbol, disable, onActionClicked }: Act
 };
 
 const BorrowAction = ({ value, usdValue, symbol, disable, onActionClicked }: ActionProps) => {
-  return (
-    !disable && (
-      <Stack>
-        <AvailableTooltip
-          variant="description"
-          text={<Trans>Available to borrow</Trans>}
-          capType={CapType.borrowCap}
-        />
-        <Stack
-          sx={{ height: '44px' }}
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
+  return !disable ? (
+    <Stack>
+      <AvailableTooltip
+        variant="description"
+        text={<Trans>Available to borrow</Trans>}
+        capType={CapType.borrowCap}
+      />
+      <Stack
+        sx={{ height: '44px' }}
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <Box>
+          <ValueWithSymbol value={value} symbol={symbol} />
+          <FormattedNumber
+            value={usdValue}
+            variant="subheader2"
+            color="text.muted"
+            symbolsColor="text.muted"
+            symbol="USD"
+          />
+        </Box>
+        <Button
+          sx={{ height: '36px', width: '96px' }}
+          onClick={onActionClicked}
+          disabled={disable}
+          fullWidth={false}
+          variant="contained"
+          data-cy="borrowButton"
         >
-          <Box>
-            <ValueWithSymbol value={value} symbol={symbol} />
-            <FormattedNumber
-              value={usdValue}
-              variant="subheader2"
-              color="text.muted"
-              symbolsColor="text.muted"
-              symbol="USD"
-            />
-          </Box>
-          <Button
-            sx={{ height: '36px', width: '96px' }}
-            onClick={onActionClicked}
-            disabled={disable}
-            fullWidth={false}
-            variant="contained"
-            data-cy="borrowButton"
-          >
-            <Trans>Borrow</Trans>
-          </Button>
-        </Stack>
+          <Trans>Borrow</Trans>
+        </Button>
       </Stack>
-    )
-  );
+    </Stack>
+  ) : null;
 };
 
 const WrappedBaseAssetSelector = ({


### PR DESCRIPTION
## General Changes

Addresses the following issue created: https://github.com/aave/interface/issues/1388

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x]  End-to-end tests are passing without any errors
- [x]  Code style generally follows existing patterns
- [x]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [x]  Code changes have been quality checked in the ephemeral URL
- [x]  QA verification has been completed
- [x]  There are two or more approvals from the core team
- [x]  Squash and merge has been checked
