### PR TITLE
fix: make tables in markdown render somewhat correctly

### DIFF
--- a/pages/governance/proposal/[proposalId].governance.tsx
+++ b/pages/governance/proposal/[proposalId].governance.tsx
@@ -10,6 +10,12 @@ import {
   Skeleton,
   styled,
   SvgIcon,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
   Typography,
   useMediaQuery,
   useTheme,
@@ -239,6 +245,33 @@ export default function ProposalPage({
                     <ReactMarkdown
                       remarkPlugins={[remarkGfm]}
                       components={{
+                        table({ node, ...props }) {
+                          return (
+                            <TableContainer component={Paper} variant="outlined">
+                              <Table {...props} sx={{ wordBreak: 'normal' }} />
+                            </TableContainer>
+                          );
+                        },
+                        tr({ node, ...props }) {
+                          return (
+                            <TableRow
+                              sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                              {...props}
+                            />
+                          );
+                        },
+                        td({ children }) {
+                          return <TableCell>{children}</TableCell>;
+                        },
+                        th({ children }) {
+                          return <TableCell>{children}</TableCell>;
+                        },
+                        tbody({ children }) {
+                          return <TableBody>{children}</TableBody>;
+                        },
+                        thead({ node, ...props }) {
+                          return <TableHead {...props} />;
+                        },
                         img({ src: _src, alt }) {
                           if (!_src) return null;
                           const src = /^\.\.\//.test(_src)

--- a/pages/governance/proposal/[proposalId].governance.tsx
+++ b/pages/governance/proposal/[proposalId].governance.tsx
@@ -260,11 +260,11 @@ export default function ProposalPage({
                             />
                           );
                         },
-                        td({ children }) {
-                          return <TableCell>{children}</TableCell>;
+                        td({ children, style }) {
+                          return <TableCell style={style}>{children}</TableCell>;
                         },
-                        th({ children }) {
-                          return <TableCell>{children}</TableCell>;
+                        th({ children, style }) {
+                          return <TableCell style={style}>{children}</TableCell>;
                         },
                         tbody({ children }) {
                           return <TableBody>{children}</TableBody>;


### PR DESCRIPTION
## General Changes

Setting React markdown to render tables properly

## Developer Notes

Tables are currently completely broken.

Before:
![image](https://user-images.githubusercontent.com/4396533/213681655-fe830afc-6bdd-49ca-aaf3-cbdf13ade302.png)

After:
![image](https://user-images.githubusercontent.com/4396533/213681436-b0e48f93-8779-4611-b254-e5b9d72f1fe7.png)

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x]  End-to-end tests are passing without any errors
- [x]  Code style generally follows existing patterns
- [x]  Code changes do not significantly increase the application bundle size
- [x]  If there are new 3rd-party packages, they do not introduce potential security threats
- [x]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [x]  Code changes have been quality checked in the ephemeral URL
- [x]  QA verification has been completed
- [x]  There are two or more approvals from the core team
- [x]  Squash and merge has been checked
