### PR TITLE
fix: incorrect supply cap error when trying to swap collateral

### DIFF
--- a/src/components/transactions/Swap/SwapModalContent.tsx
+++ b/src/components/transactions/Swap/SwapModalContent.tsx
@@ -13,6 +13,7 @@ import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { ListSlippageButton } from 'src/modules/dashboard/lists/SlippageList';
 import { remainingCap } from 'src/utils/getMaxAmountAvailableToSupply';
 import { calculateHFAfterSwap } from 'src/utils/hfUtils';
+import { amountToUSD } from 'src/utils/utils';
 
 import {
   ComputedUserReserveData,
@@ -34,7 +35,7 @@ export const SwapModalContent = ({
   userReserve,
   isWrongNetwork,
 }: ModalWrapperProps) => {
-  const { reserves, user } = useAppDataContext();
+  const { reserves, user, marketReferencePriceInUsd } = useAppDataContext();
   const { currentChainId, currentNetworkConfig } = useProtocolDataContext();
   const { currentAccount } = useWeb3Context();
   const { gasLimit, mainTxState: supplyTxState, txError } = useModalContext();
@@ -63,7 +64,11 @@ export const SwapModalContent = ({
     new BigNumber(poolReserve.availableLiquidity).multipliedBy(0.99)
   ).toString(10);
 
-  const remainingCapBn = remainingCap(swapTarget.reserve);
+  const remainingCapUsd = amountToUSD(
+    remainingCap(swapTarget.reserve),
+    swapTarget.reserve.formattedPriceInMarketReferenceCurrency,
+    marketReferencePriceInUsd
+  );
 
   const isMaxSelected = _amount === '-1';
   const amount = isMaxSelected ? maxAmountToSwap : _amount;
@@ -116,7 +121,7 @@ export const SwapModalContent = ({
   // consider caps
   // we cannot check this in advance as it's based on the swap result
   let blockingError: ErrorType | undefined = undefined;
-  if (!remainingCapBn.eq('-1') && remainingCapBn.lt(amount)) {
+  if (!remainingCapUsd.eq('-1') && remainingCapUsd.lt(outputAmountUSD)) {
     blockingError = ErrorType.SUPPLY_CAP_REACHED;
   } else if (!hfAfterSwap.eq('-1') && hfAfterSwap.lt('1.01')) {
     blockingError = ErrorType.HF_BELOW_ONE;

--- a/src/components/transactions/Swap/SwapModalContent.tsx
+++ b/src/components/transactions/Swap/SwapModalContent.tsx
@@ -13,7 +13,7 @@ import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { ListSlippageButton } from 'src/modules/dashboard/lists/SlippageList';
 import { remainingCap } from 'src/utils/getMaxAmountAvailableToSupply';
 import { calculateHFAfterSwap } from 'src/utils/hfUtils';
-import { amountToUSD } from 'src/utils/utils';
+import { amountToUsd } from 'src/utils/utils';
 
 import {
   ComputedUserReserveData,
@@ -64,7 +64,7 @@ export const SwapModalContent = ({
     new BigNumber(poolReserve.availableLiquidity).multipliedBy(0.99)
   ).toString(10);
 
-  const remainingCapUsd = amountToUSD(
+  const remainingCapUsd = amountToUsd(
     remainingCap(swapTarget.reserve),
     swapTarget.reserve.formattedPriceInMarketReferenceCurrency,
     marketReferencePriceInUsd

--- a/src/modules/reserve-overview/ReserveActions.tsx
+++ b/src/modules/reserve-overview/ReserveActions.tsx
@@ -32,7 +32,7 @@ import { BuyWithFiat } from 'src/modules/staking/BuyWithFiat';
 import { useRootStore } from 'src/store/root';
 import { getMaxAmountAvailableToBorrow } from 'src/utils/getMaxAmountAvailableToBorrow';
 import { getMaxAmountAvailableToSupply } from 'src/utils/getMaxAmountAvailableToSupply';
-import { amountToUSD } from 'src/utils/utils';
+import { amountToUsd } from 'src/utils/utils';
 
 import { CapType } from '../../components/caps/helper';
 import { AvailableTooltip } from '../../components/infoTooltips/AvailableTooltip';
@@ -68,7 +68,7 @@ export const ReserveActions = ({ reserve }: ReserveActionsProps) => {
     InterestRate.Variable
   ).toString();
 
-  const maxAmountToBorrowUSD = amountToUSD(
+  const maxAmountToBorrowUsd = amountToUsd(
     maxAmountToBorrow,
     reserve.formattedPriceInMarketReferenceCurrency,
     marketReferencePriceInUsd
@@ -81,7 +81,7 @@ export const ReserveActions = ({ reserve }: ReserveActionsProps) => {
     minRemainingBaseTokenBalance
   ).toString();
 
-  const maxAmountToSupplyUSD = amountToUSD(
+  const maxAmountToSupplyUsd = amountToUsd(
     maxAmountToSupply,
     reserve.formattedPriceInMarketReferenceCurrency,
     marketReferencePriceInUsd
@@ -139,14 +139,14 @@ export const ReserveActions = ({ reserve }: ReserveActionsProps) => {
           <Stack gap={3}>
             <SupplyAction
               value={maxAmountToSupply}
-              usdValue={maxAmountToSupplyUSD}
+              usdValue={maxAmountToSupplyUsd}
               symbol={selectedAsset}
               disable={disableSupplyButton}
               onActionClicked={onSupplyClicked}
             />
             <BorrowAction
               value={maxAmountToBorrow}
-              usdValue={maxAmountToBorrowUSD}
+              usdValue={maxAmountToBorrowUsd}
               symbol={selectedAsset}
               disable={disableBorrowButton}
               onActionClicked={() => openBorrow(reserve.underlyingAsset)}

--- a/src/modules/reserve-overview/ReserveActions.tsx
+++ b/src/modules/reserve-overview/ReserveActions.tsx
@@ -1,5 +1,4 @@
 import { API_ETH_MOCK_ADDRESS, InterestRate } from '@aave/contract-helpers';
-import { USD_DECIMALS, valueToBigNumber } from '@aave/math-utils';
 import { Trans } from '@lingui/macro';
 import {
   Box,
@@ -33,23 +32,12 @@ import { BuyWithFiat } from 'src/modules/staking/BuyWithFiat';
 import { useRootStore } from 'src/store/root';
 import { getMaxAmountAvailableToBorrow } from 'src/utils/getMaxAmountAvailableToBorrow';
 import { getMaxAmountAvailableToSupply } from 'src/utils/getMaxAmountAvailableToSupply';
+import { amountToUSD } from 'src/utils/utils';
 
 import { CapType } from '../../components/caps/helper';
 import { AvailableTooltip } from '../../components/infoTooltips/AvailableTooltip';
 import { Link, ROUTES } from '../../components/primitives/Link';
 import { useReserveActionState } from '../../hooks/useReserveActionState';
-
-const amountToUSD = (
-  amount: string,
-  formattedPriceInMarketReferenceCurrency: string,
-  marketReferencePriceInUsd: string
-) => {
-  return valueToBigNumber(amount)
-    .multipliedBy(formattedPriceInMarketReferenceCurrency)
-    .multipliedBy(marketReferencePriceInUsd)
-    .shiftedBy(-USD_DECIMALS)
-    .toString();
-};
 
 interface ReserveActionsProps {
   reserve: ComputedReserveData;
@@ -84,7 +72,7 @@ export const ReserveActions = ({ reserve }: ReserveActionsProps) => {
     maxAmountToBorrow,
     reserve.formattedPriceInMarketReferenceCurrency,
     marketReferencePriceInUsd
-  );
+  ).toString();
 
   const maxAmountToSupply = getMaxAmountAvailableToSupply(
     balance?.amount || '0',
@@ -97,7 +85,7 @@ export const ReserveActions = ({ reserve }: ReserveActionsProps) => {
     maxAmountToSupply,
     reserve.formattedPriceInMarketReferenceCurrency,
     marketReferencePriceInUsd
-  );
+  ).toString();
 
   const { disableSupplyButton, disableBorrowButton, alerts } = useReserveActionState({
     balance: balance?.amount || '0',

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@aave/contract-helpers';
+import { BigNumberValue, USD_DECIMALS, valueToBigNumber } from '@aave/math-utils';
 
 export function hexToAscii(_hex: string): string {
   const hex = _hex.toString();
@@ -46,4 +47,15 @@ export const optimizedPath = (currentChainId: ChainId) => {
 export const minBaseTokenRemainingByNetwork: Record<number, string> = {
   [ChainId.optimism]: '0.0001',
   [ChainId.arbitrum_one]: '0.0001',
+};
+
+export const amountToUSD = (
+  amount: BigNumberValue,
+  formattedPriceInMarketReferenceCurrency: string,
+  marketReferencePriceInUsd: string
+) => {
+  return valueToBigNumber(amount)
+    .multipliedBy(formattedPriceInMarketReferenceCurrency)
+    .multipliedBy(marketReferencePriceInUsd)
+    .shiftedBy(-USD_DECIMALS);
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -49,7 +49,7 @@ export const minBaseTokenRemainingByNetwork: Record<number, string> = {
   [ChainId.arbitrum_one]: '0.0001',
 };
 
-export const amountToUSD = (
+export const amountToUsd = (
   amount: BigNumberValue,
   formattedPriceInMarketReferenceCurrency: string,
   marketReferencePriceInUsd: string


### PR DESCRIPTION
## General Changes

- Fixes a bug where the user would see an error in some cases when trying to swap collateral. There's a check to make sure the supply cap isn't going to be exceeded after the swap is done, but the values weren't converted to USD first. We also were using the input swap amount, but this is changed to now use the `outputAmoutUsd` from the fetched swap route.

## Developer Notes

Pulled out a helper function for converting an amount to a USD value to a common utils file. There's other places in the app where we're doing the same calculation that we can eventually migrate over to use the same method.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
