### PR TITLE
chore: support permit for tokens with nonstandard nonce check

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test:ci": "jest --ci"
   },
   "dependencies": {
-    "@aave/contract-helpers": "^1.13.5",
-    "@aave/math-utils": "^1.13.5",
+    "@aave/contract-helpers": "^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0",
+    "@aave/math-utils": "^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0",
     "@bgd-labs/aave-address-book": "^1.13.1",
     "@emotion/cache": "11.10.3",
     "@emotion/react": "11.10.4",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test:ci": "jest --ci"
   },
   "dependencies": {
-    "@aave/contract-helpers": "^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0",
-    "@aave/math-utils": "^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0",
+    "@aave/contract-helpers": "1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0",
+    "@aave/math-utils": "1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0",
     "@bgd-labs/aave-address-book": "^1.13.1",
     "@emotion/cache": "11.10.3",
     "@emotion/react": "11.10.4",

--- a/src/ui-config/permitConfig.ts
+++ b/src/ui-config/permitConfig.ts
@@ -4,14 +4,13 @@ export const permitByChainAndToken: {
   [chainId: number]: Record<string, boolean>;
 } = {
   [ChainId.mainnet]: {
-    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': false,
     '0x6b175474e89094c44da98b954eedeac495271d0f': false,
     '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9': true,
     '0x514910771af9ca656af840dff83e8264ecf986ca': false,
     '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': false,
     '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2': false,
     '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0': true,
-    '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': true,
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': true,
   },
   [ChainId.arbitrum_one]: {
     '0xf97f4df75117a78c1a5a0dbb814af92458539fb4': true,

--- a/src/ui-config/permitConfig.ts
+++ b/src/ui-config/permitConfig.ts
@@ -11,6 +11,7 @@ export const permitByChainAndToken: {
     '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': false,
     '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2': false,
     '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0': true,
+    '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': true,
   },
   [ChainId.arbitrum_one]: {
     '0xf97f4df75117a78c1a5a0dbb814af92458539fb4': true,
@@ -19,7 +20,8 @@ export const permitByChainAndToken: {
     '0x82af49447d8a07e3bd95bd0d56f35241523fbab1': true,
     '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9': true,
     '0xba5ddd1f9d7f570dc94a51479a000e3bce967196': true,
-    '0xd22a58f79e9481d1a88e00c343885a588b34b68b': false, // eurs
+    '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1': true,
+    '0xd22a58f79e9481d1a88e00c343885a588b34b68b': true,
   },
   [ChainId.fantom]: {
     '0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e': true,
@@ -34,12 +36,17 @@ export const permitByChainAndToken: {
   },
   [ChainId.polygon]: {
     '0x4e3decbb3645551b8a19f0ea1678079fcb33fb4c': true,
+    '0x2791bca1f2de4661ed88a30c99a7a9449aa84174': true,
   },
   [ChainId.harmony]: {},
   [ChainId.avalanche]: {
     '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7': true,
+    '0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64': true,
+    '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e': true,
   },
   [ChainId.optimism]: {
-    '0x76fb31fb4af56892a25e32cfc43de717950c9278': false, // aave
+    '0x4200000000000000000000000000000000000042': true,
+    '0x76fb31fb4af56892a25e32cfc43de717950c9278': true,
+    '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1': true,
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@aave/contract-helpers@^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0":
-  version "1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0"
-  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0.tgz#e7ba1a28834ce2a10a43a354fbcbd807144d4eab"
-  integrity sha512-6hWZJAAlN8DKf2Ij+yoVIHZKJSqdufqg8gYATVFbKExHip3Vppg7njieGc1WK3iD874l6q7RpKK5kQK/uc2yFQ==
+"@aave/contract-helpers@1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0":
+  version "1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0"
+  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0.tgz#7a5f9e94ce2dfc27cc2af7d4168d3de97fa61cfb"
+  integrity sha512-womwrKg8xV0J3kJ98Dixa3srU4X1G77L59xYwgYcPdbg2CdbPaCE/EwNJoxWK7R4xRSzPI0RKVF4lQ6nh5c42g==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 
-"@aave/math-utils@^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0":
-  version "1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0"
-  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0.tgz#1cb413d4b857bf087977a2932f82f9c7c993c006"
-  integrity sha512-5TKU1UNoLR81N+OVbpBba6wyW3V4u1lcnAgVohW8zayXSb14WQbOjGoQp6AapZQZ4vSm9/jz9WH8fHaAKXJVIw==
+"@aave/math-utils@1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0":
+  version "1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0"
+  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.13.6-df8123c8490b2a5153f9e7e8252a4309b0895a6a.0.tgz#124464da6d5c1ba2cf2ea9e58c687afabaa3f542"
+  integrity sha512-8IGgIfkAhx//0SWhHylo9NQcU8xsQRRfKwVxxGj04zVcZZXhxExRMDGJ+/Zah4EoSeZZDLzU6cnRG/+8M7WLnw==
 
 "@adobe/css-tools@^4.0.1":
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@aave/contract-helpers@^1.13.5":
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.13.5.tgz#187990cbbb5c07410a6a0210f572156ca1783c97"
-  integrity sha512-PeqiHHnBHylOnMFM5L4LG77ajYS9gtiLsrrUhf2wuZh0Er8eZJIqueD17cCU88H8PZKHlBbfaMJDD3wWgv/iaA==
+"@aave/contract-helpers@^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0":
+  version "1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0"
+  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0.tgz#e7ba1a28834ce2a10a43a354fbcbd807144d4eab"
+  integrity sha512-6hWZJAAlN8DKf2Ij+yoVIHZKJSqdufqg8gYATVFbKExHip3Vppg7njieGc1WK3iD874l6q7RpKK5kQK/uc2yFQ==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 
-"@aave/math-utils@^1.13.5":
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.13.5.tgz#e46f75685c386846a589cbe83fe594fc1caee47a"
-  integrity sha512-3BZowcvnIIlHaQUSppv4yW7K6RU1D3nEp97WBaiWsAxMu8eMXe9+NFjmlQGmUA7JE8GglzyAU/RoAU9RoCQ3Dw==
+"@aave/math-utils@^1.13.6-9240319b19ca6fc33bd60d484bfaba171ca22a52.0":
+  version "1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0"
+  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.13.6-ff645236ef18eaed1999054d54ce6f753fbb8098.0.tgz#1cb413d4b857bf087977a2932f82f9c7c993c006"
+  integrity sha512-5TKU1UNoLR81N+OVbpBba6wyW3V4u1lcnAgVohW8zayXSb14WQbOjGoQp6AapZQZ4vSm9/jz9WH8fHaAKXJVIw==
 
 "@adobe/css-tools@^4.0.1":
   version "4.0.1"


### PR DESCRIPTION
## General Changes

Certain tokens support `permit` but check `nonce + 1` instead of the standard `nonce`. This bumps the utilities version to support `nonce + 1` tokens and enables permit for:

OP - Optimism
AAVE - Optimism
DAI - Optimism
DAI - Arbitrum
EURS - Arbitrum
FRAX - Avalanche
USDC - Avalanche
USDC - Polygon
USDC - Mainnet


Still getting invalid signature for USDC on V3 mainnet :/

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
