### PR TITLE
feat: display asset with max supply cap

### DIFF
--- a/src/modules/dashboard/lists/SupplyAssetsList/SupplyAssetsListItem.tsx
+++ b/src/modules/dashboard/lists/SupplyAssetsList/SupplyAssetsListItem.tsx
@@ -36,9 +36,9 @@ export const SupplyAssetsListItem = ({
   const { currentMarket } = useProtocolDataContext();
   const { openSupply } = useModalContext();
 
-  // Hide the asset to prevent it from being supplied if supply cap has been reached
+  // Disable the asset to prevent it from being supplied if supply cap has been reached
   const { supplyCap: supplyCapUsage, debtCeiling } = useAssetCaps();
-  if (supplyCapUsage.isMaxed) return null;
+  const isMaxCapReached = supplyCapUsage.isMaxed;
 
   return (
     <ListItemWrapper
@@ -55,7 +55,7 @@ export const SupplyAssetsListItem = ({
         value={Number(walletBalance)}
         subValue={walletBalanceUSD}
         withTooltip
-        disabled={Number(walletBalance) === 0}
+        disabled={Number(walletBalance) === 0 || isMaxCapReached}
         capsComponent={
           <CapsHint
             capType={CapType.supplyCap}
@@ -81,7 +81,7 @@ export const SupplyAssetsListItem = ({
 
       <ListButtonsColumn>
         <Button
-          disabled={!isActive || isFreezed || Number(walletBalance) <= 0}
+          disabled={!isActive || isFreezed || Number(walletBalance) <= 0 || isMaxCapReached}
           variant="contained"
           onClick={() => openSupply(underlyingAsset)}
         >

--- a/src/modules/dashboard/lists/SupplyAssetsList/SupplyAssetsListMobileItem.tsx
+++ b/src/modules/dashboard/lists/SupplyAssetsList/SupplyAssetsListMobileItem.tsx
@@ -34,9 +34,9 @@ export const SupplyAssetsListMobileItem = ({
   const { currentMarket } = useProtocolDataContext();
   const { openSupply } = useModalContext();
 
-  // Hide the asset to prevent it from being supplied if supply cap has been reached
+  // Disable the asset to prevent it from being supplied if supply cap has been reached
   const { supplyCap: supplyCapUsage } = useAssetCaps();
-  if (supplyCapUsage.isMaxed) return null;
+  const isMaxCapReached = supplyCapUsage.isMaxed;
 
   return (
     <ListMobileItemWrapper
@@ -51,7 +51,7 @@ export const SupplyAssetsListMobileItem = ({
         title={<Trans>Supply balance</Trans>}
         value={Number(walletBalance)}
         subValue={walletBalanceUSD}
-        disabled={Number(walletBalance) === 0}
+        disabled={Number(walletBalance) === 0 || isMaxCapReached}
         capsComponent={
           <CapsHint
             capType={CapType.supplyCap}
@@ -90,7 +90,7 @@ export const SupplyAssetsListMobileItem = ({
 
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 5 }}>
         <Button
-          disabled={!isActive || isFreezed || Number(walletBalance) <= 0}
+          disabled={!isActive || isFreezed || Number(walletBalance) <= 0 || isMaxCapReached}
           variant="contained"
           onClick={() => openSupply(underlyingAsset)}
           sx={{ mr: 1.5 }}


### PR DESCRIPTION
## General Changes

- Let assets with max supply cap reached to be displayed in the supply list but disabled

## Developer Notes

- `SupplyAssetsListItem` and `SupplyAssetsListMobileItem` no longer returns null if `supplyCapUsage.isMaxed`

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [x]  Code style generally follows existing patterns
- [x]  Code changes do not significantly increase the application bundle size
- [x]  If there are new 3rd-party packages, they do not introduce potential security threats
- [x]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [x]  There are two or more approvals from the core team
- [x]  Squash and merge has been checked

Close #1500