### PR TITLE
fix: don't override default padding right for MuiSelect in market switcher

### DIFF
--- a/src/components/MarketSwitcher.tsx
+++ b/src/components/MarketSwitcher.tsx
@@ -172,7 +172,8 @@ export const MarketSwitcher = () => {
         },
         sx: {
           '&.MarketSwitcher__select .MuiSelect-outlined': {
-            p: 0,
+            pl: 0,
+            py: 0,
             backgroundColor: 'transparent !important',
           },
           '.MuiSelect-icon': { color: '#F1F1F3' },


### PR DESCRIPTION
## General Changes

- Fixes a bug where the market switcher dropdown icon wasn't positioned correctly in some cases.

To reproduce the bug, go to the Governance page and refresh the page. Then navigate to the Dashboard or Markets page.

## Developer Notes

This bug happens because when you load the app on the governance page, the default styles are loaded for the MuiSelect component, which includes a padding right of 32px. When you navigate to the dashboard, our custom styling overrides the default and sets a padding of 0. If you start on the dashboard, the default styles take precedence over our custom styling, so the padding right is applied.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
