### PR TITLE
Fix: Redirect to 404 page if reserve details asset is invalid

### DIFF
--- a/pages/reserve-overview.page.tsx
+++ b/pages/reserve-overview.page.tsx
@@ -19,24 +19,30 @@ import { ContentContainer } from '../src/components/ContentContainer';
 export default function ReserveOverview() {
   const router = useRouter();
   const { reserves } = useAppDataContext();
-  const underlyingAsset = router.query.underlyingAsset as string;
   const { breakpoints } = useTheme();
   const lg = useMediaQuery(breakpoints.up('lg'));
 
+  const [reserve, setReserve] = useState<ComputedReserveData>();
   const [mode, setMode] = useState<'overview' | 'actions' | ''>('');
+
+  const underlyingAsset = router.query.underlyingAsset as string;
 
   useEffect(() => {
     if (!mode) setMode('overview');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lg]);
 
-  const reserve = reserves.find(
-    (reserve) => reserve.underlyingAsset === underlyingAsset
-  ) as ComputedReserveData;
+    if (router.isReady && reserves.length) {
+      const reserveFound = reserves.find((reserve) => reserve.underlyingAsset === underlyingAsset);
+
+      if (reserveFound) setReserve(reserveFound);
+      else router.replace('/404');
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lg, router.isReady, reserves.length]);
 
   const isOverview = mode === 'overview';
 
-  return (
+  return reserve ? (
     <AssetCapsProvider asset={reserve}>
       <ReserveTopDetails underlyingAsset={underlyingAsset} />
 
@@ -92,7 +98,7 @@ export default function ReserveOverview() {
         </Box>
       </ContentContainer>
     </AssetCapsProvider>
-  );
+  ) : null;
 }
 
 ReserveOverview.getLayout = function getLayout(page: React.ReactElement) {


### PR DESCRIPTION
## General Changes

- Fixes [#1156](https://github.com/aave/interface/issues/1156)

## Developer Notes

Implementing getStaticProps will run at build time rather than query. To handle redirection based on route parameters, redirect on static. This can be achieved by checking for the existence of a reserve based on the underlyingAsset during page mount. If the reserve exists, load the page. Otherwise, redirect to the 404 page.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
