### PR TITLE
Fix: Remove extra header column in ListLoader

### DIFF
--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -267,7 +267,6 @@ msgstr "Asset is not listed"
 msgid "Asset supply is limited to a certain amount to reduce protocol exposure to the asset and to help manage risks involved."
 msgstr "Asset supply is limited to a certain amount to reduce protocol exposure to the asset and to help manage risks involved."
 
-#: src/modules/dashboard/lists/ListHeader.tsx
 #: src/modules/dashboard/lists/SupplyAssetsList/SupplyAssetsList.tsx
 #: src/modules/migration/MigrationList.tsx
 msgid "Assets"

--- a/src/modules/dashboard/lists/ListHeader.tsx
+++ b/src/modules/dashboard/lists/ListHeader.tsx
@@ -1,4 +1,3 @@
-import { Trans } from '@lingui/macro';
 import { ReactNode } from 'react';
 
 import { ListColumn } from '../../../components/lists/ListColumn';
@@ -13,14 +12,8 @@ interface ListHeaderProps {
 export const ListHeader = ({ head }: ListHeaderProps) => {
   return (
     <ListHeaderWrapper>
-      <ListColumn maxWidth={160} isRow>
-        <ListHeaderTitle>
-          <Trans>Assets</Trans>
-        </ListHeaderTitle>
-      </ListColumn>
-
       {head.map((title, i) => (
-        <ListColumn overFlow={'visible'} key={i}>
+        <ListColumn overFlow={'visible'} key={i} isRow={i === 0}>
           <ListHeaderTitle>{title}</ListHeaderTitle>
         </ListColumn>
       ))}


### PR DESCRIPTION
## General Changes

- Fixes bug [#1576](https://github.com/aave/interface/issues/1576)

## Developer Notes

The problem is there is an extra list-column in headers of the ListLoader. After this was removed, the skeletons align properly.

## Screen shots
<details>
<summary>Before</summary>
<br />

<img width="1728" alt="before" src="https://user-images.githubusercontent.com/89173284/235568449-72a31745-ad7c-4a87-b69d-c485db66dc46.png">

</details>

<details>
<summary>After</summary>
<br />

<img width="1728" alt="before" src="https://user-images.githubusercontent.com/89173284/235568464-b3e062e4-5111-4266-bf50-3d2b73ed9823.png">
</details>
---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
