### PR TITLE
fix: make sure reserve can be an isolated asset

### DIFF
--- a/src/components/transactions/Swap/SwapModalContent.tsx
+++ b/src/components/transactions/Swap/SwapModalContent.tsx
@@ -215,7 +215,8 @@ export const SwapModalContent = ({
   if (
     isMaxSelected &&
     swapSourceCollateralType === CollateralType.ENABLED &&
-    swapTarget.underlyingBalance === '0'
+    swapTarget.underlyingBalance === '0' &&
+    swapTarget.reserve.isIsolated
   ) {
     const reservesAsCollateral = user.userReservesData.filter(
       (r) => r.usageAsCollateralEnabledOnUser


### PR DESCRIPTION
## General Changes

- Fixes a bug where the swap target would incorrectly say a user was entering isolation mode when trying to swap the entire amount of a collateral.

Context: if you have only 1 asset supplied, or only 1 asset enabled as collateral, and you try to swap the entire amount to an isolated asset, you will enter isolation mode. The swap details will indicate this on the collateral type of the swap target.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
