### PR TITLE
fix: wrong behaviour of switch wallet

### DIFF
--- a/src/components/WalletConnection/WalletSelector.tsx
+++ b/src/components/WalletConnection/WalletSelector.tsx
@@ -115,20 +115,21 @@ export const WalletSelector = () => {
   const mainnetProvider = getENSProvider();
   const [unsTlds, setUnsTlds] = useState<string[]>([]);
   const trackEvent = useRootStore((store) => store.trackEvent);
+  const [blockingError, setBlockingError] = useState<ErrorType | undefined>();
 
-  let blockingError: ErrorType | undefined = undefined;
-  if (error) {
-    if (error instanceof UnsupportedChainIdError) {
-      blockingError = ErrorType.UNSUPORTED_CHAIN;
-    } else if (error instanceof UserRejectedRequestError) {
-      blockingError = ErrorType.USER_REJECTED_REQUEST;
-    } else if (error instanceof NoEthereumProviderError) {
-      blockingError = ErrorType.NO_WALLET_DETECTED;
-    } else {
-      blockingError = ErrorType.UNDETERMINED_ERROR;
+  useEffect(() => {
+    if (error) {
+      if (error instanceof UnsupportedChainIdError) {
+        setBlockingError(ErrorType.UNSUPORTED_CHAIN);
+      } else if (error instanceof UserRejectedRequestError) {
+        setBlockingError(ErrorType.USER_REJECTED_REQUEST);
+      } else if (error instanceof NoEthereumProviderError) {
+        setBlockingError(ErrorType.NO_WALLET_DETECTED);
+      } else {
+        setBlockingError(ErrorType.UNDETERMINED_ERROR);
+      }
     }
-    // TODO: add other errors
-  }
+  }, [error]);
 
   // Get UNS Tlds. Grabbing this fron an endpoint since Unstoppable adds new TLDs frequently, so this wills tay updated
   useEffect(() => {
@@ -203,7 +204,7 @@ export const WalletSelector = () => {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
       <TxModalTitle title="Connect a wallet" />
-      {error && <Warning severity="error">{handleBlocking()}</Warning>}
+      {blockingError && <Warning severity="error">{handleBlocking()}</Warning>}
       <WalletRow
         key="browser_wallet"
         walletName="Browser wallet"

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -64,6 +64,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
 
   // const [provider, setProvider] = useState<JsonRpcProvider>();
   const [connector, setConnector] = useState<AbstractConnector>();
+  const [currentAccount, setCurrentAccount] = useState<string | undefined>(account?.toLowerCase());
   const [loading, setLoading] = useState(false);
   const [tried, setTried] = useState(false);
   const [deactivated, setDeactivated] = useState(false);
@@ -120,6 +121,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     setLoading(false);
     setDeactivated(true);
     setSwitchNetworkError(undefined);
+    setCurrentAccount(undefined);
   }, [provider, connector]);
 
   const connectReadOnlyMode = (address: string): Promise<void> => {
@@ -424,7 +426,10 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
 
   // inject account into zustand as long as aave itnerface is using old web3 providers
   useEffect(() => {
-    setAccount(account?.toLowerCase());
+    if (account && account.toLowerCase() !== currentAccount) {
+      setCurrentAccount(account?.toLowerCase());
+      setAccount(account?.toLowerCase());
+    }
   }, [account]);
 
   useEffect(() => {
@@ -446,7 +451,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
           getTxError,
           sendTx,
           signTxData,
-          currentAccount: account?.toLowerCase() || '',
+          currentAccount: currentAccount || '',
           addERC20Token,
           error,
           switchNetworkError,


### PR DESCRIPTION
## General Changes

Fixes #1208 

## Developer Notes

The core of the issue is when cancelling a to connect. The web3react plugin will quickly logout then log back in. I fixed this by adding a state and only updating the ui ONLY IF the user switches to a new account.

This also caused an problems when showing the error. When the web3react plugin logs back in the error disappears. This was fixed so that the error persists using useState

## Logic Explanation

user opens modal & switches account -> update to the ui
user opens modal & doesn't switch account -> no update to the ui
user logs out -> update ui


## Screen Capture

<table >
  <tr>
     <th >Before<th>
     <th>After <th>
  <tr> 
  <tr>
    <td> 
      <video alt="Screen Recording" src="https://github.com/aave/interface/assets/89173284/986aa96f-c80f-46a0-9c35-7fb02da6c548" />
    <td>
    <td>
      <video alt="Screen Recording" src="https://github.com/aave/interface/assets/89173284/61c7ee32-314c-436f-84af-4a775642ede1" />
    <td>
  <tr>
<table>

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [x]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
