### PR TITLE
fix: remove auto focus on address input

### DIFF
--- a/src/components/WalletConnection/WalletSelector.tsx
+++ b/src/components/WalletConnection/WalletSelector.tsx
@@ -240,7 +240,6 @@ export const WalletSelector = () => {
           })}
           placeholder="Enter ethereum address or username"
           fullWidth
-          autoFocus
           value={inputMockWalletAddress}
           onChange={(e) => setInputMockWalletAddress(e.target.value)}
           inputProps={{


### PR DESCRIPTION
## General Changes

- Remove auto focus on input for entering address for 'read-only' mode. The input was getting focus when clicking on a wallet option, causing weird UX

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
