### PR TITLE
fix: debt switch symobl icon and max amount

### DIFF
--- a/src/components/transactions/DebtSwitch/DebtSwitchModalContent.tsx
+++ b/src/components/transactions/DebtSwitch/DebtSwitchModalContent.tsx
@@ -180,7 +180,7 @@ export const DebtSwitchModalContent = ({
         value={amount}
         onChange={handleChange}
         usdValue={poolReserveAmountUSD.toString()}
-        symbol={poolReserve.iconSymbol}
+        symbol={poolReserve.symbol}
         assets={[
           {
             balance: maxAmountToSwitch,

--- a/src/store/poolSlice.ts
+++ b/src/store/poolSlice.ts
@@ -535,7 +535,7 @@ export const createPoolSlice: StateCreator<
       return debtSwitchService.debtSwitch({
         user,
         debtAssetUnderlying: poolReserve.underlyingAsset,
-        debtRepayAmount: amountToSwap,
+        debtRepayAmount: isMaxSelected ? MAX_UINT_AMOUNT : amountToSwap,
         debtRateMode: currentRateMode,
         newAssetUnderlying: targetReserve.underlyingAsset,
         newAssetDebtToken: targetReserve.variableDebtTokenAddress,


### PR DESCRIPTION
## General Changes

- When switching max amount, pass in max uint value in transaction
- Use `symbol` prop for asset target input so correct name shows. For example, `USDC.e` vs `USDC`

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
