### PR TITLE
fix: use userReserve instead of reserve stableBorrowApy

### DIFF
--- a/src/modules/dashboard/lists/BorrowedPositionsList/BorrowedPositionsListItem.tsx
+++ b/src/modules/dashboard/lists/BorrowedPositionsList/BorrowedPositionsListItem.tsx
@@ -49,7 +49,7 @@ export const BorrowedPositionsListItem = ({ item }: { item: DashboardReserve }) 
     borrowAPY:
       item.borrowRateMode === InterestRate.Variable
         ? Number(reserve.variableBorrowAPY)
-        : Number(reserve.stableBorrowAPY),
+        : Number(item.stableBorrowAPY),
     incentives:
       item.borrowRateMode === InterestRate.Variable
         ? reserve.vIncentivesData


### PR DESCRIPTION
## General Changes

`reserve.stableBorrowAPY` updates with the rate for new positions, `userReserve.stableBorrowAPY` is for an individual position and should be used on dashboard.

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
