### PR TITLE
chore: disable testnet WrappedBaseAsset permit

### DIFF
--- a/src/components/transactions/Repay/RepayActions.tsx
+++ b/src/components/transactions/Repay/RepayActions.tsx
@@ -33,7 +33,10 @@ export const RepayActions = ({
 }: RepayActionProps) => {
   const { repay, repayWithPermit, tryPermit } = useRootStore();
 
-  const usingPermit = tryPermit(poolAddress);
+  const usingPermit = tryPermit({
+    reserveAddress: poolAddress,
+    isWrappedBaseAsset: poolReserve.isWrappedBaseAsset,
+  });
   const { approval, action, requiresApproval, loadingTxns, approvalTxState, mainTxState } =
     useTransactionHandler({
       tryPermit: usingPermit,

--- a/src/components/transactions/Supply/SupplyActions.tsx
+++ b/src/components/transactions/Supply/SupplyActions.tsx
@@ -31,6 +31,7 @@ export interface SupplyActionProps extends BoxProps {
   symbol: string;
   blocked: boolean;
   decimals: number;
+  isWrappedBaseAsset: boolean;
 }
 
 interface SignedParams {
@@ -48,6 +49,7 @@ export const SupplyActions = React.memo(
     symbol,
     blocked,
     decimals,
+    isWrappedBaseAsset,
     ...props
   }: SupplyActionProps) => {
     const [
@@ -82,7 +84,7 @@ export const SupplyActions = React.memo(
       setTxError,
     } = useModalContext();
     const { refetchPoolData, refetchIncentiveData, refetchGhoData } = useBackgroundDataProvider();
-    const permitAvailable = tryPermit(poolAddress);
+    const permitAvailable = tryPermit({ reserveAddress: poolAddress, isWrappedBaseAsset });
     const { signTxData, sendTx } = useWeb3Context();
 
     const [usePermit, setUsePermit] = useState(false);

--- a/src/components/transactions/Supply/SupplyModalContent.tsx
+++ b/src/components/transactions/Supply/SupplyModalContent.tsx
@@ -174,6 +174,7 @@ export const SupplyModalContent = React.memo(
       symbol: supplyUnWrapped ? currentNetworkConfig.baseAssetSymbol : poolReserve.symbol,
       blocked: false,
       decimals: poolReserve.decimals,
+      isWrappedBaseAsset: poolReserve.isWrappedBaseAsset,
     };
 
     if (supplyTxState.success)

--- a/src/store/protocolDataSlice.ts
+++ b/src/store/protocolDataSlice.ts
@@ -13,6 +13,11 @@ import { NetworkConfig } from '../ui-config/networksConfig';
 import { RootStore } from './root';
 import { setQueryParameter } from './utils/queryParams';
 
+type TypePermitParams = {
+  reserveAddress: string;
+  isWrappedBaseAsset: boolean;
+};
+
 export interface ProtocolDataSlice {
   currentMarket: CustomMarket;
   currentMarketData: MarketDataType;
@@ -20,7 +25,7 @@ export interface ProtocolDataSlice {
   currentNetworkConfig: NetworkConfig;
   jsonRpcProvider: () => providers.Provider;
   setCurrentMarket: (market: CustomMarket, omitQueryParameterUpdate?: boolean) => void;
-  tryPermit: (reserveAddress: string) => boolean;
+  tryPermit: ({ reserveAddress, isWrappedBaseAsset }: TypePermitParams) => boolean;
 }
 
 export const createProtocolDataSlice: StateCreator<
@@ -51,18 +56,16 @@ export const createProtocolDataSlice: StateCreator<
         currentNetworkConfig: getNetworkConfig(nextMarketData.chainId),
       });
     },
-    tryPermit: (reserveAddress: string) => {
+    tryPermit: ({ reserveAddress, isWrappedBaseAsset }: TypePermitParams) => {
       const currentNetworkConfig = get().currentNetworkConfig;
       const currentMarketData = get().currentMarketData;
       // current chain id, or underlying chain id for fork networks
       const underlyingChainId = currentNetworkConfig.isFork
         ? currentNetworkConfig.underlyingChainId
         : currentMarketData.chainId;
-      // enable permit for all v3 test network assets or v3 production assets included in permitConfig)
+      // enable permit for all v3 test network assets (except WrappedBaseAssets) or v3 production assets included in permitConfig)
       const testnetPermitEnabled = Boolean(
-        currentMarketData.v3 &&
-          currentNetworkConfig.isTestnet &&
-          reserveAddress.toLowerCase() !== '0xb685400156cf3cbe8725958deaa61436727a30c3' // WMATIC on Mumbai is a special case
+        currentMarketData.v3 && currentNetworkConfig.isTestnet && !isWrappedBaseAsset
       );
       const productionPermitEnabled = Boolean(
         currentMarketData.v3 &&


### PR DESCRIPTION
## General Changes

All V3 testnets use a deployment of WETH9Mock which does not implement `permit`/`nonces`. This PR disables the permit approval option for these reserves.

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
