### PR TITLE
fix: native vs. bridged USDC naming

### DIFF
--- a/cypress/fixtures/assets.json
+++ b/cypress/fixtures/assets.json
@@ -634,8 +634,8 @@
       "wrapped": false
     },
     "USDC": {
-      "fullName": "USD Coin",
-      "shortName": "USDC",
+      "fullName": "Bridged USDC",
+      "shortName": "USDC.e",
       "collateral": true,
       "wrapped": false
     },

--- a/cypress/fixtures/assets.json
+++ b/cypress/fixtures/assets.json
@@ -635,7 +635,7 @@
     },
     "USDC": {
       "fullName": "Bridged USDC",
-      "shortName": "USDC.e",
+      "shortName": "USDC.E",
       "collateral": true,
       "wrapped": false
     },

--- a/src/ui-config/reservePatches.ts
+++ b/src/ui-config/reservePatches.ts
@@ -1,3 +1,4 @@
+import { AaveV3Arbitrum, AaveV3Optimism, AaveV3Polygon } from '@bgd-labs/aave-address-book';
 import { unPrefixSymbol } from 'src/hooks/app-data-provider/useAppDataProvider';
 
 /**
@@ -103,20 +104,17 @@ export function fetchIconSymbolAndName({ underlyingAsset, symbol, name }: IconSy
       symbol: 'KNCL',
       iconSymbol: 'KNCL',
     },
-    // arbitrum
-    '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8': {
+    [AaveV3Arbitrum.ASSETS.USDC.UNDERLYING.toLowerCase()]: {
       name: 'Bridged USDC',
       symbol: 'USDC.e',
       iconSymbol: 'USDC',
     },
-    // optimism
-    '0x7f5c764cbc14f9669b88837ca1490cca17c31607': {
+    [AaveV3Optimism.ASSETS.USDC.UNDERLYING.toLowerCase()]: {
       name: 'Bridged USDC',
       symbol: 'USDC.e',
       iconSymbol: 'USDC',
     },
-    // polygon
-    '0x2791bca1f2de4661ed88a30c99a7a9449aa84174': {
+    [AaveV3Polygon.ASSETS.USDC.UNDERLYING.toLowerCase()]: {
       name: 'Bridged USDC',
       symbol: 'USDC.e',
       iconSymbol: 'USDC',

--- a/src/ui-config/reservePatches.ts
+++ b/src/ui-config/reservePatches.ts
@@ -103,8 +103,21 @@ export function fetchIconSymbolAndName({ underlyingAsset, symbol, name }: IconSy
       symbol: 'KNCL',
       iconSymbol: 'KNCL',
     },
+    // arbitrum
     '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8': {
       name: 'Bridged USDC',
+      symbol: 'USDC.e',
+      iconSymbol: 'USDC',
+    },
+    // optimism
+    '0x7f5c764cbc14f9669b88837ca1490cca17c31607': {
+      name: 'Bridged USDC',
+      symbol: 'USDC.e',
+      iconSymbol: 'USDC',
+    },
+    // polygon
+    '0x2791bca1f2de4661ed88a30c99a7a9449aa84174': {
+      name: 'USD Coin (PoS)',
       symbol: 'USDC.e',
       iconSymbol: 'USDC',
     },

--- a/src/ui-config/reservePatches.ts
+++ b/src/ui-config/reservePatches.ts
@@ -117,7 +117,7 @@ export function fetchIconSymbolAndName({ underlyingAsset, symbol, name }: IconSy
     },
     // polygon
     '0x2791bca1f2de4661ed88a30c99a7a9449aa84174': {
-      name: 'USD Coin (PoS)',
+      name: 'Bridged USDC',
       symbol: 'USDC.e',
       iconSymbol: 'USDC',
     },


### PR DESCRIPTION
## General Changes

- Updates the token display name for USDC to differentiate between bridged and native versions. Some markets have both the native and bridged versions of USDC. This change updates OP and Polygon markets so it's clear which one is being used.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
