### PR TITLE
fix: gho reserve details

### DIFF
--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1395,6 +1395,7 @@ msgstr "Max slippage"
 msgid "Maximum amount available to borrow against this asset is limited because debt ceiling is at {0}%."
 msgstr "Maximum amount available to borrow against this asset is limited because debt ceiling is at {0}%."
 
+#: src/modules/reserve-overview/BorrowInfo.tsx
 #: src/modules/reserve-overview/Gho/GhoBorrowInfo.tsx
 #: src/modules/reserve-overview/Gho/GhoBorrowInfo.tsx
 msgid "Maximum amount available to borrow is <0/> {0} (<1/>)."
@@ -1404,7 +1405,6 @@ msgstr "Maximum amount available to borrow is <0/> {0} (<1/>)."
 msgid "Maximum amount available to borrow is limited because protocol borrow cap is nearly reached."
 msgstr "Maximum amount available to borrow is limited because protocol borrow cap is nearly reached."
 
-#: src/modules/reserve-overview/BorrowInfo.tsx
 #: src/modules/reserve-overview/SupplyInfo.tsx
 msgid "Maximum amount available to supply is <0/> {0} (<1/>)."
 msgstr "Maximum amount available to supply is <0/> {0} (<1/>)."

--- a/src/modules/reserve-overview/BorrowInfo.tsx
+++ b/src/modules/reserve-overview/BorrowInfo.tsx
@@ -1,6 +1,7 @@
 import { valueToBigNumber } from '@aave/math-utils';
 import { Trans } from '@lingui/macro';
 import { Box, Typography } from '@mui/material';
+import { BigNumber } from 'bignumber.js';
 import { CapsCircularStatus } from 'src/components/caps/CapsCircularStatus';
 import { IncentivesButton } from 'src/components/incentives/IncentivesButton';
 import { VariableAPYTooltip } from 'src/components/infoTooltips/VariableAPYTooltip';
@@ -34,6 +35,16 @@ export const BorrowInfo = ({
   showBorrowCapStatus,
   borrowCap,
 }: BorrowInfoProps) => {
+  const maxAvailableToBorrow = BigNumber.max(
+    valueToBigNumber(reserve.borrowCap).minus(valueToBigNumber(reserve.totalDebt)),
+    0
+  ).toNumber();
+
+  const maxAvailableToBorrowUSD = BigNumber.max(
+    valueToBigNumber(reserve.borrowCapUSD).minus(valueToBigNumber(reserve.totalDebtUSD)),
+    0
+  ).toNumber();
+
   return (
     <Box sx={{ flexGrow: 1, minWidth: 0, maxWidth: '100%', width: '100%' }}>
       <Box
@@ -51,20 +62,11 @@ export const BorrowInfo = ({
               tooltipContent={
                 <>
                   <Trans>
-                    Maximum amount available to supply is{' '}
-                    <FormattedNumber
-                      value={
-                        valueToBigNumber(reserve.borrowCap).toNumber() -
-                        valueToBigNumber(reserve.totalDebt).toNumber()
-                      }
-                      variant="secondary12"
-                    />{' '}
+                    Maximum amount available to borrow is{' '}
+                    <FormattedNumber value={maxAvailableToBorrow} variant="secondary12" />{' '}
                     {reserve.symbol} (
                     <FormattedNumber
-                      value={
-                        valueToBigNumber(reserve.borrowCapUSD).toNumber() -
-                        valueToBigNumber(reserve.totalDebtUSD).toNumber()
-                      }
+                      value={maxAvailableToBorrowUSD}
                       variant="secondary12"
                       symbol="USD"
                     />

--- a/src/modules/reserve-overview/Gho/GhoReserveTopDetails.tsx
+++ b/src/modules/reserve-overview/Gho/GhoReserveTopDetails.tsx
@@ -3,10 +3,13 @@ import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { FormattedNumber } from 'src/components/primitives/FormattedNumber';
 import { TextWithTooltip } from 'src/components/TextWithTooltip';
 import { TopInfoPanelItem } from 'src/components/TopInfoPanel/TopInfoPanelItem';
-import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
+import {
+  ComputedReserveData,
+  useAppDataContext,
+} from 'src/hooks/app-data-provider/useAppDataProvider';
 
-export const GhoReserveTopDetails = () => {
-  const { ghoLoadingData, ghoReserveData } = useAppDataContext();
+export const GhoReserveTopDetails = ({ reserve }: { reserve: ComputedReserveData }) => {
+  const { ghoLoadingData } = useAppDataContext();
 
   const loading = ghoLoadingData;
   const theme = useTheme();
@@ -19,7 +22,7 @@ export const GhoReserveTopDetails = () => {
     <>
       <TopInfoPanelItem title={<Trans>Total borrowed</Trans>} loading={loading} hideIcon>
         <FormattedNumber
-          value={ghoReserveData.aaveFacilitatorBucketLevel}
+          value={reserve.totalDebt}
           symbol="USD"
           variant={valueTypographyVariant}
           symbolsVariant={symbolsTypographyVariant}
@@ -29,7 +32,7 @@ export const GhoReserveTopDetails = () => {
 
       <TopInfoPanelItem title={<Trans>Available to borrow</Trans>} loading={loading} hideIcon>
         <FormattedNumber
-          value={ghoReserveData.aaveFacilitatorRemainingCapacity}
+          value={reserve.borrowCap}
           symbol="USD"
           variant={valueTypographyVariant}
           symbolsVariant={symbolsTypographyVariant}

--- a/src/modules/reserve-overview/ReserveTopDetailsWrapper.tsx
+++ b/src/modules/reserve-overview/ReserveTopDetailsWrapper.tsx
@@ -207,7 +207,11 @@ export const ReserveTopDetailsWrapper = ({ underlyingAsset }: ReserveTopDetailsP
           />
         </>
       )}
-      {isGho ? <GhoReserveTopDetails /> : <ReserveTopDetails underlyingAsset={underlyingAsset} />}
+      {isGho ? (
+        <GhoReserveTopDetails reserve={poolReserve} />
+      ) : (
+        <ReserveTopDetails underlyingAsset={underlyingAsset} />
+      )}
     </TopInfoPanel>
   );
 };


### PR DESCRIPTION
## General Changes

- Updated the borrow info section on the gho reserve page to use the total debt instead of the facilitator level which fixes some inconsistencies
- Updated the top details on the gho reserve page to use the total debt instead of facilitator level
- Fixes a bug in the borrow info circular gauge tooltip where the value could show as negative if the total debt exceeded the borrow cap

Gauge should now show 100%, and tooltip should show 0 for amount available to borrow
![image](https://github.com/aave/interface/assets/23554636/a5935805-e0a5-4410-82c8-605d51252da4)

This bug is visible on Metis, USDT. It'll now show 0 in this case 
![image](https://github.com/aave/interface/assets/23554636/7a81aac1-e614-4bd9-859c-f2f5925a762a)

Reserve top details numbers are currently showing the facilitator level, but will now show total debt (interest included)
![image](https://github.com/aave/interface/assets/23554636/9de20fbc-8a41-48c6-a649-9e75bfa3614d)

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
