### PR TITLE
fix: show warning when low FH

### DIFF
--- a/cypress/e2e/4-gho-ethereum/helpers/token.helper.ts
+++ b/cypress/e2e/4-gho-ethereum/helpers/token.helper.ts
@@ -43,7 +43,7 @@ const donors: Donors = {
   },
   aMATICPolygonV3: {
     name: 'aMATIC',
-    donorWalletAddress: '0xa9F6e565A12A1D512Df641Fd703b58E620e8483E',
+    donorWalletAddress: '0x42C8e43048f6Ff3586945A1fD23e0bEc540dcD07',
     tokenAddress: '0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97',
   },
   aETHOptimismV3: {

--- a/src/modules/dashboard/lists/BorrowAssetsList/BorrowAssetsList.tsx
+++ b/src/modules/dashboard/lists/BorrowAssetsList/BorrowAssetsList.tsx
@@ -223,7 +223,7 @@ export const BorrowAssetsList = () => {
               <MarketWarning marketName="Ethereum AMM" />
             )}
 
-            {+collateralUsagePercent >= 0.98 && (
+            {user.healthFactor !== '-1' && Number(user.healthFactor) <= 1.1 && (
               <Warning severity="error">
                 <Trans>
                   Be careful - You are very close to liquidation. Consider depositing more


### PR DESCRIPTION
## General Changes

- Fixes liquidation warning showing incorrectly in the borrow list. Previously was based off of collateral usage, which will trigger warning to show incorrectly for low LTV assets. It's now based on health factor

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [x]  The PR is in `Open` state and not in `Draft` mode
- [x]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
