### PR TITLE
fix: fetch aToken symbol name on add

### DIFF
--- a/src/components/transactions/FlowCommons/Success.tsx
+++ b/src/components/transactions/FlowCommons/Success.tsx
@@ -108,7 +108,7 @@ export const TxSuccessView = ({
                 addERC20Token({
                   address: addToken.address,
                   decimals: addToken.decimals,
-                  symbol: addToken.aToken ? `a${addToken.symbol}` : addToken.symbol,
+                  symbol: addToken.aToken ? '' : addToken.symbol,
                   image: !/_/.test(addToken.symbol) ? base64 : undefined,
                 });
               }}

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -1,4 +1,4 @@
-import { API_ETH_MOCK_ADDRESS, transactionType } from '@aave/contract-helpers';
+import { API_ETH_MOCK_ADDRESS, ERC20Service, transactionType } from '@aave/contract-helpers';
 import { SignatureLike } from '@ethersproject/bytes';
 import {
   JsonRpcProvider,
@@ -404,13 +404,20 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     const injectedProvider = (window as any).ethereum;
     if (provider && account && window && injectedProvider) {
       if (address.toLowerCase() !== API_ETH_MOCK_ADDRESS.toLowerCase()) {
+        let tokenSymbol = symbol;
+        if (!tokenSymbol) {
+          const { getTokenData } = new ERC20Service(provider);
+          const { symbol } = await getTokenData(address);
+          tokenSymbol = symbol;
+        }
+
         await injectedProvider.request({
           method: 'wallet_watchAsset',
           params: {
             type: 'ERC20',
             options: {
               address,
-              symbol,
+              symbol: tokenSymbol,
               decimals,
               image,
             },

--- a/src/modules/reserve-overview/AddTokenDropdown.tsx
+++ b/src/modules/reserve-overview/AddTokenDropdown.tsx
@@ -183,7 +183,7 @@ export const AddTokenDropdown = ({
                   addERC20Token({
                     address: poolReserve.aTokenAddress,
                     decimals: poolReserve.decimals,
-                    symbol: `a${poolReserve.symbol}`,
+                    symbol: '',
                     image: !/_/.test(poolReserve.symbol) ? aTokenBase64 : undefined,
                   });
                 }


### PR DESCRIPTION
## General Changes

- Updates the 'add token' logic to fetch the token symbol from the contract. Previously it was assumed that all aToken symbols just had 'a' prefixed onto the underlying asset symbol name, which is not the case

## Developer Notes

In order to minimize the surface area of changes, I assumed that if an empty string is passed in for the symbol, it should be fetched from the contracts.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
