### PR TITLE
Feat: Add secondary IPFS Pin Server (#1973)

### DIFF
--- a/.github/workflows/update-prod-staging.yml
+++ b/.github/workflows/update-prod-staging.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Pin to secondary IPFS server
         id: ipfs-secondary
-        uses: crustio/ipfs-crust-action@v2.0.7
+        uses: crustio/ipfs-crust-action@main
         continue-on-error: true
         with:
           cid: ${{ inputs.PINATA_HASH }}

--- a/.github/workflows/update-prod-staging.yml
+++ b/.github/workflows/update-prod-staging.yml
@@ -37,6 +37,14 @@ jobs:
           BUILD_PATH: 'out'
           PINATA_HASH: '${{ inputs.PINATA_HASH }}'
 
+      - name: Pin to secondary IPFS server
+        id: ipfs-secondary
+        uses: crustio/ipfs-crust-action@v2.0.7
+        continue-on-error: true
+        with:
+          cid: ${{ inputs.PINATA_HASH }}
+          seeds: ${{ secrets.CRUST_SEEDS }}
+
       - uses: aave/cloudflare-update-action@5c1b528c9c6e0aed18a7dbdd7f957e0b8815a75e
         with:
           CF_API_TOKEN: '${{ secrets.CF_API_TOKEN }}'


### PR DESCRIPTION
## General Changes

Change the 'update-prod-staging.yml' to add secondary ipfs pin server, utilized the crustio/ipfs-crust-action action which is supported by Crust Network.

## Developer Notes

Use the "continue-on-error: true" to make sure this new action would not break the build.

Git repo administrator needs to set the 'secrets.CRUST_SEEDS' in the repo 'Setting' in order to enable this new action.

PS: Crust Network will provide free CRUST_SEEDS for Aave to use, so do not have any additional charge.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
