### PR TITLE
fix: default emode [skip cypress]

### DIFF
--- a/src/store/poolSelectors.ts
+++ b/src/store/poolSelectors.ts
@@ -66,5 +66,19 @@ export const formatEmodes = (reserves: ReserveDataHumanized[]) => {
     return acc;
   }, {} as Record<number, EmodeCategory>);
 
+  // If all reserves have an eMode cateogry other than 0, we need to add the default empty one.
+  // The UI assumes that there is always an eMode category 0, which is 'none'.
+  if (!eModes[0]) {
+    eModes[0] = {
+      liquidationBonus: 0,
+      id: 0,
+      label: '',
+      liquidationThreshold: 0,
+      ltv: 0,
+      priceSource: '0x0000000000000000000000000000000000000000',
+      assets: [],
+    };
+  }
+
   return eModes;
 };


### PR DESCRIPTION
## General Changes

- Ensures there is always a default eMode (none) if all reserves have a non-zero eMode category

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [x]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
