### PR TITLE
feat: Gho debt swap APY display

### DIFF
--- a/src/components/transactions/DebtSwitch/DebtSwitchModalDetails.tsx
+++ b/src/components/transactions/DebtSwitch/DebtSwitchModalDetails.tsx
@@ -11,7 +11,7 @@ import { TokenIcon } from 'src/components/primitives/TokenIcon';
 import { TextWithTooltip } from 'src/components/TextWithTooltip';
 import { DetailsIncentivesLine } from 'src/components/transactions/FlowCommons/TxModalDetails';
 import { CustomMarket } from 'src/ui-config/marketsConfig';
-import { weightedAverageAPY } from 'src/utils/ghoUtilities';
+import { displayGhoForMintableMarket, weightedAverageAPY } from 'src/utils/ghoUtilities';
 
 import { ComputedUserReserveData } from '../../../hooks/app-data-provider/useAppDataProvider';
 import { GhoRange } from './DebtSwitchModalContent';
@@ -89,7 +89,10 @@ export const DebtSwitchModalDetails = ({
             <Skeleton variant="rectangular" height={20} width={100} sx={{ borderRadius: '4px' }} />
           ) : (
             <>
-              {switchSource.reserve.symbol === 'GHO' && ghoData ? (
+              {displayGhoForMintableMarket({
+                symbol: switchSource.reserve.symbol,
+                currentMarket,
+              }) && ghoData ? (
                 <GhoIncentivesCard
                   useApyRange={false}
                   rangeValues={ghoData.ghoApyRange}
@@ -110,7 +113,10 @@ export const DebtSwitchModalDetails = ({
                 <FormattedNumber value={sourceBorrowAPY} variant="secondary14" percent />
               )}
               {ArrowRightIcon}
-              {switchTarget.reserve.symbol === 'GHO' && ghoData ? (
+              {displayGhoForMintableMarket({
+                symbol: switchTarget.reserve.symbol,
+                currentMarket,
+              }) && ghoData ? (
                 <GhoIncentivesCard
                   useApyRange={ghoData.qualifiesForDiscount && !ghoData.inputAmount}
                   rangeValues={ghoData.inputAmount === 0 ? ghoData.ghoApyRange : switchToRange}


### PR DESCRIPTION

## General Changes

- When GHO is not a mintable reserve (arbitrum) display the apy the same way as any other reserve.

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
