### PR TITLE
✨ Add "Supply WBTC, Borrow USDT" Merit APRs

### DIFF
--- a/src/components/incentives/IncentivesTooltipContent.tsx
+++ b/src/components/incentives/IncentivesTooltipContent.tsx
@@ -38,6 +38,11 @@ const IncentivesSymbolMap: {
     symbol: 'aUSDC',
     aToken: true,
   },
+  aEthUSDT: {
+    tokenIconSymbol: 'USDT',
+    symbol: 'aUSDT',
+    aToken: true,
+  },
 };
 
 interface IncentivesTooltipContentProps {

--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -98,7 +98,11 @@ export const useMeritIncentives = ({
         return null;
       }
 
-      const APR = data.actionsAPR[meritReserveIncentiveData.action];
+      const APR =
+        meritReserveIncentiveData.action == MeritAction.SUPPLY_WBTC_BORROW_USDT
+          ? 5
+          : data.actionsAPR[meritReserveIncentiveData.action];
+
       return {
         incentiveAPR: (APR / 100).toString(),
         rewardTokenAddress: meritReserveIncentiveData.rewardTokenAddress,

--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -53,7 +53,7 @@ const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData>> 
       protocolAction: ProtocolAction.borrow,
       customMessage: 'You must supply cbBTC and borrow USDC in order to receive merit rewards.',
     },
-    wBTC: {
+    WBTC: {
       action: MeritAction.SUPPLY_WBTC_BORROW_USDT,
       rewardTokenAddress: AaveV3Ethereum.ASSETS.USDT.A_TOKEN,
       rewardTokenSymbol: 'aEthUSDT',

--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -7,6 +7,7 @@ import { CustomMarket } from 'src/ui-config/marketsConfig';
 export enum MeritAction {
   ETHEREUM_STKGHO = 'ethereum-stkgho',
   SUPPLY_CBBTC_BORROW_USDC = 'ethereum-supply-cbbtc-borrow-usdc',
+  SUPPLY_WBTC_BORROW_USDT = 'ethereum-supply-wbtc-borrow-usdt',
 }
 
 type MeritIncentives = {
@@ -51,6 +52,20 @@ const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData>> 
       rewardTokenSymbol: 'aEthUSDC',
       protocolAction: ProtocolAction.borrow,
       customMessage: 'You must supply cbBTC and borrow USDC in order to receive merit rewards.',
+    },
+    wBTC: {
+      action: MeritAction.SUPPLY_WBTC_BORROW_USDT,
+      rewardTokenAddress: AaveV3Ethereum.ASSETS.USDT.A_TOKEN,
+      rewardTokenSymbol: 'aEthUSDT',
+      protocolAction: ProtocolAction.supply,
+      customMessage: 'You must supply wBTC and borrow USDT in order to receive merit rewards.',
+    },
+    USDT: {
+      action: MeritAction.SUPPLY_WBTC_BORROW_USDT,
+      rewardTokenAddress: AaveV3Ethereum.ASSETS.USDT.A_TOKEN,
+      rewardTokenSymbol: 'aEthUSDT',
+      protocolAction: ProtocolAction.borrow,
+      customMessage: 'You must supply cbBTC and borrow USDT in order to receive merit rewards.',
     },
   },
 };


### PR DESCRIPTION
## General Changes

This PR add the APR of a new upcoming Merit program:  "Supply WBTC, Borrow USDT"
This program incentives users that Supply WBTC AND Borrow USDT (like cbBTC/USDC, both actions are required to get the incentives). The program is paid in aUSDT.

## Developer Notes

We are currently working on the implementation of the program, it will be ready soon. In the mean time, I mocked the APR at 5%.

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
