### PR TITLE
fix: use legacy providers for testnets

### DIFF
--- a/src/services/UIPoolService.ts
+++ b/src/services/UIPoolService.ts
@@ -7,6 +7,7 @@ import {
 } from '@aave/contract-helpers';
 import { Provider } from '@ethersproject/providers';
 import { MarketDataType } from 'src/ui-config/marketsConfig';
+import { ENABLE_TESTNET } from 'src/utils/marketsAndNetworksConfig';
 
 export type UserReservesDataHumanized = {
   userReserves: UserReserveDataHumanized[];
@@ -35,6 +36,7 @@ export class UiPoolService {
 
   private useLegacyUiPoolDataProvider(marketData: MarketDataType) {
     if (
+      ENABLE_TESTNET ||
       !marketData.v3 ||
       marketData.marketTitle === 'Fantom' ||
       marketData.marketTitle === 'Harmony'


### PR DESCRIPTION
## General Changes

- Use legacy data providers for testnets since they do not have the 3.2 upgrade

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
