### PR TITLE
[Draft] feat: register new liquidity mining on Base throw Merit

### DIFF
--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -1,6 +1,6 @@
 import { ProtocolAction } from '@aave/contract-helpers';
 import { ReserveIncentiveResponse } from '@aave/math-utils/dist/esm/formatters/incentive/calculate-reserve-incentives';
-import { AaveV3Ethereum } from '@bgd-labs/aave-address-book';
+import { AaveV3Base, AaveV3Ethereum } from '@bgd-labs/aave-address-book';
 import { useQuery } from '@tanstack/react-query';
 import { CustomMarket } from 'src/ui-config/marketsConfig';
 
@@ -8,6 +8,9 @@ export enum MeritAction {
   ETHEREUM_STKGHO = 'ethereum-stkgho',
   SUPPLY_CBBTC_BORROW_USDC = 'ethereum-supply-cbbtc-borrow-usdc',
   SUPPLY_WBTC_BORROW_USDT = 'ethereum-supply-wbtc-borrow-usdt',
+  BASE_SUPPLY_CBBTC = 'base-supply-cbbtc',
+  BASE_SUPPLY_USDC = 'base-supply-usdc',
+  BASE_BORROW_USDC = 'base-borrow-usdc',
 }
 
 type MeritIncentives = {
@@ -66,6 +69,26 @@ const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData>> 
       rewardTokenSymbol: 'aEthUSDT',
       protocolAction: ProtocolAction.borrow,
       customMessage: 'You must supply wBTC and borrow USDT in order to receive merit rewards.',
+    },
+  },
+  [CustomMarket.proto_base_v3]: {
+    cbBTC: {
+      action: MeritAction.BASE_SUPPLY_CBBTC,
+      rewardTokenAddress: AaveV3Base.ASSETS.USDC.UNDERLYING,
+      rewardTokenSymbol: 'aBasUSDC',
+      protocolAction: ProtocolAction.supply,
+    },
+    USDC: {
+      action: MeritAction.BASE_SUPPLY_USDC,
+      rewardTokenAddress: AaveV3Base.ASSETS.USDC.UNDERLYING,
+      rewardTokenSymbol: 'aBasUSDC',
+      protocolAction: ProtocolAction.supply,
+    },
+    USDCBorrow: {
+      action: MeritAction.BASE_BORROW_USDC,
+      rewardTokenAddress: AaveV3Base.ASSETS.USDC.UNDERLYING,
+      rewardTokenSymbol: 'aBasUSDC',
+      protocolAction: ProtocolAction.borrow,
     },
   },
 };


### PR DESCRIPTION
## General Changes

This PR add the following campaigns to Base Mainnet:
- Supply USDC (funded by Base)
- Borrow USDC (funded by Aave DAO)
- cbBTC (funded by Base)

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
