### PR TITLE
feat: mask Merit campaign when aprs are not found

### DIFF
--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -16,7 +16,7 @@ export enum MeritAction {
 type MeritIncentives = {
   totalAPR: number;
   actionsAPR: {
-    [key in MeritAction]: number;
+    [key in MeritAction]: number | null | undefined;
   };
 };
 
@@ -140,6 +140,10 @@ export const useMeritIncentives = ({
       }
 
       const APR = data.actionsAPR[incentive.action];
+
+      if (!APR) {
+        return null;
+      }
 
       return {
         incentiveAPR: (APR / 100).toString(),


### PR DESCRIPTION
## General Changes
Merit campaigns can be temporarily paused. This pull request introduces functionality to quickly disable the incentive box during such pauses.

It's important to note that paused campaigns often indicate that clients are taking some time to reflect before deciding to renew the incentives, rather than always signaling the end of the campaign.

- mask incentive box when the corresponding Merit campaign is temporary paused, preventing the following:
<img width="100" alt="Capture d’écran 2024-11-28 à 11 51 38" src="https://github.com/user-attachments/assets/3e659cf6-f657-4758-bd1a-2f1eb8c00321">



## Developer Notes

RAS

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x]  End-to-end tests are passing without any errors
- [x]  Code changes do not significantly increase the application bundle size
- [x]  If there are new 3rd-party packages, they do not introduce potential security threats
- [x]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
