### PR TITLE
Remove staging deployment

### DIFF
--- a/.github/workflows/update-prod-staging.yml
+++ b/.github/workflows/update-prod-staging.yml
@@ -19,12 +19,6 @@ jobs:
             domain: 'app.aave.com',
             artifact: 'out',
             build_path: 'out'
-          },
-          {
-            name: 'Staging',
-            domain: 'staging.aave.com',
-            artifact: 'out_staging',
-            build_path: 'out_staging'
           }
         ]
     environment:
@@ -39,18 +33,6 @@ jobs:
           name: ${{ matrix.environment.artifact }}
           path: ${{ matrix.environment.build_path }}
 
-      # Only for staging environment
-      - name: pinata
-        id: pinata
-        if: matrix.environment.name == 'Staging'
-        uses: aave/pinata-action@35662944e92cf082457973f10aa42e48df179b47
-        with:
-          PINATA_API_KEY: '${{ secrets.PINATA_API_KEY }}'
-          PINATA_SECRET_KEY: '${{ secrets.PINATA_SECRET_KEY }}'
-          PIN_ALIAS: 'app-aave-staging'
-          BUILD_LOCATION: './out_staging'
-          CID_VERSION: 1
-
       - name: Pin to primary IPFS server
         id: ipfs-primary
         uses: ./.github/actions/ipfs-pin
@@ -60,25 +42,22 @@ jobs:
           IPFS_SERVER: '${{ secrets.IPFS_PRIMARY_SERVER }}'
           IPFS_SERVER_KEY: '${{ secrets.IPFS_PRIMARY_SERVER_KEY }}'
           BUILD_PATH: ${{ matrix.environment.build_path }}
-          PINATA_HASH: ${{ matrix.environment.name == 'Production' && inputs.PINATA_HASH || steps.pinata.outputs.hash }}
+          PINATA_HASH: ${{ inputs.PINATA_HASH }}
 
       - uses: aave/cloudflare-update-action@0f2084730a068fab162853c4e7cc40537233d34a
         with:
           CF_API_TOKEN: '${{ secrets.CF_API_TOKEN }}'
           CF_ZONE_ID: '${{ secrets.CF_ZONE_ID }}'
-          HASH: ${{ matrix.environment.name == 'Production' && inputs.PINATA_HASH || steps.pinata.outputs.hash }}
+          HASH: ${{ inputs.PINATA_HASH }}
           CF_DEPLOYMENT_DOMAIN: ${{ matrix.environment.domain }}
 
-      # Only for production environment
       - name: prepare release
-        if: matrix.environment.name == 'Production'
         run: |
           cp .github/release-template.md ./release-notes.md
           sed -i 's|<ipfs-hash>|${{ inputs.PINATA_HASH }}|g' ./release-notes.md
           echo "TAG=release-$(date '+%Y-%m-%d_%H-%M')" >> ${GITHUB_ENV}
 
       - name: Create GH release
-        if: matrix.environment.name == 'Production'
         uses: ncipollo/release-action@4c75f0f2e4ae5f3c807cf0904605408e319dcaac # v1.10.0
         with:
           name: Production release

--- a/README.md
+++ b/README.md
@@ -47,8 +47,13 @@ There's a github action commenting the appropriate IPFS hash embedded in the Clo
 
 For ease of use:
 
-- the DNS of [https://staging.aave.com](https://staging.aave.com) will always point to the latest main IPFS hash with all networks enabled
-- the DNS of [https://app.aave.com](https://app.aave.com) will always point to the latest main IPFS hash with disabled test networks
+- the DNS of [https://app.aave.com](https://app.aave.com) will always point to the latest main IPFS hash.
+
+### Testnet Networks Access
+The interface now includes a feature toggle for testnet networks. Users can enable test networks by:
+1. Opening the Settings menu
+2. Toggling the "Testnet mode" switch
+3. Once enabled, testnet networks (like Sepolia, Mumbai, etc.) will become available in the network selection menu
 
 ### Links known to work at some point:
 


### PR DESCRIPTION
As we have a feature toggle to switch to testnets we no longer have the need to maintain a separate env. 
Simplifying gh action and updating Readme.
