### PR TITLE
✨ Implement new AUSD supply Merit incentives

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@aave/contract-helpers": "1.30.5",
     "@aave/math-utils": "1.30.5",
-    "@bgd-labs/aave-address-book": "4.7.0",
+    "@bgd-labs/aave-address-book": "4.7.3",
     "@emotion/cache": "11.10.3",
     "@emotion/react": "11.10.4",
     "@emotion/server": "latest",

--- a/src/components/incentives/MeritIncentivesTooltipContent.tsx
+++ b/src/components/incentives/MeritIncentivesTooltipContent.tsx
@@ -39,7 +39,7 @@ export const MeritIncentivesTooltipContent = ({
           href={
             meritIncentives.customForumLink
               ? meritIncentives.customForumLink
-              : 'https://governance.aave.com/t/arfc-merit-a-new-aave-alignment-user-reward-system/16646'
+              : 'https://governance.aave.com/t/arfc-set-aci-as-emission-manager-for-liquidity-mining-programs/17898'
           }
           sx={{ textDecoration: 'underline' }}
           variant="caption"

--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -17,6 +17,7 @@ export enum MeritAction {
   AVALANCHE_SUPPLY_USDC = 'avalanche-supply-usdc',
   AVALANCHE_SUPPLY_USDT = 'avalanche-supply-usdt',
   AVALANCHE_SUPPLY_SAVAX = 'avalanche-supply-savax',
+  AVALANCHE_SUPPLY_AUSD = 'avalanche-supply-ausd',
 }
 
 type MeritIncentives = {
@@ -162,6 +163,14 @@ const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData[]>
       {
         action: MeritAction.AVALANCHE_SUPPLY_SAVAX,
         rewardTokenAddress: AaveV3Avalanche.ASSETS.sAVAX.A_TOKEN,
+        rewardTokenSymbol: 'aAvaSAVAX',
+        protocolAction: ProtocolAction.supply,
+      },
+    ],
+    AUSD: [
+      {
+        action: MeritAction.AVALANCHE_SUPPLY_AUSD,
+        rewardTokenAddress: AaveV3Avalanche.ASSETS.AUSD.A_TOKEN,
         rewardTokenSymbol: 'aAvaSAVAX',
         protocolAction: ProtocolAction.supply,
       },

--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -51,6 +51,8 @@ const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData[]>
         action: MeritAction.ETHEREUM_STKGHO,
         rewardTokenAddress: AaveV3Ethereum.ASSETS.GHO.UNDERLYING,
         rewardTokenSymbol: 'GHO',
+        customForumLink:
+          'https://governance.aave.com/t/arfc-merit-a-new-aave-alignment-user-reward-system/16646',
       },
     ],
     cbBTC: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,10 +1066,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bgd-labs/aave-address-book@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-address-book/-/aave-address-book-4.7.0.tgz#4d64ff67dd83f32fcff71ffe7498bf9477c8586f"
-  integrity sha512-oxLDYy36woE1AuW97aXI7bk+v+/my0YAqaWbGokLJGc+An7/ABfF89cbn9aJqAx3fyT8DDRojGyrcGIeocnNBg==
+"@bgd-labs/aave-address-book@4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-address-book/-/aave-address-book-4.7.3.tgz#8a2ca1ca3b2e67474c0b07ea8e681a1400f3bc5b"
+  integrity sha512-4/QS5hLcjKuHAfdOAgaxSWVvi6RKu/U5ZHyndptvvKcNmzcC60tczN3NALCqWNXCBmzFY5e6cg82KsZJqVEjOQ==
 
 "@coinbase/wallet-sdk@4.2.3":
   version "4.2.3"


### PR DESCRIPTION
## General Changes

- update aave-address-book lib (in order to get the new AUSD token from Avalanche market)
- add a new avalanche-supply-ausd (not lived yet)
- change default forum link for the LM incentives one

## Developer Notes

You can see the result when the campaign will be lived by mocking API response: 
Put `meritIncentives.actionsAPR[MeritAction.AVALANCHE_SUPPLY_AUSD] = 0.1;` after Line 194 of `useMeritIncentives.ts`

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
