### PR TITLE
Remove unnecessary slash in explorer links [skip cypress]

### DIFF
--- a/src/ui-config/networksConfig.ts
+++ b/src/ui-config/networksConfig.ts
@@ -267,7 +267,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     baseAssetSymbol: 'ETH',
     wrappedBaseAssetSymbol: 'WETH',
     baseAssetDecimals: 18,
-    explorerLink: 'https://sepolia.basescan.org/',
+    explorerLink: 'https://sepolia.basescan.org',
     isTestnet: true,
     networkLogoPath: '/icons/networks/base.svg',
   },
@@ -354,7 +354,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     baseAssetSymbol: 'BNB',
     wrappedBaseAssetSymbol: 'WBNB',
     baseAssetDecimals: 18,
-    explorerLink: 'https://bscscan.com/',
+    explorerLink: 'https://bscscan.com',
     networkLogoPath: '/icons/networks/binance.svg',
     bridge: {
       icon: '/icons/networks/binance.svg',
@@ -371,7 +371,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     baseAssetSymbol: 'ETH',
     wrappedBaseAssetSymbol: 'WETH',
     baseAssetDecimals: 18,
-    explorerLink: 'https://scrollscan.com/',
+    explorerLink: 'https://scrollscan.com',
     networkLogoPath: '/icons/networks/scroll.svg',
     bridge: {
       icon: '/icons/networks/scroll.svg',
@@ -387,7 +387,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     baseAssetSymbol: 'ETH',
     wrappedBaseAssetSymbol: 'WETH',
     baseAssetDecimals: 18,
-    explorerLink: 'https://era.zksync.network/',
+    explorerLink: 'https://era.zksync.network',
     networkLogoPath: '/icons/networks/zksync.svg',
     bridge: {
       icon: '/icons/networks/zksync.svg',


### PR DESCRIPTION
## General Changes

- Fixes extra slash in explorer link for base_sepolia, bnb, scroll, and zksync

## Developer Notes

Related to https://github.com/aave/interface/issues/2315

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
