### PR TITLE
fix: gho debt amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@aave/contract-helpers": "1.31.1",
-    "@aave/math-utils": "1.31.1",
+    "@aave/contract-helpers": "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2",
+    "@aave/math-utils": "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2",
     "@bgd-labs/aave-address-book": "4.10.0",
     "@emotion/cache": "11.10.3",
     "@emotion/react": "11.10.4",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@aave/contract-helpers": "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc",
-    "@aave/math-utils": "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc",
+    "@aave/contract-helpers": "1.32.1",
+    "@aave/math-utils": "1.32.1",
     "@bgd-labs/aave-address-book": "4.10.0",
     "@emotion/cache": "11.10.3",
     "@emotion/react": "11.10.4",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@aave/contract-helpers": "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2",
-    "@aave/math-utils": "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2",
+    "@aave/contract-helpers": "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc",
+    "@aave/math-utils": "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc",
     "@bgd-labs/aave-address-book": "4.10.0",
     "@emotion/cache": "11.10.3",
     "@emotion/react": "11.10.4",

--- a/src/hooks/pool/useUserYield.ts
+++ b/src/hooks/pool/useUserYield.ts
@@ -155,7 +155,7 @@ export const useUserYields = (
     ) => {
       return formatUserYield(formattedPoolReserves, undefined, undefined, user, marketData.market);
     };
-    if (GHO_MINTING_MARKETS.includes(marketData.marketTitle))
+    if (GHO_MINTING_MARKETS.includes(marketData.market))
       return combineQueries(
         [
           elem,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@aave/contract-helpers@1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2":
-  version "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0"
-  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0.tgz#36ee0356a466fdaaab52e3868d55960141bcbf03"
-  integrity sha512-QjckCXsAjyiivVGuWaiHB9PKI6A4h2nXFtszLLe1v7PPp/OMdJcqpmEp33jMYD8yy4A4zvf2yFXYbMvAvFFfmg==
+"@aave/contract-helpers@1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc":
+  version "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0"
+  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0.tgz#f8e7933711b2e96ca25a791b6c6c02e706708407"
+  integrity sha512-D1uUUJTNPOGA3ScD0JpHJNrBuvLuiWEK3+OG85hO8LqSzAyimQpdBb0macpW4p/y41EXTFGSQ25Loxyt8sF/CA==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 
-"@aave/math-utils@1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2":
-  version "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0"
-  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0.tgz#444424a3a984a99a2061c44c2b856ea395565091"
-  integrity sha512-sVWvhR3OqQPZk6OA8ogxC9/WBh8rMDVkRuu87EbxjZ6zNatpmFeaZSpfi6L+zxW2kPfzLwan3dDazB/Mswonnw==
+"@aave/math-utils@1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc":
+  version "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0"
+  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0.tgz#78bcb2eb6290c1261c9998ec4a490cedfdbb4089"
+  integrity sha512-3WnxOWa1CdKqvZgkETJ/pkHtLupZr+bgBDkXHg/Lt/QHn+e8FVSE3X6TYjoSvyMYXQteEsAqbuu1r84XbwRAXg==
 
 "@adobe/css-tools@^4.0.1":
   version "4.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@aave/contract-helpers@1.31.1":
-  version "1.31.1"
-  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.31.1.tgz#e0464847f18b7daa063cd5f1a1926c4b7ffce767"
-  integrity sha512-68/RIxOSZXpAJ0CbzN25tPDGF0QUoVbJQ6c7UDtA1hT2aL5g06URqHKhdIg1+Jvnz4VU8Qu0YYC26F5K+lVUcQ==
+"@aave/contract-helpers@1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2":
+  version "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0"
+  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0.tgz#36ee0356a466fdaaab52e3868d55960141bcbf03"
+  integrity sha512-QjckCXsAjyiivVGuWaiHB9PKI6A4h2nXFtszLLe1v7PPp/OMdJcqpmEp33jMYD8yy4A4zvf2yFXYbMvAvFFfmg==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 
-"@aave/math-utils@1.31.1":
-  version "1.31.1"
-  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.31.1.tgz#f465a316c1b59b75b112b772236118541e14b716"
-  integrity sha512-thdudjGLygOhvDlhhndhSZjVcwglWfYROv1z6qfx9c4LsyiVITAxfz1FLUXbjEOI3kirHitl060Ng4rNuYjT1Q==
+"@aave/math-utils@1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0+92932f2":
+  version "1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0"
+  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.32.1-bd72feb3714d34adba7f999d58e81efe29b4c376.0.tgz#444424a3a984a99a2061c44c2b856ea395565091"
+  integrity sha512-sVWvhR3OqQPZk6OA8ogxC9/WBh8rMDVkRuu87EbxjZ6zNatpmFeaZSpfi6L+zxW2kPfzLwan3dDazB/Mswonnw==
 
 "@adobe/css-tools@^4.0.1":
   version "4.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@aave/contract-helpers@1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc":
-  version "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0"
-  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0.tgz#f8e7933711b2e96ca25a791b6c6c02e706708407"
-  integrity sha512-D1uUUJTNPOGA3ScD0JpHJNrBuvLuiWEK3+OG85hO8LqSzAyimQpdBb0macpW4p/y41EXTFGSQ25Loxyt8sF/CA==
+"@aave/contract-helpers@1.32.1":
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.32.1.tgz#ad3e216118f282f450b7ab160bd270930ccf5fa4"
+  integrity sha512-iYkopRnzbfnW7Pxa/qNmqVJVSCWKqF14FNK9SKpmLAkndH8P0UZqSkIdcnvW/ekNx6cyGIc506gKc00j5OnegQ==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 
-"@aave/math-utils@1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0+61cb6dc":
-  version "1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0"
-  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.32.1-db28ac7c7ab64d0fa77194db52bfba21a935914b.0.tgz#78bcb2eb6290c1261c9998ec4a490cedfdbb4089"
-  integrity sha512-3WnxOWa1CdKqvZgkETJ/pkHtLupZr+bgBDkXHg/Lt/QHn+e8FVSE3X6TYjoSvyMYXQteEsAqbuu1r84XbwRAXg==
+"@aave/math-utils@1.32.1":
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.32.1.tgz#9cd4bb9343f2fabb078b6ca61b5845c7044fe643"
+  integrity sha512-uLjwGNEOilWWguW7CX6Dwsk9uP4aT9HmOCzXpHqDrPbR2oGSLV8BlvHWx/8wzY9Cdt5Jr4ofP0vm/Xs4lrgDNg==
 
 "@adobe/css-tools@^4.0.1":
   version "4.4.1"


### PR DESCRIPTION
## General Changes

- Updates utils packages which includes fix properly calculating a users gho debt balance with a discount applied
- Updates reserves in app data provider in the case where the user does have a gho discount so the correct amount can be used throughout the app
- Fixes a bug where the discount rate wasn't being factored into the users weighted average borrow apy displayed

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
