### PR TITLE
fix: allow withdrawals having an ltv=0 asset if total borrows are zero

### DIFF
--- a/src/hooks/useZeroLTVBlockingWithdraw.tsx
+++ b/src/hooks/useZeroLTVBlockingWithdraw.tsx
@@ -10,6 +10,10 @@ export const useZeroLTVBlockingWithdraw = () => {
     return [];
   }
 
+  if (userSummary.totalBorrowsUSD === '0') {
+    return [];
+  }
+
   const zeroLTVBlockingWithdraw: string[] = [];
   userSummary.userReservesData.forEach((userReserve) => {
     if (


### PR DESCRIPTION
## General Changes
 
Fixing an issue reported by an user that blocked him to withdraw while having assets with LTV=0.

Co-Authored with @grothem 