### PR TITLE
chore(e2e): migrate from tenderly forks to virtual testnets

### DIFF
--- a/cypress/support/steps/configuration.steps.ts
+++ b/cypress/support/steps/configuration.steps.ts
@@ -25,7 +25,7 @@ export const configEnvWithTenderly = ({
   enableTestnet?: boolean;
   urlSuffix?: string;
 }) => {
-  const tenderly = new TenderlyVnet({ forkNetworkID: chainId });
+  const tenderly = new TenderlyVnet({ vnetNetworkID: chainId });
   const walletAddress: string = wallet != null ? wallet.address : DEFAULT_TEST_ACCOUNT.address;
   const privateKey: string = wallet != null ? wallet.privateKey : DEFAULT_TEST_ACCOUNT.privateKey;
   let provider: JsonRpcProvider;

--- a/cypress/support/steps/configuration.steps.ts
+++ b/cypress/support/steps/configuration.steps.ts
@@ -3,7 +3,7 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 
 import { CustomizedBridge } from '../tools/bridge';
-import { DEFAULT_TEST_ACCOUNT, TenderlyFork } from '../tools/tenderly';
+import { DEFAULT_TEST_ACCOUNT, TenderlyVnet } from '../tools/tenderly';
 
 const URL = Cypress.env('URL');
 const PERSIST_FORK_AFTER_RUN = Cypress.env('PERSIST_FORK_AFTER_RUN') || false;
@@ -25,7 +25,7 @@ export const configEnvWithTenderly = ({
   enableTestnet?: boolean;
   urlSuffix?: string;
 }) => {
-  const tenderly = new TenderlyFork({ forkNetworkID: chainId });
+  const tenderly = new TenderlyVnet({ forkNetworkID: chainId });
   const walletAddress: string = wallet != null ? wallet.address : DEFAULT_TEST_ACCOUNT.address;
   const privateKey: string = wallet != null ? wallet.privateKey : DEFAULT_TEST_ACCOUNT.privateKey;
   let provider: JsonRpcProvider;
@@ -94,8 +94,8 @@ export const configEnvWithTenderly = ({
   });
   after(async () => {
     if (!PERSIST_FORK_AFTER_RUN) {
-      cy.log('deleting fork');
-      await tenderly.deleteFork();
+      cy.log('deleting vnet');
+      await tenderly.deleteVnet();
     }
   });
 };

--- a/cypress/support/tools/tenderly.ts
+++ b/cypress/support/tools/tenderly.ts
@@ -29,8 +29,8 @@ export class TenderlyVnet {
   private _vnet_admin_rpc: string;
   private vnet_id?: string;
 
-  constructor({ forkNetworkID }: { forkNetworkID: number }) {
-    this._vnetNetworkID = forkNetworkID;
+  constructor({ vnetNetworkID }: { vnetNetworkID: number }) {
+    this._vnetNetworkID = vnetNetworkID;
     this._chainID = 3030;
     this._vnet_admin_rpc = '';
   }

--- a/cypress/support/tools/tenderly.ts
+++ b/cypress/support/tools/tenderly.ts
@@ -23,20 +23,22 @@ const tenderly = axios.create({
   },
 });
 
-export class TenderlyFork {
+export class TenderlyVnet {
   public _vnetNetworkID: number;
   public _chainID: number;
+  private _vnet_admin_rpc: string;
   private vnet_id?: string;
-  private vnet_admin_rpc?: string;
 
   constructor({ forkNetworkID }: { forkNetworkID: number }) {
     this._vnetNetworkID = forkNetworkID;
     this._chainID = 3030;
+    this._vnet_admin_rpc = '';
   }
 
-  private checkForkInitialized() {
+  private checkVnetInitialized() {
     if (!this.vnet_id) throw new Error('Vnet not initialized!');
-    if (!this.vnet_admin_rpc) throw new Error('Vnet not initialized! Admin RPC url not found!');
+    if (this._vnet_admin_rpc == '')
+      throw new Error('Vnet not initialized! Admin RPC url not found!');
   }
 
   async init() {
@@ -53,18 +55,18 @@ export class TenderlyFork {
       }
     );
     this.vnet_id = response.data.id;
-    this.vnet_admin_rpc = response.data.rpcs.find(
+    this._vnet_admin_rpc = response.data.rpcs.find(
       (rpc: { name: string }) => rpc.name === 'Admin RPC'
     )?.url;
   }
 
   get_rpc_url() {
-    this.checkForkInitialized();
-    return this.vnet_admin_rpc;
+    this.checkVnetInitialized();
+    return this._vnet_admin_rpc;
   }
 
   async add_balance_rpc(address: string) {
-    this.checkForkInitialized();
+    this.checkVnetInitialized();
     return axios({
       url: this.get_rpc_url(),
       method: 'post',
@@ -126,7 +128,7 @@ export class TenderlyFork {
     return res;
   }
 
-  async deleteFork() {
+  async deleteVnet() {
     await tenderly.delete(
       `account/${TENDERLY_ACCOUNT}/project/${TENDERLY_PROJECT}/vnets/${this.vnet_id}`
     );


### PR DESCRIPTION
## General Changes

- Changes tenderly fork dependency with virtual testnets (vnet term is used in code)

## Developer Notes

Tests result is the same as with tenderly forks. I am just not sure if it is expecting.
`yarn dev`
`DOTENV_CONFIG_PATH='.env.local' yarn run test:headless` 
https://app.warp.dev/block/7DcfA8QJeMqf9tbgsCkcTq

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
