### PR TITLE
fix: decimals formatting when number is 1 

### DIFF
--- a/src/components/primitives/FormattedNumber.tsx
+++ b/src/components/primitives/FormattedNumber.tsx
@@ -89,7 +89,7 @@ export function FormattedNumber({
   if (number === 0) {
     decimals = 0;
   } else if (visibleDecimals === undefined) {
-    if (number > 1 || percent || symbol === 'USD') {
+    if (number >= 1 || percent || symbol === 'USD') {
       decimals = 2;
     } else {
       decimals = 7;


### PR DESCRIPTION
Fix 7 decimals when number is 1

We are currently showing 1.0000000
Let's be consistent and show 1.00 with two decimals.