### PR TITLE
chore: patch sonic usdc [skip cypress]

### DIFF
--- a/src/ui-config/reservePatches.ts
+++ b/src/ui-config/reservePatches.ts
@@ -3,6 +3,7 @@ import {
   AaveV3Gnosis,
   AaveV3Optimism,
   AaveV3Polygon,
+  AaveV3Sonic,
 } from '@bgd-labs/aave-address-book';
 import { unPrefixSymbol } from 'src/hooks/app-data-provider/useAppDataProvider';
 
@@ -133,6 +134,11 @@ export function fetchIconSymbolAndName({ underlyingAsset, symbol, name }: IconSy
       name: 'Savings xDAI',
       symbol: 'sDAI',
       iconSymbol: 'gnosissdai',
+    },
+    [AaveV3Sonic.ASSETS.USDCe.UNDERLYING.toLowerCase()]: {
+      name: 'USDC',
+      symbol: 'USDC',
+      iconSymbol: 'USDC',
     },
     '0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c': {
       name: 'BTCB Token',


### PR DESCRIPTION
Updated USDC reserve name since it's now the native asset on sonic. Contracts will be updated soon, so putting in a patch until they are.