### PR TITLE
fix: truncated paraswap approval amounts[skip cypress]

### DIFF
--- a/src/hooks/paraswap/common.ts
+++ b/src/hooks/paraswap/common.ts
@@ -448,7 +448,9 @@ export const SIGNATURE_AMOUNT_MARGIN = 0.1;
 
 // Calculate aToken amount to request for signature, adding small margin to account for accruing interest
 export const calculateSignedAmount = (amount: string, decimals: number, margin?: number) => {
-  const amountWithMargin = Number(amount) + Number(amount) * (margin ?? SIGNATURE_AMOUNT_MARGIN); // 10% margin for aToken interest accrual, custom amount for actions where output amount is variable
+  const amountBN = valueToBigNumber(amount);
+  const marginBN = valueToBigNumber(margin ?? SIGNATURE_AMOUNT_MARGIN);
+  const amountWithMargin = amountBN.plus(amountBN.multipliedBy(marginBN));
   const formattedAmountWithMargin = valueToWei(amountWithMargin.toString(), decimals);
   return formattedAmountWithMargin;
 };


### PR DESCRIPTION
Fixing edge case for truncated amounts.
Example:
```     
const bigAmount = "9007199254740992001"; // 2^53 + 1
console.log("Input string:", bigAmount);
console.log("Number(bigAmount):", Number(bigAmount));
console.log("calculateSignedAmount(bigAmount, 0, 0):", calculateSignedAmount(bigAmount, 0, 0));      

Input string:                           9007199254740992001
Number(bigAmount):                      9007199254740992000
calculateSignedAmount(bigAmount, 0, 0): 9007199254740992000
```

Now using BigNumber.

```
without margin
Input string: 9007199254740992001
Number(bigAmount): 9007199254740992000
amountBN 9007199254740992001
marginBN 0
amountWithMargin 9007199254740992001
alculateSignedAmount(bigAmount, 0, 0): 9007199254740992001


with margin

Input string: 9007199254740992001
Number(bigAmount): 9007199254740992000
amountBN 9007199254740992001
marginBN 0.1
amountWithMargin 9907919180215091201.1
calculateSignedAmount(bigAmount, 0, 0): 9907919180215091201
```