### PR TITLE
fix: update docs urls in the menu

### DIFF
--- a/cypress/e2e/2-settings/switch-tabs.cy.ts
+++ b/cypress/e2e/2-settings/switch-tabs.cy.ts
@@ -33,8 +33,8 @@ describe.skip('Switch tabs in header', () => {
 
   it('step4: Switch from Governance to More', () => {
     cy.get('#more-button').click();
-    checkLinkOfButtons('FAQ', 'https://docs.aave.com/faq/governance');
-    checkLinkOfButtons('Developers', 'https://docs.aave.com/portal/');
+    checkLinkOfButtons('FAQ', 'https://aave.com/faq');
+    checkLinkOfButtons('Developers', 'https://aave.com/docs');
     checkLinkOfButtons('Github', 'https://github.com/aave/interface');
   });
 });

--- a/src/ui-config/menu-items/index.tsx
+++ b/src/ui-config/menu-items/index.tsx
@@ -61,12 +61,12 @@ interface MoreMenuItem extends Navigation {
 
 const moreMenuItems: MoreMenuItem[] = [
   {
-    link: 'https://docs.aave.com/faq/',
+    link: 'https://aave.com/faq/',
     title: t`FAQ`,
     icon: <QuestionMarkCircleIcon />,
   },
   {
-    link: 'https://docs.aave.com/portal/',
+    link: 'https://aave.com/docs/',
     title: t`Developers`,
     icon: <BookOpenIcon />,
   },


### PR DESCRIPTION
## General Changes

- Updated FAQ to aave.com/faq
- Updated docs to aave.com/doc

## Developer Notes

Modified  `cypress/e2e/2-settings/switch-tabs.cy.ts` and `src/ui-config/menu-items/index.tsx` to match current docs urls

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x]  End-to-end tests are passing without any errors
- [x]  Code changes do not significantly increase the application bundle size
- [x]  If there are new 3rd-party packages, they do not introduce potential security threats
- [x]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
