### PR TITLE
feat: forcing a minimum slippage for cow eth-flow orders

### DIFF
--- a/src/components/transactions/Switch/BaseSwitchModalContent.tsx
+++ b/src/components/transactions/Switch/BaseSwitchModalContent.tsx
@@ -119,7 +119,6 @@ export const BaseSwitchModalContent = ({
   showChangeNetworkWarning?: boolean;
 } & SwitchModalCustomizableProps) => {
   // State
-  const [slippage, setSlippage] = useState('0.10');
   const [inputAmount, setInputAmount] = useState('');
   const [debounceInputAmount, setDebounceInputAmount] = useState('');
   const { mainTxState: switchTxState, gasLimit, txError, setTxError, close } = useModalContext();
@@ -132,14 +131,10 @@ export const BaseSwitchModalContent = ({
     return defaultNetwork.chainId;
   });
   const switchProvider = useSwitchProvider({ chainId: selectedChainId });
+  const [slippage, setSlippage] = useState(switchProvider == 'cowprotocol' ? '2' : '0.10');
   const [showGasStation, setShowGasStation] = useState(switchProvider == 'paraswap');
   const selectedNetworkConfig = getNetworkConfig(selectedChainId);
   const isWrongNetwork = useIsWrongNetwork(selectedChainId);
-  const slippageValidation = validateSlippage(slippage, switchProvider);
-  const safeSlippage =
-    slippageValidation && slippageValidation.severity === ValidationSeverity.ERROR
-      ? 0
-      : Number(slippage) / 100;
 
   const [filteredTokens, setFilteredTokens] = useState<TokenInfoWithBalance[]>(initialFromTokens);
   const { data: baseTokenList, refetch: refetchBaseTokenList } = useTokensBalance(
@@ -294,6 +289,17 @@ export const BaseSwitchModalContent = ({
   useEffect(() => {
     setSelectedOutputToken(defaultOutputToken);
   }, [defaultOutputToken]);
+
+  const slippageValidation = validateSlippage(
+    slippage,
+    selectedChainId,
+    isNativeToken(selectedInputToken?.address),
+    switchProvider
+  );
+  const safeSlippage =
+    slippageValidation && slippageValidation.severity === ValidationSeverity.ERROR
+      ? 0
+      : Number(slippage) / 100;
 
   // Data
   const {

--- a/src/components/transactions/Switch/SwitchSlippageSelector.tsx
+++ b/src/components/transactions/Switch/SwitchSlippageSelector.tsx
@@ -17,7 +17,7 @@ import { Warning } from 'src/components/primitives/Warning';
 
 import { ValidationData } from './validation.helpers';
 
-const DEFAULT_SLIPPAGE_OPTIONS = ['0.10', '0.50', '1.00'];
+const DEFAULT_SLIPPAGE_OPTIONS = ['0.10', '0.50', '2.0'];
 
 type SwitchSlippageSelectorProps = {
   slippage: string;

--- a/src/components/transactions/Switch/validation.helpers.ts
+++ b/src/components/transactions/Switch/validation.helpers.ts
@@ -12,40 +12,58 @@ export interface ValidationData {
 
 export const validateSlippage = (
   slippage: string,
+  chainId: number,
+  isNativeToken = false,
   provider?: SwitchProvider
 ): ValidationData | undefined => {
   try {
+    const numberSlippage = Number(slippage);
     if (provider === 'cowprotocol') {
+      if (isNativeToken) {
+        if (chainId === 1) {
+          if (numberSlippage < 2) {
+            return {
+              message: 'Slippage lower than 2% may result in failed transactions',
+              severity: ValidationSeverity.ERROR,
+            };
+          }
+        } else {
+          if (numberSlippage < 0.5) {
+            return {
+              message: 'Slippage lower than 0.5% may result in failed transactions',
+              severity: ValidationSeverity.ERROR,
+            };
+          }
+        }
+      }
+    } else {
+      if (Number.isNaN(numberSlippage))
+        return {
+          message: 'Invalid slippage',
+          severity: ValidationSeverity.ERROR,
+        };
+      if (numberSlippage > 30)
+        return {
+          message: 'Slippage must be lower 30%',
+          severity: ValidationSeverity.ERROR,
+        };
+      if (numberSlippage < 0)
+        return {
+          message: 'Slippage must be positive',
+          severity: ValidationSeverity.ERROR,
+        };
+      if (numberSlippage > 10)
+        return {
+          message: 'High slippage',
+          severity: ValidationSeverity.WARNING,
+        };
+      if (numberSlippage < 0.1)
+        return {
+          message: 'Slippage lower than 0.1% may result in failed transactions',
+          severity: ValidationSeverity.WARNING,
+        };
       return undefined;
     }
-
-    const numberSlippage = Number(slippage);
-    if (Number.isNaN(numberSlippage))
-      return {
-        message: 'Invalid slippage',
-        severity: ValidationSeverity.ERROR,
-      };
-    if (numberSlippage > 30)
-      return {
-        message: 'Slippage must be lower 30%',
-        severity: ValidationSeverity.ERROR,
-      };
-    if (numberSlippage < 0)
-      return {
-        message: 'Slippage must be positive',
-        severity: ValidationSeverity.ERROR,
-      };
-    if (numberSlippage > 10)
-      return {
-        message: 'High slippage',
-        severity: ValidationSeverity.WARNING,
-      };
-    if (numberSlippage < 0.1)
-      return {
-        message: 'Slippage lower than 0.1% may result in failed transactions',
-        severity: ValidationSeverity.WARNING,
-      };
-    return undefined;
   } catch {
     return { message: 'Invalid slippage', severity: ValidationSeverity.ERROR };
   }


### PR DESCRIPTION
By recommendation of the CoW team, we now force a minimum slippage for swaps using the eth-flow, this is a safe-check for potential automatic reimbursements using cow infra in case of expired quotes due to slow network effects. 

<img width="421" alt="image" src="https://github.com/user-attachments/assets/a2bff870-ebb0-43ff-80c2-0cb7223ca4c8" />

Closes AAVE-451