### PR TITLE
🔧 Disable SPK airdrop tooltip

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -87,7 +87,7 @@ export const showExternalIncentivesTooltip = (
   protocolAction?: ProtocolAction
 ) => {
   const superFestRewardsEnabled = false;
-  const spkRewardsEnabled = true;
+  const spkRewardsEnabled = false;
   const kernelPointsEnabled = true;
 
   const tooltipsConfig: ExternalIncentivesTooltipsConfig = {


### PR DESCRIPTION
## General Changes

This PR remove the $SPK Pre-farming airdrop tooltip, as the airdrop has ended.

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
