### PR TITLE
feat: use new sgho Merit key for former stkgho

### DIFF
--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -14,7 +14,7 @@ import { useQuery } from '@tanstack/react-query';
 import { CustomMarket } from 'src/ui-config/marketsConfig';
 
 export enum MeritAction {
-  ETHEREUM_STKGHO = 'ethereum-stkgho',
+  ETHEREUM_SGHO = 'ethereum-sgho',
   ETHEREUM_SUPPLY_PYUSD = 'ethereum-supply-pyusd',
   ETHEREUM_SUPPLY_ETHX = 'ethereum-supply-ethx',
   ETHEREUM_SUPPLY_RLUSD = 'ethereum-supply-rlusd',
@@ -115,7 +115,7 @@ const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData[]>
   [CustomMarket.proto_mainnet_v3]: {
     GHO: [
       {
-        action: MeritAction.ETHEREUM_STKGHO,
+        action: MeritAction.ETHEREUM_SGHO,
         rewardTokenAddress: AaveV3Ethereum.ASSETS.GHO.UNDERLYING,
         rewardTokenSymbol: 'GHO',
         customForumLink:


### PR DESCRIPTION
## General Changes

Upgrade sgho Merit root to avoid using currently depreciated sktGHO root

- [x] check that APR is still well display after the change



## Developer Notes

I'm in charge of [ACI Merit endpoint](https://apps.aavechan.com/api/merit/aprs) and created this pull request to upgrade the current root key as currently used is deprecated since Umbrella deployment.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
