### PR TITLE
fix: slippage input rounding

### DIFF
--- a/src/hooks/paraswap/common.ts
+++ b/src/hooks/paraswap/common.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { ChainId, valueToWei } from '@aave/contract-helpers';
 import { normalize, normalizeBN, valueToBigNumber } from '@aave/math-utils';
 import {
@@ -463,7 +464,7 @@ export const maxInputAmountWithSlippage = (
   if (inputAmount === '0') return '0';
   return valueToBigNumber(inputAmount)
     .multipliedBy(1 + Number(slippage) / 100)
-    .toFixed(decimals);
+    .toFixed(decimals, BigNumber.ROUND_UP);
 };
 
 export const minimumReceivedAfterSlippage = (

--- a/src/hooks/paraswap/common.ts
+++ b/src/hooks/paraswap/common.ts
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js';
 import { ChainId, valueToWei } from '@aave/contract-helpers';
 import { normalize, normalizeBN, valueToBigNumber } from '@aave/math-utils';
 import {
@@ -23,6 +22,7 @@ import {
   TransactionParams,
 } from '@paraswap/sdk';
 import { GetRateFunctions, RateOptions } from '@paraswap/sdk/dist/methods/swap/rates';
+import { BigNumber } from 'bignumber.js';
 
 import { ComputedReserveData } from '../app-data-provider/useAppDataProvider';
 


### PR DESCRIPTION
## General Changes

- Round up on slippage input amount calcs. This fixes an issue where some swaps could fail due to a 1 wei precision error.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
