### PR TITLE
feat: add Masiv Avalanche supply GHO incentive

### DIFF
--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -48,6 +48,7 @@ export enum MeritAction {
   AVALANCHE_SUPPLY_USDT = 'avalanche-supply-usdt',
   AVALANCHE_SUPPLY_SAVAX = 'avalanche-supply-savax',
   AVALANCHE_SUPPLY_AUSD = 'avalanche-supply-ausd',
+  AVALANCHE_SUPPLY_GHO = 'avalanche-supply-gho',
   SONIC_SUPPLY_USDCE = 'sonic-supply-usdce',
   SONIC_SUPPLY_STS_BORROW_WS = 'sonic-supply-sts-borrow-ws',
   GNOSIS_BORROW_EURE = 'gnosis-borrow-eure',
@@ -514,6 +515,15 @@ const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData[]>
         protocolAction: ProtocolAction.supply,
         customMessage: antiLoopMessage,
         customForumLink: AusdRenewalForumLink,
+      },
+    ],
+    GHO: [
+      {
+        action: MeritAction.AVALANCHE_SUPPLY_GHO,
+        rewardTokenAddress: AaveV3Avalanche.ASSETS.GHO.A_TOKEN,
+        rewardTokenSymbol: 'aAvaSAVAX',
+        protocolAction: ProtocolAction.supply,
+        customMessage: antiLoopMessage,
       },
     ],
   },


### PR DESCRIPTION
## General Changes

Add display of Avalanche supply GHO incentive that will be launched this week in sync with Ava Labs and Tokenlogic


## Developer Notes
I enforce display of incentive to verify if display is correct.
<img width="613" height="95" alt="Capture d’écran 2025-07-28 à 16 33 25" src="https://github.com/user-attachments/assets/1ee725d3-726d-48e9-81d5-a58f78fec341" />

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
