### PR TITLE
fix: Remove USDe Liquid Leverage APR hardcode

### DIFF
--- a/src/hooks/useMerklIncentives.ts
+++ b/src/hooks/useMerklIncentives.ts
@@ -128,14 +128,7 @@ const additionalIncentiveData: Record<string, ReserveIncentiveAdditionalData> = 
   },
 };
 
-const hardcodedIncentives: Record<string, ExtendedReserveIncentiveResponse> = {
-  [AaveV3Ethereum.ASSETS.USDe.A_TOKEN]: {
-    incentiveAPR: '0.12',
-    rewardTokenAddress: AaveV3Ethereum.ASSETS.USDe.A_TOKEN,
-    rewardTokenSymbol: 'aEthUSDe',
-    ...additionalIncentiveData[AaveV3Ethereum.ASSETS.USDe.A_TOKEN],
-  },
-};
+const hardcodedIncentives: Record<string, ExtendedReserveIncentiveResponse> = {};
 
 const getUnderlyingAndAToken = (assets: {
   [key: string]: {


### PR DESCRIPTION
## General Changes

it removes the USDe Liquid Leverage APR hardocde because the campaigns will be very soon push to Merkl, so need to hardcode it anymore.

This PR will need to be merge as soon as Campaign APR will be available on Merkl

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
