### PR TITLE
feat: add GHO on Gnosis

### DIFF
--- a/src/components/transactions/Bridge/BridgeConfig.ts
+++ b/src/components/transactions/Bridge/BridgeConfig.ts
@@ -6,6 +6,7 @@ import {
   AaveV3Base,
   AaveV3BaseSepolia,
   AaveV3Ethereum,
+  AaveV3Gnosis,
   AaveV3Sepolia,
   GhoArbitrum,
   GhoBase,
@@ -171,6 +172,30 @@ const prodConfig: Config[] = [
         decimals: 18,
         address: constants.AddressZero, // Use zero address for network token ccip
         chainId: ChainId.avalanche,
+        logoURI:
+          'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png',
+        extensions: {
+          isNative: true,
+        },
+        balance: '0',
+      },
+    ],
+  },
+  {
+    sourceChainId: ChainId.xdai,
+    chainSelector: '465200170687744372',
+    burnMintTokenPool: '0xDe6539018B095353A40753Dc54C91C68c9487D4E',
+    router: '0x4aAD6071085df840abD9Baf1697d5D5992bDadce',
+    tokenOracle: '0x360d8aa8F6b09B7BC57aF34db2Eb84dD87bf4d12',
+    wrappedNativeOracle: AaveV3Gnosis.ASSETS.WXDAI.ORACLE,
+    subgraphUrl: ``,
+    feeTokens: [
+      {
+        name: 'xDAI',
+        symbol: 'xDAI',
+        decimals: 18,
+        address: constants.AddressZero, // Use zero address for network token ccip
+        chainId: ChainId.xdai,
         logoURI:
           'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png',
         extensions: {

--- a/src/ui-config/TokenList.ts
+++ b/src/ui-config/TokenList.ts
@@ -12957,6 +12957,15 @@ export const TOKEN_LIST: TokenList = {
         'https://assets.coingecko.com/coins/images/30663/standard/gho-token-logo.png?1720517092',
     },
     {
+      name: 'Gho Token',
+      address: '0xfc421aD3C883Bf9E7C4f42dE845C4e4405799e73',
+      symbol: 'GHO',
+      decimals: 18,
+      chainId: 100,
+      logoURI:
+        'https://assets.coingecko.com/coins/images/30663/standard/gho-token-logo.png?1720517092',
+    },
+    {
       name: 'Aave',
       address: '0x63706e401c06ac8513145b7687A14804d17f814b',
       symbol: 'AAVE',

--- a/src/ui-config/marketsConfig.tsx
+++ b/src/ui-config/marketsConfig.tsx
@@ -627,6 +627,7 @@ export const marketsData: {
       COLLECTOR: AaveV3Gnosis.COLLECTOR,
       DEBT_SWITCH_ADAPTER: AaveV3Gnosis.DEBT_SWAP_ADAPTER,
       WITHDRAW_SWITCH_ADAPTER: AaveV3Gnosis.WITHDRAW_SWAP_ADAPTER,
+      GHO_TOKEN_ADDRESS: '0xfc421aD3C883Bf9E7C4f42dE845C4e4405799e73',
     },
   },
   [CustomMarket.proto_bnb_v3]: {


### PR DESCRIPTION
## General Changes

Adds support for GHO launching on Gnosis per [proposal #352](https://vote.onaave.com/proposal/?proposalId=352&ipfsHash=0x1d24f0279264d6d17f5d1e432bfb88a1c755b4e2e5b25f3d58cec9a6ed064aa0)

## Developer Notes

TODO:
- [ ] the `subgraphUrl` is currently missing
- [ ] the GHO is not display yet, should we ask BGD to update the aave-address-book?

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
