### PR TITLE
fix: issue#2573:  show GHO in core markets & link banner GHO to sGHO savings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,5 +154,6 @@
     "budget": null,
     "budgetPercentIncreaseRed": 20,
     "showDetails": true
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -154,6 +154,5 @@
     "budget": null,
     "budgetPercentIncreaseRed": 20,
     "showDetails": true
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/components/primitives/Link.tsx
+++ b/src/components/primitives/Link.tsx
@@ -12,10 +12,10 @@ const Anchor = styled('a')({});
 
 interface NextLinkComposedProps
   extends Omit<
-    AnchorHTMLAttributes<HTMLAnchorElement>,
-    'href' | 'onClick' | 'onMouseEnter' | 'onTouchStart'
-  >,
-  Omit<NextLinkProps, 'href' | 'as' | 'onClick' | 'onMouseEnter' | 'onTouchStart'> {
+      AnchorHTMLAttributes<HTMLAnchorElement>,
+      'href' | 'onClick' | 'onMouseEnter' | 'onTouchStart'
+    >,
+    Omit<NextLinkProps, 'href' | 'as' | 'onClick' | 'onMouseEnter' | 'onTouchStart'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];
   href?: NextLinkProps['href'];

--- a/src/modules/markets/Gho/GhoBanner.tsx
+++ b/src/modules/markets/Gho/GhoBanner.tsx
@@ -4,17 +4,12 @@ import { Box, Button, Skeleton, Stack, Typography, useMediaQuery, useTheme } fro
 import { FormattedNumber } from 'src/components/primitives/FormattedNumber';
 import { Link, ROUTES } from 'src/components/primitives/Link';
 import { TokenIcon } from 'src/components/primitives/TokenIcon';
-import { FormattedReservesAndIncentives } from 'src/hooks/pool/usePoolFormattedReserves';
 import { useGeneralStakeUiData } from 'src/hooks/stake/useGeneralStakeUiData';
 import { useMeritIncentives } from 'src/hooks/useMeritIncentives';
 import { useRootStore } from 'src/store/root';
 import { GHO_SYMBOL } from 'src/utils/ghoUtilities';
 
-interface GhoBannerProps {
-  reserve?: FormattedReservesAndIncentives;
-}
-
-export const SavingsGhoBanner = ({ reserve }: GhoBannerProps) => {
+export const SavingsGhoBanner = () => {
   const theme = useTheme();
   const isCustomBreakpoint = useMediaQuery('(min-width:1125px)');
   const isMd = useMediaQuery(theme.breakpoints.up('xs'));
@@ -23,7 +18,7 @@ export const SavingsGhoBanner = ({ reserve }: GhoBannerProps) => {
   const downToSm = useMediaQuery('(max-width:780px)');
 
   const currentMarketData = useRootStore((store) => store.currentMarketData);
-  const currentMarket = useRootStore((store) => store.currentMarket);
+
   const { data: meritIncentives, isLoading: meritIncentivesLoading } = useMeritIncentives({
     symbol: GHO_SYMBOL,
     market: currentMarketData.market,
@@ -36,7 +31,7 @@ export const SavingsGhoBanner = ({ reserve }: GhoBannerProps) => {
   const stakeData = stakeGeneralResult?.[0];
 
   if (downToSm) {
-    return <GhoSavingsBannerMobile reserve={reserve} />;
+    return <GhoSavingsBannerMobile />;
   }
 
   return (
@@ -53,7 +48,7 @@ export const SavingsGhoBanner = ({ reserve }: GhoBannerProps) => {
     >
       <Stack
         component={Link}
-        href={ROUTES.reserveOverview(reserve?.underlyingAsset || '', currentMarket)}
+        href={ROUTES.sGHO}
         sx={(theme) => ({
           [theme.breakpoints.up(780)]: {
             height: '116px',
@@ -178,9 +173,8 @@ export const SavingsGhoBanner = ({ reserve }: GhoBannerProps) => {
   );
 };
 
-const GhoSavingsBannerMobile = ({ reserve }: GhoBannerProps) => {
+const GhoSavingsBannerMobile = () => {
   const currentMarketData = useRootStore((store) => store.currentMarketData);
-  const currentMarket = useRootStore((store) => store.currentMarket);
   const { data: meritIncentives, isLoading: meritIncentivesLoading } = useMeritIncentives({
     symbol: GHO_SYMBOL,
     market: currentMarketData.market,
@@ -206,7 +200,7 @@ const GhoSavingsBannerMobile = ({ reserve }: GhoBannerProps) => {
     >
       <Stack
         component={Link}
-        href={ROUTES.reserveOverview(reserve?.underlyingAsset || '', currentMarket)}
+        href={ROUTES.sGHO}
         sx={(theme) => ({
           [theme.breakpoints.up(780)]: {
             height: '116px',
@@ -279,13 +273,7 @@ const GhoSavingsBannerMobile = ({ reserve }: GhoBannerProps) => {
               </Typography>
             </Stack>
           </Stack>
-          <Button
-            variant="contained"
-            fullWidth
-            component={Link}
-            size="medium"
-            href={ROUTES.reserveOverview(reserve?.underlyingAsset || '', currentMarket)}
-          >
+          <Button variant="contained" fullWidth component={Link} size="medium" href={ROUTES.sGHO}>
             <Trans>View details</Trans>
           </Button>
         </Stack>

--- a/src/modules/markets/MarketAssetsListContainer.tsx
+++ b/src/modules/markets/MarketAssetsListContainer.tsx
@@ -11,7 +11,7 @@ import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvide
 import MarketAssetsList from 'src/modules/markets/MarketAssetsList';
 import { useRootStore } from 'src/store/root';
 import { fetchIconSymbolAndName } from 'src/ui-config/reservePatches';
-import { getGhoReserve, GHO_MINTING_MARKETS, GHO_SYMBOL } from 'src/utils/ghoUtilities';
+import { GHO_MINTING_MARKETS, GHO_SYMBOL } from 'src/utils/ghoUtilities';
 import { useShallow } from 'zustand/shallow';
 
 import { GENERAL } from '../../utils/events';
@@ -48,14 +48,14 @@ export const MarketAssetsListContainer = () => {
   const { breakpoints } = useTheme();
   const sm = useMediaQuery(breakpoints.down('sm'));
 
-  const ghoReserve = getGhoReserve(reserves);
   const displayGhoBanner = shouldDisplayGhoBanner(currentMarket, searchTerm);
 
   const filteredData = reserves
     // Filter out any non-active reserves
     .filter((res) => res.isActive)
     // Filter out GHO if the banner is being displayed
-    .filter((res) => (displayGhoBanner ? res !== ghoReserve : true))
+    //* Disabled to always show GHO in the core markets list as per issue #2573
+    //.filter((res) => (displayGhoBanner ? res !== ghoReserve : true))
     // filter out any that don't meet search term criteria
     .filter((res) => {
       if (!searchTerm) return true;
@@ -104,7 +104,7 @@ export const MarketAssetsListContainer = () => {
     >
       {displayGhoBanner && (
         <Box mb={4}>
-          <SavingsGhoBanner reserve={ghoReserve} />
+          <SavingsGhoBanner />
         </Box>
       )}
 

--- a/src/modules/markets/MarketAssetsListContainer.tsx
+++ b/src/modules/markets/MarketAssetsListContainer.tsx
@@ -53,9 +53,6 @@ export const MarketAssetsListContainer = () => {
   const filteredData = reserves
     // Filter out any non-active reserves
     .filter((res) => res.isActive)
-    // Filter out GHO if the banner is being displayed
-    //* Disabled to always show GHO in the core markets list as per issue #2573
-    //.filter((res) => (displayGhoBanner ? res !== ghoReserve : true))
     // filter out any that don't meet search term criteria
     .filter((res) => {
       if (!searchTerm) return true;


### PR DESCRIPTION
## General Changes

- Solving issue #2573.

- Show GHO in the core markets asset list.

- Update GHO banner link to navigate to the sGHO page (ROUTES.sGHO).

## Developer Notes

1. To ensure the GHO token is always visible in the Core assets list on the Markets page, I commented out a filter that was previously blocking it.  

Line 57-58: 
```
 //* Disabled to always show GHO in the core markets list as per issue #2573
 //.filter((res) => (displayGhoBanner ? res !== ghoReserve : true)) 
```

2. Updated the banner link in both mobile and desktop components.

Replaced:
```
href={ROUTES.reserveOverview(reserve?.underlyingAsset || '', currentMarket)}
```
with:
```
href={ROUTES.sGHO}
```
As a result of this change, some props and function calls that were only used to build the old URL are no longer needed:

- Removed the unused `reserve` prop from ``SavingsGhoBanner`` and its caller.

- Removed `getGhoReserve` usage in ``MarketAssetsListContainer``, as it was only used to build the old URL.

Please confirm whether the removal of these unused elements is intended.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
