### PR TITLE
fix: gho deleted from safety mode when not connected 

### DIFF
--- a/src/components/ConnectWalletPaperStaking.tsx
+++ b/src/components/ConnectWalletPaperStaking.tsx
@@ -46,10 +46,12 @@ export const ConnectWalletPaperStaking = ({
               )}
             </Typography>
             <ConnectWalletButton funnel={'Staking page'} />
-            <Grid container spacing={1} pt={6} sx={{ maxWidth: '758px', textAlign: 'right' }}>
-              <Grid item xs={12} md={4}>
-                <StakingPanelNoWallet stakedToken={'GHO'} icon={'gho'} />
-              </Grid>
+            <Grid
+              container
+              spacing={1}
+              pt={6}
+              sx={{ maxWidth: '758px', textAlign: 'right', justifyContent: 'center' }}
+            >
               <Grid item xs={12} md={4}>
                 <StakingPanelNoWallet stakedToken={'AAVE'} icon={'aave'} />
               </Grid>


### PR DESCRIPTION
## General Changes

- Solving issue #2578 

- The Gho section is removed when wallet not connected in the Safety Mode page.

- Added `justifyContent: 'center'` to improve the grid’s appearance.

## Developer Notes

- None

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x]  End-to-end tests are passing without any errors
- [x]  Code changes do not significantly increase the application bundle size
- [x]  If there are new 3rd-party packages, they do not introduce potential security threats
- [x]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
