### PR TITLE
fix: crop Merit tooltip to prevent overflow

### DIFF
--- a/src/components/ContentWithTooltip.tsx
+++ b/src/components/ContentWithTooltip.tsx
@@ -5,7 +5,7 @@ interface ContentWithTooltipProps {
   children: ReactNode;
   // eslint-disable-next-line
   tooltipContent: ReactElement<any, string | JSXElementConstructor<any>>;
-  placement?: 'top' | 'bottom';
+  placement?: 'right' | 'left' | 'bottom';
   withoutHover?: boolean;
   open?: boolean;
   setOpen?: (value: boolean) => void;
@@ -34,7 +34,7 @@ export const PopperComponent = styled(Popper)(({ theme }) =>
 export const ContentWithTooltip = ({
   children,
   tooltipContent,
-  placement = 'top',
+  placement = 'right',
   withoutHover,
   open,
   setOpen,
@@ -64,6 +64,12 @@ export const ContentWithTooltip = ({
               name: 'offset',
               options: {
                 offset: offset ?? [],
+              },
+            },
+            {
+              name: 'flip',
+              options: {
+                fallbackPlacements: ['left', 'bottom'],
               },
             },
           ],


### PR DESCRIPTION
## General Changes

- Solves issue #2580  
- Fixes tooltip overflow in certain cases.  
- Tooltip now appears on the right by default, and will automatically flip to the left or bottom if there is not enough space.

## Developer Notes

- Changes applied to the `ContentWithTooltip` component.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
