### PR TITLE
fix: Debounce input to query quote only when user finished writing input amount

### DIFF
--- a/src/components/transactions/Switch/BaseSwitchModalContent.tsx
+++ b/src/components/transactions/Switch/BaseSwitchModalContent.tsx
@@ -220,7 +220,7 @@ export const BaseSwitchModalContent = ({
   const debouncedInputChange = useMemo(() => {
     return debounce((value: string) => {
       setDebounceInputAmount(value);
-    }, 300);
+    }, 1500);
   }, [setDebounceInputAmount]);
 
   const handleInputChange = (value: string) => {


### PR DESCRIPTION
## General Changes

- Increased the debouncing time from 300ms to 1500ms. With 300ms, a quote is triggered on every number change — it technically works correctly, but the effect is that if a user changes a digit and pauses (before typing the next one), a new quote request is already executed. By increasing to 1500ms, we achieve the intended debouncing behavior, reducing the number of quote calls. Since a Cow/Paraswap calculation takes a few seconds, this provides a smoother and more user-friendly experience.


## Developer Notes


---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
