### PR TITLE
fix: fix Horizon banner redirection when navigating from the sGHO page

### DIFF
--- a/pages/sgho.page.tsx
+++ b/pages/sgho.page.tsx
@@ -3,6 +3,7 @@ import { AaveV3Ethereum } from '@bgd-labs/aave-address-book';
 import { Trans } from '@lingui/macro';
 import { Box, Paper, Typography, useMediaQuery, useTheme } from '@mui/material';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { ContentContainer } from 'src/components/ContentContainer';
 import { ConnectWalletButton } from 'src/components/WalletConnection/ConnectWalletButton';
@@ -49,14 +50,16 @@ export default function SavingsGho() {
   const { data: stakeUserResult } = useUserStakeUiData(currentMarketData);
 
   const { data: stakeGeneralResult } = useGeneralStakeUiData(currentMarketData);
-
-  // Automatically switch to mainnet if not already on mainnet
+  const router = useRouter();
+  console.log('Router path:', router.pathname);
+  // Automatically switch to mainnet if not already on mainnet when entering the sGHO page
   // since sGHO only exists on Ethereum mainnet
+  // NOTE: Having currentMarket as a dependency in useEffect causes conflicts with the Horizon Banner interaction.
   useEffect(() => {
-    if (currentMarket !== CustomMarket.proto_mainnet_v3) {
+    if (router.pathname === '/sgho' && currentMarket !== CustomMarket.proto_mainnet_v3) {
       setCurrentMarket(CustomMarket.proto_mainnet_v3);
     }
-  }, [currentMarket, setCurrentMarket]);
+  }, [router.pathname, setCurrentMarket]);
 
   useEffect(() => {
     trackEvent('Page Viewed', {

--- a/pages/sgho.page.tsx
+++ b/pages/sgho.page.tsx
@@ -51,7 +51,6 @@ export default function SavingsGho() {
 
   const { data: stakeGeneralResult } = useGeneralStakeUiData(currentMarketData);
   const router = useRouter();
-  console.log('Router path:', router.pathname);
   // Automatically switch to mainnet if not already on mainnet when entering the sGHO page
   // since sGHO only exists on Ethereum mainnet
   // NOTE: Having currentMarket as a dependency in useEffect causes conflicts with the Horizon Banner interaction.


### PR DESCRIPTION
## General Changes

- fixed Horizon banner redirection when navigating from the sGHO page

## Developer Notes

- Could `currentMarket` change while we’re on the `/sGho` page? This might be an edge case. I don’t think it’s possible.
We can’t add `currentMarket` to the `useEffect` dependency array because it conflicts with the banner redirection.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
