### PR TITLE
fix: enabled aBasweETH for Cowswap's collateral swap

### DIFF
--- a/src/components/transactions/Switch/cowprotocol/cowprotocol.constants.ts
+++ b/src/components/transactions/Switch/cowprotocol/cowprotocol.constants.ts
@@ -17,7 +17,6 @@ export const COW_UNSUPPORTED_ASSETS: Partial<
     [SupportedChainId.BASE]: [
       '0x067ae75628177FD257c2B1e500993e1a0baBcBd1'.toLowerCase(), // aGHO not supported
       '0x90072A4aA69B5Eb74984Ab823EFC5f91e90b3a72'.toLowerCase(), // alBTC does not have good solver liquidity
-      '0x7C307e128efA31F540F2E2d976C995E0B65F51F6'.toLowerCase(), // aWETH does not have good solver liquidity
     ],
     [SupportedChainId.MAINNET]: [
       '0x00907f9921424583e7ffBfEdf84F92B7B2Be4977'.toLowerCase(), // aGHO not supported


### PR DESCRIPTION
## General Changes

aBasweETH should now be working in Base.
Token address: 0x7C307e128efA31F540F2E2d976C995E0B65F51F6


## Proof
https://explorer.cow.fi/base/orders/0x1089ac17759e93d6af431207b7eb7c7910a83d5edf047f9340dfa045a3b4bad99fa3c00a92ec5f96b1ad2527ab41b3932efeda5868ca9e4c

https://explorer.cow.fi/base/orders/0x349b56381214bfee3c1dc6141b503af69baf7b83aff884eaf2769e076819a0689fa3c00a92ec5f96b1ad2527ab41b3932efeda5868caa0d9