### PR TITLE
fix: lazy loading icons in firefox

### DIFF
--- a/src/components/primitives/TokenIcon.tsx
+++ b/src/components/primitives/TokenIcon.tsx
@@ -194,15 +194,23 @@ function SingleTokenIcon({ symbol, aToken, waToken, ...rest }: TokenIconProps) {
 
 interface ExternalTokenIconProps extends IconProps {
   symbol: string;
+  height?: string;
+  width?: string;
   logoURI?: string;
 }
 
-export function ExternalTokenIcon({ symbol, logoURI, ...rest }: ExternalTokenIconProps) {
+export function ExternalTokenIcon({
+  symbol,
+  logoURI,
+  height,
+  width,
+  ...rest
+}: ExternalTokenIconProps) {
   const [tokenSymbol, setTokenSymbol] = useState(symbol.toLowerCase());
 
   return (
     <Icon {...rest} sx={{ display: 'flex', position: 'relative', borderRadius: '50%', ...rest.sx }}>
-      <LazyLoad>
+      <LazyLoad height={height ?? '24px'} width={width ?? '24px'}>
         <img
           src={tokenSymbol === 'default' || !logoURI ? '/icons/tokens/default.svg' : logoURI}
           width="100%"

--- a/src/components/transactions/Switch/SwitchAssetInput.tsx
+++ b/src/components/transactions/Switch/SwitchAssetInput.tsx
@@ -407,7 +407,9 @@ export const SwitchAssetInput = ({
                     <ExternalTokenIcon
                       symbol={asset.symbol}
                       logoURI={asset.logoURI}
-                      sx={{ mr: 2, width: 28, height: 28 }}
+                      height="28px"
+                      width="28px"
+                      sx={{ mr: 2 }}
                     />
                     <ListItemText
                       sx={{ flexGrow: 0 }}

--- a/src/components/transactions/Switch/SwitchModalTxDetails.tsx
+++ b/src/components/transactions/Switch/SwitchModalTxDetails.tsx
@@ -248,6 +248,8 @@ const IntentTxDetails = ({
                 <ExternalTokenIcon
                   symbol={selectedOutputToken.symbol}
                   logoURI={selectedOutputToken.logoURI}
+                  height="16px"
+                  width="16px"
                   sx={{ mr: 2, ml: 4, fontSize: '16px' }}
                 />
                 <FormattedNumber value={networkFeeFormatted} variant="secondary12" compact />
@@ -275,6 +277,8 @@ const IntentTxDetails = ({
                 <ExternalTokenIcon
                   symbol={selectedOutputToken.symbol}
                   logoURI={selectedOutputToken.logoURI}
+                  height="16px"
+                  width="16px"
                   sx={{ mr: 2, ml: 4, fontSize: '16px' }}
                 />
                 <FormattedNumber value={partnerFeeFormatted} variant="secondary12" compact />
@@ -312,6 +316,8 @@ const IntentTxDetails = ({
             <ExternalTokenIcon
               symbol={selectedOutputToken.symbol}
               logoURI={selectedOutputToken.logoURI}
+              height="16px"
+              width="16px"
               sx={{ mr: 2, ml: 4, fontSize: '16px' }}
             />
             <FormattedNumber
@@ -379,6 +385,8 @@ const MarketOrderTxDetails = ({
             <ExternalTokenIcon
               symbol={selectedOutputToken.symbol}
               logoURI={selectedOutputToken.logoURI}
+              height="16px"
+              width="16px"
               sx={{ mr: 2, ml: 4, fontSize: '16px' }}
             />
             <FormattedNumber

--- a/src/components/transactions/Switch/SwitchTxSuccessView.tsx
+++ b/src/components/transactions/Switch/SwitchTxSuccessView.tsx
@@ -239,7 +239,13 @@ export const SwitchTxSuccessView = ({
               : 'Sent'}
           </Typography>
           <Box display="flex" alignItems="center" gap={1}>
-            <ExternalTokenIcon symbol={iconSymbol} logoURI={iconUri} sx={{ fontSize: 20 }} />
+            <ExternalTokenIcon
+              symbol={iconSymbol}
+              logoURI={iconUri}
+              height="20px"
+              width="20px"
+              sx={{ fontSize: 20 }}
+            />
             <DarkTooltip
               title={
                 <Typography variant="secondary14" color="common.white">
@@ -273,7 +279,13 @@ export const SwitchTxSuccessView = ({
               : 'Received'}
           </Typography>
           <Box display="flex" alignItems="center" gap={1}>
-            <ExternalTokenIcon symbol={outIconSymbol} logoURI={outIconUri} sx={{ fontSize: 20 }} />
+            <ExternalTokenIcon
+              symbol={outIconSymbol}
+              logoURI={outIconUri}
+              height="20px"
+              width="20px"
+              sx={{ fontSize: 20 }}
+            />
             <DarkTooltip
               title={
                 <Typography variant="secondary14" color="common.white">


### PR DESCRIPTION
<img width="948" height="571" alt="image" src="https://github.com/user-attachments/assets/f582339a-c3fa-4c44-ac84-a3696bbc9690" />
