### PR TITLE
Potential fix for code scanning alert no. 29: Code injection

### DIFF
--- a/.github/workflows/test-deploy-fork.yml
+++ b/.github/workflows/test-deploy-fork.yml
@@ -35,12 +35,14 @@ jobs:
 
       - name: Link this CI run to PR
         uses: actions/github-script@100527700e8b29ca817ac0e0dfbfc5e8ff38edda # v6.1.1
+        env:
+          PR_NUMBER: ${{ steps.get_pr_number.outputs.pr_number }}
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: Number('${{ steps.get_pr_number.outputs.pr_number }}'),
+              issue_number: Number(process.env.PR_NUMBER),
               body: '🔎 Tests and deployment are running now!\nSee progress at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             });
 


### PR DESCRIPTION
Potential fix for [https://github.com/aave/interface/security/code-scanning/29](https://github.com/aave/interface/security/code-scanning/29)

To address the code injection concern, we should avoid interpolating `${{ steps.get_pr_number.outputs.pr_number }}` directly into the `script:` block. Instead, we should pass this value to the step as an environment variable, and read it using `process.env` inside the JavaScript code in the `actions/github-script` step. Specifically:
- On the affected step (`Link this CI run to PR` at lines 36–45), add an `env:` block that sets a variable such as `PR_NUMBER: ${{ steps.get_pr_number.outputs.pr_number }}`.
- In the `script:` block, use `process.env.PR_NUMBER`, and convert it to a number as needed.
- Remove direct usage of `${{ steps.get_pr_number.outputs.pr_number }}` from within the script.

This change confines the untrusted value to an environment variable and accesses it using JavaScript's environment API, which is not subject to expression interpolation attacks. No redundant functionality is introduced; behavior remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
