### PR TITLE
fix: incomplete string escaping

### DIFF
--- a/src/modules/governance/proposal/ProposalOverview.tsx
+++ b/src/modules/governance/proposal/ProposalOverview.tsx
@@ -197,7 +197,7 @@ export const ProposalOverview = ({ proposal, loading, error }: ProposalOverviewP
                   if (!_src) return null;
                   const src = /^\.\.\//.test(_src)
                     ? _src.replace(
-                        /\.\.\//g,
+                        /^\.\.\//,
                         'https://raw.githubusercontent.com/aave/aip/main/content/'
                       )
                     : _src;


### PR DESCRIPTION
<img width="1285" height="1247" alt="image" src="https://github.com/user-attachments/assets/32567b22-dcc8-4ac1-aa17-2c2a33fe480b" />
