### PR TITLE
fix: category filter for plasma

### DIFF
--- a/src/modules/markets/utils/assetCategories.ts
+++ b/src/modules/markets/utils/assetCategories.ts
@@ -12,7 +12,8 @@ function normalizeStableSymbol(symbol: string): string {
     .replace(/^M\./, '')
     .replace(/^W/, '')
     .replace(/USD₮0/g, 'USDT')
-    .replace(/USD₮/g, 'USDT');
+    .replace(/USD₮/g, 'USDT')
+    .replace(/USDT0/g, 'USDT');
 }
 function normalizeEthCorrelatedSymbol(symbol: string): string {
   return symbol


### PR DESCRIPTION
## General Changes

- USDT0 is now displayed under the Stablecoin category.

## Developer Notes



---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
