### PR TITLE
feat: stopped hardcoded apy value & deleted logic for hardcoded values

### DIFF
--- a/src/hooks/useMerklIncentives.ts
+++ b/src/hooks/useMerklIncentives.ts
@@ -1,6 +1,5 @@
 import { ProtocolAction } from '@aave/contract-helpers';
 import { ReserveIncentiveResponse } from '@aave/math-utils/dist/esm/formatters/incentive/calculate-reserve-incentives';
-import { AaveV3Plasma } from '@bgd-labs/aave-address-book';
 import { useQuery } from '@tanstack/react-query';
 import { useRootStore } from 'src/store/root';
 import { convertAprToApy } from 'src/utils/utils';
@@ -100,28 +99,6 @@ type WhitelistApiResponse = {
   additionalIncentiveInfo: Record<string, ReserveIncentiveAdditionalData>;
 };
 
-const hardcodedIncentives: Record<string, ExtendedReserveIncentiveResponse> = {
-  [AaveV3Plasma.ASSETS.USDe.A_TOKEN]: {
-    incentiveAPR: '0.12',
-    rewardTokenAddress: AaveV3Plasma.ASSETS.USDe.A_TOKEN,
-    rewardTokenSymbol: 'aPlaUSDe',
-    customMessage:
-      'You must supply USDe and hold an equal or greater amount of sUSDe (by USD value) to receive the incentives. To be eligible, your assets supplied must be at least 2x your account equity, and you must not be borrowing any USDe. The rate provided to eligible users will change week by week, but will be roughly in line with the sUSDe rate for the forseeable future.',
-    breakdown: {
-      protocolAPY: 0,
-      protocolIncentivesAPR: 0,
-      merklIncentivesAPR: 0,
-      totalAPY: 0,
-      isBorrow: false,
-      breakdown: {
-        protocol: 0,
-        protocolIncentives: 0,
-        merklIncentives: 0,
-      },
-    },
-  },
-};
-
 const MERKL_ENDPOINT = 'https://api.merkl.xyz/v4/opportunities?mainProtocolId=aave'; // Merkl API
 const WHITELIST_ENDPOINT = 'https://apps.aavechan.com/api/aave/merkl/whitelist-token-list'; // Endpoint to fetch whitelisted tokens
 const checkOpportunityAction = (
@@ -176,24 +153,6 @@ export const useMerklIncentives = ({
     queryKey: ['merklIncentives', market],
     staleTime: 1000 * 60 * 5,
     select: (merklOpportunities) => {
-      const hardcodedIncentive = rewardedAsset ? hardcodedIncentives[rewardedAsset] : undefined;
-
-      if (hardcodedIncentive) {
-        const protocolIncentivesAPR = protocolIncentives.reduce((sum, inc) => {
-          return sum + (inc.incentiveAPR === 'Infinity' ? 0 : +inc.incentiveAPR);
-        }, 0);
-        const merklIncentivesAPY = convertAprToApy(0.06);
-        return {
-          ...hardcodedIncentive,
-          breakdown: {
-            protocolAPY,
-            protocolIncentivesAPR,
-            merklIncentivesAPR: merklIncentivesAPY,
-            totalAPY: protocolAPY + protocolIncentivesAPR + merklIncentivesAPY,
-          } as MerklIncentivesBreakdown,
-        } as ExtendedReserveIncentiveResponse;
-      }
-
       const opportunities = merklOpportunities.filter(
         (opportunitiy) =>
           rewardedAsset &&


### PR DESCRIPTION
## General Changes

* Requested ACI to remove hardcoded APY values for USDe on Plasma.

* Removed the logic for adding hardcoded values. I mentioned this in the commit message, so if we ever need hardcoded values again in the future, we can easily reuse and reimplement the logic.

## Developer Notes



---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
