### PR TITLE
fix: exclude labels for plain support

### DIFF
--- a/pages/api/support-create-ticket.ts
+++ b/pages/api/support-create-ticket.ts
@@ -155,7 +155,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             },
           },
         ],
-        labelTypeIds: ['lt_01K36FQ2J7ZGXQ55RV769TJHYN'],
       },
     };
     const result = await makeGraphQLRequest(CREATE_THREAD_MUTATION, createThreadVariables);


### PR DESCRIPTION
## General Changes

- Deleted the application of labels to new inquiries from the Aave interface to Plain support

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
