### PR TITLE
fix: handle infinite allowance parsing

### DIFF
--- a/src/hooks/useApprovalTx.tsx
+++ b/src/hooks/useApprovalTx.tsx
@@ -1,4 +1,5 @@
 import { ApproveType, MAX_UINT_AMOUNT, ProtocolAction } from '@aave/contract-helpers';
+import { valueToBigNumber } from '@aave/math-utils';
 import { SignatureLike } from '@ethersproject/bytes';
 import { constants, ethers } from 'ethers';
 import { parseUnits } from 'ethers/lib/utils';
@@ -68,16 +69,16 @@ export const useApprovalTx = ({
       !isUSDTOnEthereum(symbol, chainId) ||
       !setShowUSDTResetWarning ||
       !signatureAmount ||
-      signatureAmount === '0'
+      signatureAmount === '0' ||
+      signatureAmount === '-1'
     ) {
       return;
     }
 
     const amountToApprove = parseUnits(signatureAmount, decimals).toString();
-    const currentApproved = parseUnits(
-      approvedAmount?.amount?.toString() || '0',
-      decimals
-    ).toString();
+    const currentApproved = approvedAmount?.amount
+      ? valueToBigNumber(approvedAmount.amount).toFixed(0)
+      : '0';
 
     if (needsUSDTApprovalReset(symbol, chainId, currentApproved, amountToApprove)) {
       setShowUSDTResetWarning(true);


### PR DESCRIPTION
## General Changes

- apply `valueToBigNumber()` instead `parseUnits()` for `approvedAmount` values retrieve from the user, to avoid app crash.




## Developer Notes

### Bug Explanation

A user account tried to repay their debt in USDT. The app was crashing when they attempted to input a value to repay in the modal.

The following log was retrieved:
<img width="478" height="88" alt="Screenshot 2025-10-08 at 18 20 13" src="https://github.com/user-attachments/assets/375ea140-3e50-4766-bad9-5641e9438644" />


Our useApprovalTx hook was not expecting “infinite approvals” and was trying to use parseUnits() on a huge number in scientific notation, which caused the crash. We’ve now replaced it with valueToBigNumber() to properly handle numbers in scientific notation and convert them to plain numbers without decimals.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
