### PR TITLE
fix: fixed responsive issue with favourited button

### DIFF
--- a/src/components/TopInfoPanel/PageTitle.tsx
+++ b/src/components/TopInfoPanel/PageTitle.tsx
@@ -93,7 +93,8 @@ export const PageTitle = ({
             onClick={handleFavoriteClick}
             variant="surface"
             sx={{
-              display: { xs: 'none', sm: 'flex' }, // Hide on mobile (xs), show on small screens and up
+              display: 'none',
+              [theme.breakpoints.up(800)]: { display: 'flex' }, // Hide on mobile (xs) and for widths between 759px and 800px, show on small screens and up
               p: '7px 8px',
               minWidth: 'unset',
               gap: 2,


### PR DESCRIPTION
## General Changes

- Solved responsiveness issue affecting the `Favourited/Favorite` button on the screen size between 759px till 800px.

## Developer Notes

### Issue:
<img width="430" height="135" alt="Screenshot 2025-10-10 at 15 52 11" src="https://github.com/user-attachments/assets/db089134-b810-4ebe-b014-6acd969a6d0d" />

### Solution:

* I just extended the behavior of mobile till 800 px (hiding). 


---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
