### PR TITLE
fix: displaying `syrupUSDT` for symbol and name

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@aave/math-utils": "1.36.1",
     "@aave/react": "0.6.1",
     "@amplitude/analytics-browser": "^2.13.0",
-    "@bgd-labs/aave-address-book": "^4.34.1",
+    "@bgd-labs/aave-address-book": "^4.36.0",
     "@cowprotocol/app-data": "^3.1.0",
     "@cowprotocol/cow-sdk": "6.3.3",
     "@emotion/cache": "11.10.3",

--- a/src/modules/markets/MarketAssetsListItem.tsx
+++ b/src/modules/markets/MarketAssetsListItem.tsx
@@ -43,7 +43,7 @@ export const MarketAssetsListItem = ({ ...reserve }: ReserveWithProtocolIncentiv
     currentMarket,
     ProtocolAction.borrow
   );
-  const { iconSymbol } = fetchIconSymbolAndName({
+  const { iconSymbol, name } = fetchIconSymbolAndName({
     underlyingAsset: reserve.underlyingToken.address,
     symbol: reserve.underlyingToken.symbol,
     name: reserve.underlyingToken.name,
@@ -77,7 +77,7 @@ export const MarketAssetsListItem = ({ ...reserve }: ReserveWithProtocolIncentiv
         <TokenIcon symbol={displayIconSymbol} fontSize="large" />
         <Box sx={{ pl: 3.5, overflow: 'hidden' }}>
           <Typography variant="h4" noWrap>
-            {reserve.underlyingToken.name}
+            {name || reserve.underlyingToken.name}
           </Typography>
 
           <Box

--- a/src/ui-config/reservePatches.ts
+++ b/src/ui-config/reservePatches.ts
@@ -200,6 +200,11 @@ export function fetchIconSymbolAndName({ underlyingAsset, symbol, name }: IconSy
       name: 'PT sUSDe January 2026',
       iconSymbol: 'ptsusde',
     },
+    [AaveV3Plasma.ASSETS.syrupUSDT.UNDERLYING.toLowerCase()]: {
+      symbol: 'syrupUSDT',
+      name: 'syrupUSDT',
+      iconSymbol: 'syrupusdt',
+    },
 
     '0xa693B19d2931d498c5B318dF961919BB4aee87a5': { iconSymbol: 'UST', name: 'UST (Wormhole)' },
     '0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4': { iconSymbol: 'BPT_BAL_WETH' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,10 +1199,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bgd-labs/aave-address-book@^4.34.1":
-  version "4.34.1"
-  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-address-book/-/aave-address-book-4.34.1.tgz#8f61e02e8619e68407631baae10ec171d6d88117"
-  integrity sha512-iOurN4qBRoeeZKMtWng7H0R+UAl/jFuUQZsm/HjYWwqr5tArCUN80sD6ZC6hCpJW0mpo1+guBoSvRgItOEn6yQ==
+"@bgd-labs/aave-address-book@^4.36.0":
+  version "4.36.0"
+  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-address-book/-/aave-address-book-4.36.0.tgz#c850f5b235675006ae92c2f2918040abd86b99e1"
+  integrity sha512-9vpDl3SYJyxVronEIEmh3B1Z58o87A5b98DCvsDmeochD1UMdsi8GmptgQ5fDwHFyiqRGwlbA1uy0YCExdz+Zg==
 
 "@coinbase/wallet-sdk@4.3.0":
   version "4.3.0"


### PR DESCRIPTION
## General Changes

- Patch added to display `syrupUSDT` as name on the interface

## Developer Notes
<img width="655" height="213" alt="Screenshot 2025-10-29 at 13 10 20" src="https://github.com/user-attachments/assets/f0ab9a2b-c246-4c24-aa0b-77d2064275e5" />
<img width="372" height="160" alt="Screenshot 2025-10-29 at 13 10 29" src="https://github.com/user-attachments/assets/ded7f93b-d14f-42cb-8c69-e194f29db40b" />

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
