### PR TITLE
feat: outbound link for deprecated v2 market

### DIFF
--- a/src/components/MarketSwitcher.tsx
+++ b/src/components/MarketSwitcher.tsx
@@ -352,7 +352,7 @@ export const MarketSwitcher = () => {
             exclusive
             onChange={(_, value) => {
               if (value === SelectedMarketVersion.V2) {
-                window.open('https://v2-markets.aave.com', '_blank', 'noopener');
+                window.open('https://v2-market.aave.com/', '_blank', 'noopener');
                 return;
               }
               if (value !== null) {


### PR DESCRIPTION
## General Changes

- Added an outbound link to https://v2-markets.aave.com/ for deprecated V2 markets

## Developer Notes

<img width="223" height="131" alt="Screenshot 2025-10-30 at 12 46 23" src="https://github.com/user-attachments/assets/856d6a41-f1d9-4941-9d4d-84c822ae1ec6" />


---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
