### PR TITLE
fix: temporary safeguard to prevent Prime USDS from displaying Core incentives

### DIFF
--- a/src/modules/markets/MarketAssetsList.tsx
+++ b/src/modules/markets/MarketAssetsList.tsx
@@ -98,11 +98,21 @@ export default function MarketAssetsList({ reserves, loading }: MarketAssetsList
       ? (aValue as number) - (bValue as number)
       : (bValue as number) - (aValue as number);
   });
-  const reservesWithIncentives: ReserveWithProtocolIncentives[] = sortedReserves.map((reserve) => ({
-    ...reserve,
-    supplyProtocolIncentives: mapAaveProtocolIncentives(reserve.incentives, 'supply'),
-    borrowProtocolIncentives: mapAaveProtocolIncentives(reserve.incentives, 'borrow'),
-  }));
+  const reservesWithIncentives: ReserveWithProtocolIncentives[] = sortedReserves.map((reserve) => {
+    const supplyProtocolIncentives = mapAaveProtocolIncentives(reserve.incentives, 'supply');
+    const borrowProtocolIncentives = mapAaveProtocolIncentives(reserve.incentives, 'borrow');
+
+    // Temporary safeguard: Prime should not display the Core extra APR incentive for USDS.
+    const isPrimeMarket = reserve.market?.name?.toLowerCase() === 'aavev3ethereumlido';
+    const isUsds = reserve.underlyingToken.symbol === 'USDS';
+
+    return {
+      ...reserve,
+      // Temporary safeguard: Prime should not display the Core extra APR incentive for USDS.
+      supplyProtocolIncentives: isPrimeMarket && isUsds ? [] : supplyProtocolIncentives,
+      borrowProtocolIncentives,
+    };
+  });
   // Show loading state when loading
   if (loading) {
     return isTableChangedToCards ? (


### PR DESCRIPTION
## General Changes
- NOT NEEDED ANYMORE, SOLVED ON THE BACKEND SIDE

- Actually, i have spotted a SDK issue, who is retrieving wrong data about incentives for token `USDS` on PRIME. 
- Added temporary safeguard till backend issue is solved. 

## Developer Notes


---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
