### PR TITLE
fix: temporary hide markets on testnet

### DIFF
--- a/pages/markets.page.tsx
+++ b/pages/markets.page.tsx
@@ -1,9 +1,12 @@
 import { Box, Container } from '@mui/material';
+import { useRouter } from 'next/router';
 import { ReactNode, useEffect } from 'react';
+import { ROUTES } from 'src/components/primitives/Link';
 import { MainLayout } from 'src/layouts/MainLayout';
 import { MarketAssetsListContainer } from 'src/modules/markets/MarketAssetsListContainer';
 import { MarketsTopPanel } from 'src/modules/markets/MarketsTopPanel';
 import { useRootStore } from 'src/store/root';
+import { ENABLE_TESTNET } from 'src/utils/marketsAndNetworksConfig';
 
 interface MarketContainerProps {
   children: ReactNode;
@@ -38,13 +41,23 @@ export const MarketContainer = ({ children }: MarketContainerProps) => {
 };
 
 export default function Markets() {
+  const router = useRouter();
   const trackEvent = useRootStore((store) => store.trackEvent);
 
   useEffect(() => {
+    if (ENABLE_TESTNET) {
+      router.replace(ROUTES.dashboard);
+      return;
+    }
+
     trackEvent('Page Viewed', {
       'Page Name': 'Markets',
     });
-  }, [trackEvent]);
+  }, [router, trackEvent]);
+
+  if (ENABLE_TESTNET) {
+    return null;
+  }
 
   return (
     <>

--- a/src/ui-config/menu-items/index.tsx
+++ b/src/ui-config/menu-items/index.tsx
@@ -28,6 +28,8 @@ export const navigation: Navigation[] = [
     link: ROUTES.markets,
     title: t`Markets`,
     dataCy: 'menuMarkets',
+    // Temporary hide Markets menu item on testnet
+    isVisible: () => !ENABLE_TESTNET,
   },
   {
     link: ROUTES.governance,


### PR DESCRIPTION
## General Changes

- The backend has incomplete support for Testnet chains, so a temporary solution is needed until the backend is updated.
- Hid the market route and redirected to the dashboard only on Testnet.

## Developer Notes


---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
