### PR TITLE
Fix/filtering by apys on Market page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ yarn-error.log*
 package-lock.json
 
 .eslintcache
+.yarn-cache
 
 # IDE specific
 .idea

--- a/src/components/transactions/Switch/cowprotocol/cowprotocol.constants.ts
+++ b/src/components/transactions/Switch/cowprotocol/cowprotocol.constants.ts
@@ -5,7 +5,7 @@ export const COW_UNSUPPORTED_ASSETS: Partial<
   Record<ModalType, Partial<Record<SupportedChainId, string[] | 'ALL'>>>
 > = {
   [ModalType.CollateralSwap]: {
-    [SupportedChainId.POLYGON]: "ALL", // Waiting for better solvers support
+    [SupportedChainId.POLYGON]: 'ALL', // Waiting for better solvers support
     [SupportedChainId.AVALANCHE]: [
       '0x8eb270e296023e9d92081fdf967ddd7878724424'.toLowerCase(), // AVaMAI not supported
       '0x078f358208685046a11c85e8ad32895ded33a249'.toLowerCase(), // aVaWBTC not supported

--- a/src/hooks/useIncentivizedApy.ts
+++ b/src/hooks/useIncentivizedApy.ts
@@ -1,0 +1,92 @@
+import { ProtocolAction } from '@aave/contract-helpers';
+import { ReserveIncentiveResponse } from '@aave/math-utils/dist/esm/formatters/incentive/calculate-reserve-incentives';
+import { ENABLE_SELF_CAMPAIGN, useMeritIncentives } from 'src/hooks/useMeritIncentives';
+import { convertAprToApy } from 'src/utils/utils';
+
+import { useMerklIncentives } from './useMerklIncentives';
+import { useMerklPointsIncentives } from './useMerklPointsIncentives';
+
+interface IncentivizedApyParams {
+  symbol: string;
+  market: string;
+  rewardedAsset: string;
+  protocolAction?: ProtocolAction;
+  protocolAPY: number | string;
+  protocolIncentives?: ReserveIncentiveResponse[];
+}
+type UseIncentivizedApyResult = {
+  displayAPY: number | 'Infinity';
+  hasInfiniteIncentives: boolean;
+  isLoading: boolean;
+};
+export const useIncentivizedApy = ({
+  symbol,
+  market,
+  rewardedAsset: address,
+  protocolAction,
+  protocolAPY: value,
+  protocolIncentives: incentives = [],
+}: IncentivizedApyParams): UseIncentivizedApyResult => {
+  const protocolAPY = typeof value === 'string' ? parseFloat(value) : value;
+
+  const protocolIncentivesAPR =
+    incentives?.reduce((sum, inc) => {
+      if (inc.incentiveAPR === 'Infinity' || sum === 'Infinity') {
+        return 'Infinity';
+      }
+      return sum + +inc.incentiveAPR;
+    }, 0 as number | 'Infinity') || 0;
+
+  const protocolIncentivesAPY = convertAprToApy(
+    protocolIncentivesAPR === 'Infinity' ? 0 : protocolIncentivesAPR
+  );
+  const { data: meritIncentives, isLoading: meritLoading } = useMeritIncentives({
+    symbol,
+    market,
+    protocolAction,
+    protocolAPY,
+    protocolIncentives: incentives || [],
+  });
+
+  const { data: merklIncentives, isLoading: merklLoading } = useMerklIncentives({
+    market,
+    rewardedAsset: address,
+    protocolAction,
+    protocolAPY,
+    protocolIncentives: incentives || [],
+  });
+
+  const { data: merklPointsIncentives, isLoading: merklPointsLoading } = useMerklPointsIncentives({
+    market,
+    rewardedAsset: address,
+    protocolAction,
+    protocolAPY,
+    protocolIncentives: incentives || [],
+  });
+
+  const isLoading = meritLoading || merklLoading || merklPointsLoading;
+
+  const meritIncentivesAPR = meritIncentives?.breakdown?.meritIncentivesAPR || 0;
+
+  // TODO: This is a one-off for the Self campaign.
+  // Remove once the Self incentives are finished.
+  const selfAPY = ENABLE_SELF_CAMPAIGN ? meritIncentives?.variants?.selfAPY ?? 0 : 0;
+  const totalMeritAPY = meritIncentivesAPR + selfAPY;
+
+  const merklIncentivesAPR = merklPointsIncentives?.breakdown?.points
+    ? merklPointsIncentives.breakdown.merklIncentivesAPR || 0
+    : merklIncentives?.breakdown?.merklIncentivesAPR || 0;
+
+  const isBorrow = protocolAction === ProtocolAction.borrow;
+
+  // If any incentive is infinite, the total should be infinite
+  const hasInfiniteIncentives = protocolIncentivesAPR === 'Infinity';
+
+  const displayAPY = hasInfiniteIncentives
+    ? 'Infinity'
+    : isBorrow
+    ? protocolAPY - (protocolIncentivesAPY as number) - totalMeritAPY - merklIncentivesAPR
+    : protocolAPY + (protocolIncentivesAPY as number) + totalMeritAPY + merklIncentivesAPR;
+
+  return { displayAPY, hasInfiniteIncentives, isLoading };
+};

--- a/src/modules/markets/MarketAssetsListMobileItem.tsx
+++ b/src/modules/markets/MarketAssetsListMobileItem.tsx
@@ -76,12 +76,12 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ReserveWithProtocolIn
   useEffect(() => {
     if (supplyDisplayApy === undefined) return;
     onApyChange(id, 'supply', supplyDisplayApy);
-  }, [id, onApyChange, supplyDisplayApy]);
+  }, [id, supplyDisplayApy]);
 
   useEffect(() => {
     if (!borrowIncentivizedApy || borrowDisplayApy === undefined) return;
     onApyChange(id, 'borrow', borrowDisplayApy);
-  }, [id, onApyChange, borrowDisplayApy, borrowIncentivizedApy]);
+  }, [id, borrowDisplayApy, borrowIncentivizedApy]);
 
   return (
     <ListMobileItemWrapper

--- a/src/modules/markets/MarketAssetsListMobileItem.tsx
+++ b/src/modules/markets/MarketAssetsListMobileItem.tsx
@@ -1,6 +1,7 @@
 import { ProtocolAction } from '@aave/contract-helpers';
 import { Trans } from '@lingui/macro';
 import { Box, Button, Divider } from '@mui/material';
+import { useEffect } from 'react';
 import { KernelAirdropTooltip } from 'src/components/infoTooltips/KernelAirdropTooltip';
 import { SpkAirdropTooltip } from 'src/components/infoTooltips/SpkAirdropTooltip';
 import { SuperFestTooltip } from 'src/components/infoTooltips/SuperFestTooltip';
@@ -17,6 +18,7 @@ import { IncentivesCard } from '../../components/incentives/IncentivesCard';
 import { FormattedNumber } from '../../components/primitives/FormattedNumber';
 import { Link, ROUTES } from '../../components/primitives/Link';
 import { Row } from '../../components/primitives/Row';
+import { useIncentivizedApy } from '../../hooks/useIncentivizedApy';
 import { ListMobileItemWrapper } from '../dashboard/lists/ListMobileItemWrapper';
 import { ReserveWithProtocolIncentives } from './MarketAssetsList';
 
@@ -24,6 +26,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ReserveWithProtocolIn
   const [trackEvent, currentMarket] = useRootStore(
     useShallow((store) => [store.trackEvent, store.currentMarket])
   );
+  const { onApyChange, id } = reserve;
 
   const externalIncentivesTooltipsSupplySide = showExternalIncentivesTooltip(
     reserve.underlyingToken.symbol,
@@ -45,6 +48,40 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ReserveWithProtocolIn
     iconSymbol?.toLowerCase() !== reserve.underlyingToken.symbol.toLowerCase()
       ? iconSymbol
       : reserve.underlyingToken.symbol;
+
+  const supplyIncentivizedApy = useIncentivizedApy({
+    symbol: reserve.underlyingToken.symbol,
+    market: currentMarket,
+    rewardedAsset: reserve.aToken.address,
+    protocolAction: ProtocolAction.supply,
+    protocolAPY: reserve.supplyInfo.apy.value,
+    protocolIncentives: reserve.supplyProtocolIncentives,
+  });
+
+  const shouldShowBorrow =
+    !!reserve.borrowInfo && Number(reserve.borrowInfo.total.amount.value) > 0;
+
+  const borrowIncentivizedApy = useIncentivizedApy({
+    symbol: reserve.underlyingToken.symbol,
+    market: currentMarket,
+    rewardedAsset: shouldShowBorrow ? reserve.vToken.address : '',
+    protocolAction: ProtocolAction.borrow,
+    protocolAPY: reserve.borrowInfo?.apy.value ?? 0,
+    protocolIncentives: reserve.borrowProtocolIncentives,
+  });
+
+  const supplyDisplayApy = supplyIncentivizedApy.displayAPY;
+  const borrowDisplayApy = borrowIncentivizedApy?.displayAPY;
+
+  useEffect(() => {
+    if (supplyDisplayApy === undefined) return;
+    onApyChange(id, 'supply', supplyDisplayApy);
+  }, [id, onApyChange, supplyDisplayApy]);
+
+  useEffect(() => {
+    if (!borrowIncentivizedApy || borrowDisplayApy === undefined) return;
+    onApyChange(id, 'borrow', borrowDisplayApy);
+  }, [id, onApyChange, borrowDisplayApy, borrowIncentivizedApy]);
 
   return (
     <ListMobileItemWrapper
@@ -97,6 +134,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ReserveWithProtocolIn
           }
           market={currentMarket}
           protocolAction={ProtocolAction.supply}
+          displayAPY={supplyDisplayApy}
         />
       </Row>
 
@@ -157,6 +195,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ReserveWithProtocolIn
           }
           market={currentMarket}
           protocolAction={ProtocolAction.borrow}
+          displayAPY={borrowDisplayApy}
         />
         {reserve.borrowInfo?.borrowingState === 'DISABLED' &&
           !reserve.isFrozen &&


### PR DESCRIPTION
## General Changes
- Fixes: AAVEV3-6 
- Now the filtering by APYs for supply and borrow is working on MarketPage, taking into account the extra APRs provided by Merit, Merkl, or Aave protocol extra incentives.

## Developer Notes



---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
