### PR TITLE
fix: show Merkl incentives when multiple campaign states are returned & bad queryKey issue fixed

### DIFF
--- a/src/hooks/useMerklPointsIncentives.ts
+++ b/src/hooks/useMerklPointsIncentives.ts
@@ -69,9 +69,9 @@ export const useMerklPointsIncentives = ({
       const merklOpportunities: MerklOpportunity[] = await response.json();
       return merklOpportunities;
     },
-    queryKey: ['merklPointsIncentives', market, rewardedAsset, protocolAction],
+    queryKey: ['merklPointsIncentives', market],
     staleTime: 1000 * 60 * 5,
-    enabled,
+    enabled: enabled && !!rewardedAsset && !!protocolAction,
     select: (merklOpportunities) => {
       const opportunities = merklOpportunities.filter((opportunity) => {
         if (!rewardedAsset || !opportunity.explorerAddress || !protocolAction) {


### PR DESCRIPTION
## General Changes

* Fixes an incorrect queryKey that prevents the page from loading.
* I discovered a bug that occurred when multiple campaigns with different statuses appeared for point-based campaigns in INK, causing some Incentives buttons for active campaigns to not show up randomly.
* I fixed the issue to handle this properly.


## Developer Notes

<img width="727" height="508" alt="Screenshot 2025-11-24 at 12 28 57" src="https://github.com/user-attachments/assets/22b40c03-8a8b-4a54-9b37-cc91be9fba73" />


---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
