### PR TITLE
fix: ui bugs affecting reserve overview page

### DIFF
--- a/src/components/TextWithTooltip.tsx
+++ b/src/components/TextWithTooltip.tsx
@@ -20,6 +20,7 @@ export interface TextWithTooltipProps extends TypographyProps {
   event?: TrackEventProps;
   open?: boolean;
   setOpen?: (open: boolean) => void;
+  placement?: 'bottom' | 'left' | 'right';
 }
 
 export const TextWithTooltip = ({
@@ -34,6 +35,7 @@ export const TextWithTooltip = ({
   event,
   open: openProp = false,
   setOpen: setOpenProp,
+  placement = 'bottom',
   ...rest
 }: TextWithTooltipProps) => {
   const [open, setOpen] = useState(openProp);
@@ -52,7 +54,12 @@ export const TextWithTooltip = ({
         </Typography>
       )}
 
-      <ContentWithTooltip tooltipContent={<>{children}</>} open={open} setOpen={toggleOpen}>
+      <ContentWithTooltip
+        tooltipContent={<>{children}</>}
+        open={open}
+        setOpen={toggleOpen}
+        placement={placement}
+      >
         <IconButton
           sx={{
             display: 'flex',

--- a/src/components/caps/CapsCircularStatus.tsx
+++ b/src/components/caps/CapsCircularStatus.tsx
@@ -42,6 +42,7 @@ export const CapsCircularStatus = ({ value, tooltipContent, onClick }: CapsCircu
   return (
     <ContentWithTooltip
       tooltipContent={<>{tooltipContent}</>}
+      placement="bottom"
       open={open}
       setOpen={(value) => {
         setOpen(value);

--- a/src/components/infoTooltips/VariableAPYTooltip.tsx
+++ b/src/components/infoTooltips/VariableAPYTooltip.tsx
@@ -4,7 +4,7 @@ import { TextWithTooltip, TextWithTooltipProps } from '../TextWithTooltip';
 
 export const VariableAPYTooltip = ({ ...rest }: TextWithTooltipProps) => {
   return (
-    <TextWithTooltip {...rest}>
+    <TextWithTooltip {...rest} placement="bottom">
       <Trans>
         Variable interest rate will <b>fluctuate</b> based on the market conditions.
       </Trans>

--- a/src/modules/reserve-overview/ReserveActions.tsx
+++ b/src/modules/reserve-overview/ReserveActions.tsx
@@ -389,7 +389,11 @@ const WrappedBaseAssetSelector = ({
       color="primary"
       value={selectedAsset}
       exclusive
-      onChange={(_, value) => setSelectedAsset(value)}
+      onChange={(_, value) => {
+        if (value !== null) {
+          setSelectedAsset(value);
+        }
+      }}
       sx={{ mb: 4 }}
     >
       <StyledTxModalToggleButton value={assetSymbol}>


### PR DESCRIPTION
## General Changes


* Solved two UI bugs that were present on the **reserve-overview** page before the refactor.

  * **Bug 1:** On mobile, the tooltips were missing the *placement* parameter, causing them to flicker up and down.
  * **Bug 2:** `WrappedBaseAssetSelector` allowed selecting more than one asset (e.g., ETH), which caused the entire selector to appear in a pressed state and also reset all the data to zero.


<img width="458" height="459" alt="Screenshot 2025-12-04 at 09 41 41" src="https://github.com/user-attachments/assets/8b026cd4-c06f-466f-bcca-989f3817d368" />


## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
