### PR TITLE
fix: show spot correctly in inverted quotes

### DIFF
--- a/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
+++ b/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
@@ -198,8 +198,8 @@ export async function getCowProtocolSellRates({
       .toString();
     const destSpotAmount =
       side === 'sell'
-        ? orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString();
+        ? orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString()
+        : orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString();
     const destSpotUSD = BigNumber(srcTokenPriceUsd)
       .multipliedBy(BigNumber(destSpotAmount).dividedBy(10 ** srcDecimals))
       .toString();


### PR DESCRIPTION
Fixing do not account for network costs on dest spot amount in inverted quotes