### PR TITLE
fix: low decimal format

### DIFF
--- a/src/components/transactions/Swap/actions/RepayWithCollateral/RepayWithCollateralActionsViaParaswap.tsx
+++ b/src/components/transactions/Swap/actions/RepayWithCollateral/RepayWithCollateralActionsViaParaswap.tsx
@@ -1,6 +1,7 @@
 import { normalize, normalizeBN, valueToBigNumber } from '@aave/math-utils';
 import { OrderStatus } from '@cowprotocol/cow-sdk';
 import { Trans } from '@lingui/macro';
+import { BigNumber as BigNumberJS } from 'bignumber.js';
 import { BigNumber, PopulatedTransaction } from 'ethers';
 import { Dispatch } from 'react';
 import { calculateSignedAmount } from 'src/hooks/paraswap/common';
@@ -127,6 +128,7 @@ export const RepayWithCollateralActionsViaParaswap = ({
         // Account slippage to make sure we have enough collateral to repay with
         repayWithAmount = valueToBigNumber(state.outputAmount || '0')
           .multipliedBy(1 + Number(state.slippage) / 100)
+          .decimalPlaces(state.destinationToken.decimals, BigNumberJS.ROUND_CEIL)
           .toFixed(state.destinationToken.decimals);
       } else {
         // If buy order i want use exactly the collateral to repay with amount


### PR DESCRIPTION
## General Changes

- Fixes precision issue for `collateral` amounts
- When `collateral` decimals are small, amounts are now **rounded up** to avoid conflicts with route-required amounts, preventing transaction failures

## Developer Notes

- Previously, small-decimal `collateral` could trigger errors like this failed transaction: https://etherscan.io/tx/0x7617516343c7db97e8c89b51a67b6c9bb692141487a0a7268b7dd7146daccb4d
- After rounding up, the route succeeds, for example: https://etherscan.io/tx/0x1f4da0d1a2cf830b278ff2d8e738c6d5eae1d0b82477fbf1b6a899d735fe8755
- Updated logic ensures amounts are safely rounded up, making the route succeed

---

## Reviewer Checklist

- [x]  End-to-end tests are passing without any errors
- [x]  Code changes do not significantly increase the application bundle size
- [x]  No new 3rd-party packages introduced
- [x]  No new environment variables added
- [x]  No CI changes