### PR TITLE
fix: fork enabled can send txs

### DIFF
--- a/src/services/UmbrellaStakeDataService.ts
+++ b/src/services/UmbrellaStakeDataService.ts
@@ -3,20 +3,26 @@ import { UmbrellaEthereum } from '@bgd-labs/aave-address-book';
 import { Provider } from '@ethersproject/providers';
 import { CustomMarket, MarketDataType } from 'src/ui-config/marketsConfig';
 
-type StakeUmbrellaConfig = Partial<{
-  [K in CustomMarket]: {
-    stakeDataProvider: string;
-    batchHelper: string;
-    stakeRewardsController: string;
-  };
-}>;
+type ForkedMarket = `fork_${CustomMarket}`;
 
+type StakeUmbrellaConfig = Partial<
+  Record<
+    CustomMarket | ForkedMarket,
+    {
+      stakeDataProvider: string;
+      batchHelper: string;
+      stakeRewardsController: string;
+    }
+  >
+>;
+const umbrellaMainnet = {
+  stakeDataProvider: '0x6321ba6b41fbddb6b678cd80db067f20a8770879',
+  batchHelper: UmbrellaEthereum.UMBRELLA_BATCH_HELPER,
+  stakeRewardsController: UmbrellaEthereum.UMBRELLA_REWARDS_CONTROLLER,
+};
 export const stakeUmbrellaConfig: StakeUmbrellaConfig = {
-  [CustomMarket.proto_mainnet_v3 || 'fork_proto_mainnet_v3']: {
-    stakeDataProvider: '0x6321ba6b41fbddb6b678cd80db067f20a8770879',
-    batchHelper: UmbrellaEthereum.UMBRELLA_BATCH_HELPER,
-    stakeRewardsController: UmbrellaEthereum.UMBRELLA_REWARDS_CONTROLLER,
-  },
+  [CustomMarket.proto_mainnet_v3]: umbrellaMainnet,
+  [`fork_${CustomMarket.proto_mainnet_v3}`]: umbrellaMainnet,
 };
 
 export class UmbrellaStakeDataService {


### PR DESCRIPTION
## General Changes

- Fixed a bug that was blocking transaction calls when fork mode was enabled in the umbrella page.

## Developer Notes

- While testing the umbrella redeem process after a reported edge case, I reproduced the user’s setup, but everything worked as expected.


---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
