### PR TITLE
fix: emode borrowing enabled checks

### DIFF
--- a/src/components/transactions/Borrow/BorrowModalContent.tsx
+++ b/src/components/transactions/Borrow/BorrowModalContent.tsx
@@ -16,7 +16,10 @@ import { useModalContext } from 'src/hooks/useModal';
 import { ERC20TokenType } from 'src/libs/web3-data-provider/Web3Provider';
 import { useRootStore } from 'src/store/root';
 import { GENERAL } from 'src/utils/events';
-import { getMaxAmountAvailableToBorrow } from 'src/utils/getMaxAmountAvailableToBorrow';
+import {
+  assetCanBeBorrowedByUser,
+  getMaxAmountAvailableToBorrow,
+} from 'src/utils/getMaxAmountAvailableToBorrow';
 import { roundToTokenDecimals } from 'src/utils/utils';
 
 import { CapType } from '../../caps/helper';
@@ -100,7 +103,7 @@ export const BorrowModalContent = ({
   let blockingError: ErrorType | undefined = undefined;
   if (valueToBigNumber(amount).gt(poolReserve.formattedAvailableLiquidity)) {
     blockingError = ErrorType.NOT_ENOUGH_LIQUIDITY;
-  } else if (!poolReserve.borrowingEnabled) {
+  } else if (!assetCanBeBorrowedByUser(poolReserve, user)) {
     blockingError = ErrorType.BORROWING_NOT_AVAILABLE;
   }
 

--- a/src/modules/dashboard/lists/BorrowAssetsList/BorrowAssetsList.tsx
+++ b/src/modules/dashboard/lists/BorrowAssetsList/BorrowAssetsList.tsx
@@ -130,7 +130,7 @@ export const BorrowAssetsList = () => {
         totalBorrows: reserve.totalDebt,
         availableBorrows,
         availableBorrowsInUSD,
-        variableBorrowRate: reserve.borrowingEnabled ? Number(reserve.variableBorrowAPY) : -1,
+        variableBorrowRate: Number(reserve.variableBorrowAPY),
         iconSymbol: reserve.iconSymbol,
         ...(reserve.isWrappedBaseAsset
           ? fetchIconSymbolAndName({

--- a/src/modules/dashboard/lists/BorrowedPositionsList/BorrowedPositionsListItem.tsx
+++ b/src/modules/dashboard/lists/BorrowedPositionsList/BorrowedPositionsListItem.tsx
@@ -4,10 +4,12 @@ import { Trans } from '@lingui/macro';
 import { Box, Button, useMediaQuery, useTheme } from '@mui/material';
 import { IncentivesCard } from 'src/components/incentives/IncentivesCard';
 import { Row } from 'src/components/primitives/Row';
+import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
 import { useAssetCaps } from 'src/hooks/useAssetCaps';
 import { useModalContext } from 'src/hooks/useModal';
 import { useRootStore } from 'src/store/root';
 import { DashboardReserve } from 'src/utils/dashboardSortUtils';
+import { assetCanBeBorrowedByUser } from 'src/utils/getMaxAmountAvailableToBorrow';
 import { displayGhoForMintableMarket } from 'src/utils/ghoUtilities';
 import { isFeatureEnabled } from 'src/utils/marketsAndNetworksConfig';
 import { showExternalIncentivesTooltip } from 'src/utils/utils';
@@ -36,15 +38,11 @@ export const BorrowedPositionsListItem = ({
   const theme = useTheme();
   const downToXSM = useMediaQuery(theme.breakpoints.down('xsm'));
   const { openBorrow, openRepay, openDebtSwitch } = useModalContext();
+  const { user } = useAppDataContext();
 
   const reserve = item.reserve;
 
-  const disableBorrow =
-    !reserve.isActive ||
-    !reserve.borrowingEnabled ||
-    reserve.isFrozen ||
-    reserve.isPaused ||
-    borrowCap.isMaxed;
+  const disableBorrow = !assetCanBeBorrowedByUser(reserve, user) || borrowCap.isMaxed;
 
   const disableRepay = !reserve.isActive || reserve.isPaused;
 

--- a/src/modules/markets/MarketAssetsListItem.tsx
+++ b/src/modules/markets/MarketAssetsListItem.tsx
@@ -163,6 +163,7 @@ export const MarketAssetsListItem = ({ ...reserve }: ReserveWithProtocolIncentiv
         />
         {reserve.borrowInfo?.borrowingState === 'DISABLED' &&
           !reserve.isFrozen &&
+          !reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed) &&
           reserve.borrowInfo.total.amount.value !== '0' && <ReserveSubheader value={'Disabled'} />}
       </ListColumn>
 

--- a/src/modules/markets/MarketAssetsListMobileItem.tsx
+++ b/src/modules/markets/MarketAssetsListMobileItem.tsx
@@ -160,6 +160,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ReserveWithProtocolIn
         />
         {reserve.borrowInfo?.borrowingState === 'DISABLED' &&
           !reserve.isFrozen &&
+          !reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed) &&
           reserve.borrowInfo.total.amount.value !== '0' && <ReserveSubheader value={'Disabled'} />}
       </Row>
       <Button

--- a/src/modules/reserve-overview/ReserveActions.tsx
+++ b/src/modules/reserve-overview/ReserveActions.tsx
@@ -20,7 +20,10 @@ import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { BuyWithFiat } from 'src/modules/staking/BuyWithFiat';
 import { useRootStore } from 'src/store/root';
 import { GENERAL } from 'src/utils/events';
-import { getMaxAmountAvailableToBorrow } from 'src/utils/getMaxAmountAvailableToBorrow';
+import {
+  assetCanBeBorrowedByUser,
+  getMaxAmountAvailableToBorrow,
+} from 'src/utils/getMaxAmountAvailableToBorrow';
 import { getMaxAmountAvailableToSupply } from 'src/utils/getMaxAmountAvailableToSupply';
 import { amountToUsd } from 'src/utils/utils';
 import { useShallow } from 'zustand/shallow';
@@ -150,7 +153,7 @@ export const ReserveActions = ({ reserve }: ReserveActionsProps) => {
               disable={disableSupplyButton}
               onActionClicked={onSupplyClicked}
             />
-            {reserve.borrowingEnabled && (
+            {assetCanBeBorrowedByUser(reserve, user) && (
               <BorrowAction
                 reserve={reserve}
                 value={maxAmountToBorrow.toString()}

--- a/src/modules/reserve-overview/ReserveConfiguration.tsx
+++ b/src/modules/reserve-overview/ReserveConfiguration.tsx
@@ -125,20 +125,22 @@ export const ReserveConfiguration: React.FC<ReserveConfigurationProps> = ({ rese
       </PanelRow>
 
       {(reserve.borrowInfo?.borrowingState === 'ENABLED' ||
-        Number(reserve.borrowInfo?.total.amount.value) > 0) && (
+        Number(reserve.borrowInfo?.total.amount.value) > 0 ||
+        reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed)) && (
         <>
           <Divider sx={{ my: { xs: 6, sm: 10 } }} />
           <PanelRow>
             <PanelTitle>Borrow info</PanelTitle>
             <Box sx={{ flexGrow: 1, minWidth: 0, maxWidth: '100%', width: '100%' }}>
-              {reserve.borrowInfo?.borrowingState === 'DISABLED' && (
-                <Warning sx={{ mb: '40px' }} severity="error">
-                  <BorrowDisabledWarning
-                    symbol={reserve.underlyingToken.symbol}
-                    currentMarket={currentMarket}
-                  />
-                </Warning>
-              )}
+              {reserve.borrowInfo?.borrowingState !== 'ENABLED' &&
+                !reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed) && (
+                  <Warning sx={{ mb: '40px' }} severity="error">
+                    <BorrowDisabledWarning
+                      symbol={reserve.underlyingToken.symbol}
+                      currentMarket={currentMarket}
+                    />
+                  </Warning>
+                )}
               <BorrowInfo
                 reserve={reserve}
                 currentMarketData={currentMarketData}
@@ -160,7 +162,8 @@ export const ReserveConfiguration: React.FC<ReserveConfigurationProps> = ({ rese
       )}
 
       {(reserve.borrowInfo?.borrowingState === 'ENABLED' ||
-        Number(reserve.borrowInfo?.total.amount.value) > 0) && (
+        Number(reserve.borrowInfo?.total.amount.value) > 0 ||
+        reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed)) && (
         <>
           <Divider sx={{ my: { xs: 6, sm: 10 } }} />
 

--- a/src/modules/reserve-overview/SupplyInfo.tsx
+++ b/src/modules/reserve-overview/SupplyInfo.tsx
@@ -169,7 +169,8 @@ export const SupplyInfo = ({
       </Box>
       {renderCharts &&
         (reserve.borrowInfo?.borrowingState === 'ENABLED' ||
-          Number(reserve.borrowInfo?.total.amount.value) > 0) && (
+          Number(reserve.borrowInfo?.total.amount.value) > 0 ||
+          reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed)) && (
           <SupplyApyGraph
             chain={currentMarketData.chainId}
             underlyingToken={reserve.underlyingToken.address}
@@ -209,7 +210,7 @@ export const SupplyInfo = ({
               <Trans>Can be collateral</Trans>
             </Typography>
           </Box>
-        ) : (
+        ) : reserve.eModeInfo?.some((eMode) => eMode.canBeCollateral) ? null : (
           <Box sx={{ pt: '42px', pb: '12px' }}>
             <Typography variant="subheader1" color="text.main">
               <Trans>Collateral usage</Trans>

--- a/src/modules/reserve-overview/TokenLinkDropdown.tsx
+++ b/src/modules/reserve-overview/TokenLinkDropdown.tsx
@@ -53,8 +53,10 @@ export const TokenLinkDropdown = ({
 
   const showVariableDebtToken =
     !hideVariableDebtToken &&
-    (poolReserve.borrowInfo?.borrowingState === 'ENABLED' ||
-      Number(poolReserve.borrowInfo?.total.amount.value) > 0);
+    !!poolReserve.borrowInfo &&
+    (poolReserve.borrowInfo.borrowingState !== 'DISABLED' ||
+      Number(poolReserve.borrowInfo.total.amount.value) > 0 ||
+      !!poolReserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed));
 
   return (
     <>

--- a/src/utils/getMaxAmountAvailableToBorrow.ts
+++ b/src/utils/getMaxAmountAvailableToBorrow.ts
@@ -100,14 +100,14 @@ export function assetCanBeBorrowedByUser(
     isFrozen,
     isPaused,
   }: ComputedReserveData,
-  user: ExtendedFormattedUser
+  user?: ExtendedFormattedUser
 ) {
-  if (!borrowingEnabled || !isActive || isFrozen || isPaused) return false;
+  if (!isActive || isFrozen || isPaused) return false;
   if (user?.isInEmode) {
     const reserveEmode = eModes.find((emode) => emode.id === user.userEmodeCategoryId);
     if (!reserveEmode) return false;
     return reserveEmode.borrowingEnabled;
   }
   if (user?.isInIsolationMode && !borrowableInIsolation) return false;
-  return true;
+  return borrowingEnabled;
 }


### PR DESCRIPTION
## General Changes

- Fixes for reserves that are borrowable in eMode, but have `borrowingEnabled` as false

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
