### PR TITLE
feat: add button to support in modal blocked address

### DIFF
--- a/src/components/AddressBlockedModal.tsx
+++ b/src/components/AddressBlockedModal.tsx
@@ -1,6 +1,8 @@
 import { ExclamationCircleIcon, LogoutIcon, RefreshIcon } from '@heroicons/react/outline';
 import { Trans } from '@lingui/macro';
 import { Box, Button, SvgIcon, Typography } from '@mui/material';
+import { useRootStore } from 'src/store/root';
+import { useShallow } from 'zustand/react/shallow';
 
 import { BasicModal } from './primitives/BasicModal';
 
@@ -19,7 +21,17 @@ export const AddressBlockedModal = ({
 }: AddressBlockedProps) => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
   const setOpen = (_value: boolean) => {}; // ignore, we want the modal to not be dismissable
+  const [setFeedbackOpen, setSupportPrefillMessage] = useRootStore(
+    useShallow((state) => [state.setFeedbackOpen, state.setSupportPrefillMessage])
+  );
+  const handleGetSupport = () => {
+    const walletAddress = address ? address : 'Address not available';
+    const template = `My wallet seems to be blocked:\n\n"${walletAddress}"`;
 
+    setSupportPrefillMessage(template);
+    setFeedbackOpen(true);
+    close();
+  };
   return (
     <BasicModal open={true} withCloseButton={false} setOpen={setOpen}>
       <Box
@@ -48,6 +60,10 @@ export const AddressBlockedModal = ({
               <Trans>Refresh</Trans>
             </Button>
           )}
+
+          <Button variant="outlined" onClick={handleGetSupport} size="small">
+            <Trans>Get support</Trans>
+          </Button>
           <Button variant="contained" onClick={onDisconnectWallet}>
             <SvgIcon fontSize="small" sx={{ mx: 1 }}>
               <LogoutIcon />

--- a/src/components/AddressBlockedModal.tsx
+++ b/src/components/AddressBlockedModal.tsx
@@ -26,7 +26,7 @@ export const AddressBlockedModal = ({
   );
   const handleGetSupport = () => {
     const walletAddress = address ? address : 'Address not available';
-    const template = `My wallet seems to be blocked:\n\n"${walletAddress}"`;
+    const template = `Unable to Connect:\n\n"${walletAddress}"`;
 
     setSupportPrefillMessage(template);
     setFeedbackOpen(true);
@@ -61,7 +61,7 @@ export const AddressBlockedModal = ({
             </Button>
           )}
 
-          <Button variant="outlined" onClick={handleGetSupport} size="small">
+          <Button variant="contained" onClick={handleGetSupport} size="small">
             <Trans>Get support</Trans>
           </Button>
           <Button variant="contained" onClick={onDisconnectWallet}>

--- a/src/components/AddressBlockedModal.tsx
+++ b/src/components/AddressBlockedModal.tsx
@@ -2,7 +2,7 @@ import { ExclamationCircleIcon, LogoutIcon, RefreshIcon } from '@heroicons/react
 import { Trans } from '@lingui/macro';
 import { Box, Button, SvgIcon, Typography } from '@mui/material';
 import { useRootStore } from 'src/store/root';
-import { useShallow } from 'zustand/react/shallow';
+import { useShallow } from 'zustand/shallow';
 
 import { BasicModal } from './primitives/BasicModal';
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1065,6 +1065,7 @@ msgstr "Reactivate cooldown period to unstake {0} {stakedToken}"
 msgid "Migrate to v3"
 msgstr "Migrate to v3"
 
+#: src/components/AddressBlockedModal.tsx
 #: src/components/transactions/FlowCommons/Error.tsx
 msgid "Get support"
 msgstr "Get support"


### PR DESCRIPTION
## General Changes

- add button to support in modal blocked address

<img width="570" height="290" alt="Screenshot 2026-02-26 at 6 53 44 PM" src="https://github.com/user-attachments/assets/3a23111b-05b0-4703-b512-f9c38bdb184c" />
<img width="496" height="616" alt="Screenshot 2026-02-26 at 6 54 07 PM" src="https://github.com/user-attachments/assets/bde80d05-7f0d-4db8-bf42-92aeb3e85380" />


## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
