### PR TITLE
fix: swap beforeNetworkCosts/afterNetworkCosts for cow-sdk v7.3.8 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@aave/react": "^0.8.2",
     "@amplitude/analytics-browser": "^2.13.0",
     "@bgd-labs/aave-address-book": "^4.44.22",
-    "@cowprotocol/cow-sdk": "7.3.4",
+    "@cowprotocol/cow-sdk": "7.3.8",
     "@cowprotocol/sdk-ethers-v5-adapter": "0.3.5",
     "@cowprotocol/sdk-flash-loans": "1.7.4",
     "@emotion/cache": "11.10.3",

--- a/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
+++ b/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
@@ -194,17 +194,19 @@ export async function getCowProtocolSellRates({
 
   if (invertedQuoteRoute) {
     // Calculate Amounts
+    // Note: beforeNetworkCosts/afterNetworkCosts were swapped in cow-sdk v7.3.5+
+    // (sdk-order-book v1.0.0) to fix a naming bug where the semantics were inverted.
     const srcSpotAmount =
       side === 'sell'
-        ? orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.buyAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString();
+        ? orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString()
+        : orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.buyAmount.toString();
     const srcSpotUSD = BigNumber(destTokenPriceUsd)
       .multipliedBy(BigNumber(srcSpotAmount).dividedBy(10 ** destDecimals))
       .toString();
     const destSpotAmount =
       side === 'sell'
-        ? orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString();
+        ? orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString()
+        : orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString();
     const destSpotUSD = BigNumber(srcTokenPriceUsd)
       .multipliedBy(BigNumber(destSpotAmount).dividedBy(10 ** srcDecimals))
       .toString();
@@ -236,17 +238,19 @@ export async function getCowProtocolSellRates({
     };
   } else {
     // Calculate Amounts
+    // Note: beforeNetworkCosts/afterNetworkCosts were swapped in cow-sdk v7.3.5+
+    // (sdk-order-book v1.0.0) to fix a naming bug where the semantics were inverted.
     const srcSpotAmount =
       orderBookQuote.quoteResults.orderToSign.kind === OrderKind.SELL
-        ? orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString();
+        ? orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString()
+        : orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString();
     const srcSpotUSD = BigNumber(srcTokenPriceUsd)
       .multipliedBy(BigNumber(srcSpotAmount).dividedBy(10 ** srcDecimals))
       .toString();
     const destSpotAmount =
       orderBookQuote.quoteResults.orderToSign.kind === OrderKind.SELL
-        ? orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.buyAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString();
+        ? orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString()
+        : orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.buyAmount.toString();
     const destSpotUSD = BigNumber(destTokenPriceUsd)
       .multipliedBy(BigNumber(destSpotAmount).dividedBy(10 ** destDecimals))
       .toString();

--- a/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
+++ b/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
@@ -194,19 +194,16 @@ export async function getCowProtocolSellRates({
 
   if (invertedQuoteRoute) {
     // Calculate Amounts
-    // Note: beforeNetworkCosts/afterNetworkCosts were swapped in cow-sdk v7.3.5+
-    // (sdk-order-book v1.0.0) to fix a naming bug where the semantics were inverted.
+    // cow-sdk v7.3.5+ (sdk-order-book v1.0.0) fixed a naming bug where
+    // beforeNetworkCosts/afterNetworkCosts were inverted for SELL orders.
+    // After the fix, both SELL and BUY resolve to the same fields.
     const srcSpotAmount =
-      side === 'sell'
-        ? orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.buyAmount.toString();
+      orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString();
     const srcSpotUSD = BigNumber(destTokenPriceUsd)
       .multipliedBy(BigNumber(srcSpotAmount).dividedBy(10 ** destDecimals))
       .toString();
     const destSpotAmount =
-      side === 'sell'
-        ? orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString();
+      orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString();
     const destSpotUSD = BigNumber(srcTokenPriceUsd)
       .multipliedBy(BigNumber(destSpotAmount).dividedBy(10 ** srcDecimals))
       .toString();
@@ -238,19 +235,16 @@ export async function getCowProtocolSellRates({
     };
   } else {
     // Calculate Amounts
-    // Note: beforeNetworkCosts/afterNetworkCosts were swapped in cow-sdk v7.3.5+
-    // (sdk-order-book v1.0.0) to fix a naming bug where the semantics were inverted.
+    // cow-sdk v7.3.5+ (sdk-order-book v1.0.0) fixed a naming bug where
+    // beforeNetworkCosts/afterNetworkCosts were inverted for SELL orders.
+    // After the fix, both SELL and BUY resolve to the same fields.
     const srcSpotAmount =
-      orderBookQuote.quoteResults.orderToSign.kind === OrderKind.SELL
-        ? orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.sellAmount.toString();
+      orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.sellAmount.toString();
     const srcSpotUSD = BigNumber(srcTokenPriceUsd)
       .multipliedBy(BigNumber(srcSpotAmount).dividedBy(10 ** srcDecimals))
       .toString();
     const destSpotAmount =
-      orderBookQuote.quoteResults.orderToSign.kind === OrderKind.SELL
-        ? orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString()
-        : orderBookQuote.quoteResults.amountsAndCosts.beforeNetworkCosts.buyAmount.toString();
+      orderBookQuote.quoteResults.amountsAndCosts.afterNetworkCosts.buyAmount.toString();
     const destSpotUSD = BigNumber(destTokenPriceUsd)
       .multipliedBy(BigNumber(destSpotAmount).dividedBy(10 ** destDecimals))
       .toString();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,18 +1390,18 @@
   dependencies:
     chalk "^4.1.0"
 
-"@cowprotocol/cow-sdk@7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-7.3.4.tgz#cdc4bb406cf3b21094fca9cc89e36cf3408af772"
-  integrity sha512-3ckIwrG7UV8jwe2D0UL7h9hLJDyS9cYJEEToFqMcarO1GcPUH8VA8p0g5XCy0MM8Kcp14kXA/aZ1seUPS8c15Q==
+"@cowprotocol/cow-sdk@7.3.8":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-7.3.8.tgz#b5911a709bc096e6f0bcd8bd87dc97fe600de616"
+  integrity sha512-ziY6vnvRYMqKfnOyONO8IabKTlVyCVsu5Iw84TyZKrx3BAjDIcuwFdlYxNVNXxyn3NPHru6t7NSJjrptSqZLLA==
   dependencies:
-    "@cowprotocol/sdk-app-data" "4.6.2"
-    "@cowprotocol/sdk-common" "0.5.4"
-    "@cowprotocol/sdk-config" "0.7.3"
-    "@cowprotocol/sdk-contracts-ts" "1.4.2"
-    "@cowprotocol/sdk-order-book" "0.6.3"
-    "@cowprotocol/sdk-order-signing" "0.1.30"
-    "@cowprotocol/sdk-trading" "0.10.0"
+    "@cowprotocol/sdk-app-data" "4.6.5"
+    "@cowprotocol/sdk-common" "0.6.2"
+    "@cowprotocol/sdk-config" "0.8.1"
+    "@cowprotocol/sdk-contracts-ts" "1.6.1"
+    "@cowprotocol/sdk-order-book" "1.0.0"
+    "@cowprotocol/sdk-order-signing" "0.1.34"
+    "@cowprotocol/sdk-trading" "1.0.0"
 
 "@cowprotocol/sdk-app-data@4.6.2":
   version "4.6.2"
@@ -1415,6 +1415,18 @@
     json-stringify-deterministic "^1.0.8"
     multiformats "^9.6.4"
 
+"@cowprotocol/sdk-app-data@4.6.5":
+  version "4.6.5"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-app-data/-/sdk-app-data-4.6.5.tgz#b202913b0593214e2012f2e570bb73699e630a8b"
+  integrity sha512-0ww6vtJ13SOoHA8YIX/DXzswteYnD1w7McQO/t4TsYGXIhrfwSj1aV5hBscp+Nkyvrh9CSwGQfBWWMs2BhPq9g==
+  dependencies:
+    "@cowprotocol/sdk-common" "0.6.2"
+    ajv "^8.11.0"
+    cross-fetch "^3.1.5"
+    ipfs-only-hash "^4.0.0"
+    json-stringify-deterministic "^1.0.8"
+    multiformats "^9.6.4"
+
 "@cowprotocol/sdk-common@0.5.4":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-common/-/sdk-common-0.5.4.tgz#4792030fee1297d33c70afd027c87bbbbb06197b"
@@ -1422,10 +1434,25 @@
   dependencies:
     "@cowprotocol/sdk-config" "0.7.3"
 
+"@cowprotocol/sdk-common@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-common/-/sdk-common-0.6.2.tgz#21738c0b7c7100eb8bbd99bd7b98b0c429dba6ee"
+  integrity sha512-zoifb8uzi1b8jQh7SidMx3iqRIlL+eu38MzmGIOtcO10oDNEgu8ved479baLdclu+uXb0soutOjAYLj0TAIEFA==
+  dependencies:
+    "@cowprotocol/sdk-config" "0.8.1"
+
 "@cowprotocol/sdk-config@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-config/-/sdk-config-0.7.3.tgz#e60f599e535629fcb1f2fc3c1ead982bb9bc0b0d"
   integrity sha512-rDkld/1JRTBXzAKgI1a/GH2YnXdJtMTSX7VwSIUnxviySbUuUnx7JqA4BciAqoJfdoPw5yhwmxPr8TLf1trdhA==
+  dependencies:
+    exponential-backoff "^3.1.1"
+    limiter "^2.1.0"
+
+"@cowprotocol/sdk-config@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-config/-/sdk-config-0.8.1.tgz#90515cfba8c6dfdb172b665882779b082396efcc"
+  integrity sha512-gKrILavzbIYkvju0Ko58KAw5b+YM6RN7MYfk7qND9RkGi1E99gHOgfgwp9hWvNhlXf2V/ltM0INl5OV2tQuMKg==
   dependencies:
     exponential-backoff "^3.1.1"
     limiter "^2.1.0"
@@ -1437,6 +1464,14 @@
   dependencies:
     "@cowprotocol/sdk-common" "0.5.4"
     "@cowprotocol/sdk-config" "0.7.3"
+
+"@cowprotocol/sdk-contracts-ts@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-contracts-ts/-/sdk-contracts-ts-1.6.1.tgz#bfd2b493c58f6d5166c5484bfe69af3464e1658a"
+  integrity sha512-nKIYU0dI88pruZdflMwsdLm1xQWwJ+E+GXuBiIbisZEf632ONMFJKlF2d72d3xWP4rvRyeWjnek2K3K87QOSOg==
+  dependencies:
+    "@cowprotocol/sdk-common" "0.6.2"
+    "@cowprotocol/sdk-config" "0.8.1"
 
 "@cowprotocol/sdk-ethers-v5-adapter@0.3.5":
   version "0.3.5"
@@ -1468,6 +1503,17 @@
     exponential-backoff "^3.1.2"
     limiter "^3.0.0"
 
+"@cowprotocol/sdk-order-book@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-order-book/-/sdk-order-book-1.0.0.tgz#34dccaef736fbd97e6ec1a2d205cf07b027203a1"
+  integrity sha512-qDxiI/kJq6JjYkbjh8/u9X3N5h5kJvZ0F0+KN7snk4x0IjiYnb0I5ETXYFFkNsnko5qBGI9wVhvTfE6EHuqPjA==
+  dependencies:
+    "@cowprotocol/sdk-common" "0.6.2"
+    "@cowprotocol/sdk-config" "0.8.1"
+    cross-fetch "^3.2.0"
+    exponential-backoff "^3.1.2"
+    limiter "^3.0.0"
+
 "@cowprotocol/sdk-order-signing@0.1.30":
   version "0.1.30"
   resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-order-signing/-/sdk-order-signing-0.1.30.tgz#ff80e7d2a5f1da1ef42b74ec92ed937425193eb9"
@@ -1477,6 +1523,16 @@
     "@cowprotocol/sdk-config" "0.7.3"
     "@cowprotocol/sdk-contracts-ts" "1.4.2"
     "@cowprotocol/sdk-order-book" "0.6.3"
+
+"@cowprotocol/sdk-order-signing@0.1.34":
+  version "0.1.34"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-order-signing/-/sdk-order-signing-0.1.34.tgz#cb191cdde04b508d98e5605d367985381a4322ea"
+  integrity sha512-jUnxoo2ovff15RZUgE+hefe5Enql/r8R9vhspRYAt7m5VW6/6CcI3G0/n2KV1wsiqssMEp/QB8HVlC1AtAQ6dg==
+  dependencies:
+    "@cowprotocol/sdk-common" "0.6.2"
+    "@cowprotocol/sdk-config" "0.8.1"
+    "@cowprotocol/sdk-contracts-ts" "1.6.1"
+    "@cowprotocol/sdk-order-book" "1.0.0"
 
 "@cowprotocol/sdk-trading@0.10.0":
   version "0.10.0"
@@ -1489,6 +1545,19 @@
     "@cowprotocol/sdk-contracts-ts" "1.4.2"
     "@cowprotocol/sdk-order-book" "0.6.3"
     "@cowprotocol/sdk-order-signing" "0.1.30"
+    deepmerge "^4.3.1"
+
+"@cowprotocol/sdk-trading@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-trading/-/sdk-trading-1.0.0.tgz#3739a8ee1ac793b963d0858fc1953bd394dd44cb"
+  integrity sha512-iQPA3Fv2eu9jlTD0/YKWGTm425JWhjveSpk9UVYWkK0tP3F/SIAg39DgZv/V3Kd34Z4cnNjRb5mIhFz1v+vVMA==
+  dependencies:
+    "@cowprotocol/sdk-app-data" "4.6.5"
+    "@cowprotocol/sdk-common" "0.6.2"
+    "@cowprotocol/sdk-config" "0.8.1"
+    "@cowprotocol/sdk-contracts-ts" "1.6.1"
+    "@cowprotocol/sdk-order-book" "1.0.0"
+    "@cowprotocol/sdk-order-signing" "0.1.34"
     deepmerge "^4.3.1"
 
 "@cspotcode/source-map-support@^0.8.0":


### PR DESCRIPTION
## Summary

- Bumps `@cowprotocol/cow-sdk` from `7.3.4` to `7.3.8`
- Swaps `beforeNetworkCosts` / `afterNetworkCosts` references in `rates.helpers.ts` to match corrected semantics

## Context

[cow-sdk PR #800](https://github.com/cowprotocol/cow-sdk/pull/800) (shipped in `sdk-order-book@1.0.0`, bundled in `cow-sdk@7.3.5+`) fixed a naming bug where `beforeNetworkCosts` and `afterNetworkCosts` had **inverted semantics** for SELL orders.

The CoW `/quote` API returns `sellAmount` already **after** network costs for SELL orders. The old SDK incorrectly labeled this as `beforeNetworkCosts`, and `sellAmount + feeAmount` (the pre-fee value) as `afterNetworkCosts`.

The new SDK fixes the labels to match their actual meaning:
| Field (SELL order) | Old SDK (v7.3.4) | New SDK (v7.3.8) |
|---|---|---|
| `beforeNetworkCosts.sellAmount` | 0.99 ETH (actually after) | 1.0 ETH (correct: before) |
| `afterNetworkCosts.sellAmount` | 1.0 ETH (actually before) | 0.99 ETH (correct: after) |

Our code relied on the old (inverted) naming to get the user's input amount via `afterNetworkCosts.sellAmount`. With the fix, we swap the references so the same values are retrieved under the now-correct field names.

See [migration guide](https://github.com/cowprotocol/cow-sdk/blob/main/packages/order-book/src/quoteAmountsAndCosts/MIGRATION.md) for full details.

## Test plan

- [ ] Verify SELL quote: `srcSpotAmount` matches user's input amount (e.g., 1.0 ETH)
- [ ] Verify BUY quote: `destSpotAmount` matches user's requested buy amount
- [ ] Verify inverted quote routes display correct amounts
- [ ] Run `yarn install` to pull updated lockfile for cow-sdk 7.3.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)