### PR TITLE
fix: handle non-Error wallet rejections in error UI and Sentry filters

### DIFF
--- a/src/components/transactions/FlowCommons/GasEstimationError.tsx
+++ b/src/components/transactions/FlowCommons/GasEstimationError.tsx
@@ -4,6 +4,21 @@ import { Warning } from 'src/components/primitives/Warning';
 import { TxErrorType } from 'src/ui-config/errorMapping';
 
 export const GasEstimationError = ({ txError }: { txError: TxErrorType }) => {
+  const isUserRejection = !txError.blocking && !txError.actionBlocked;
+
+  if (isUserRejection) {
+    return (
+      <Warning severity="info" sx={{ mt: 4, mb: 0 }}>
+        <Typography variant="description">{txError.error}</Typography>
+      </Warning>
+    );
+  }
+
+  const errorText =
+    txError.rawError instanceof Error
+      ? txError.rawError.message
+      : String(txError.rawError ?? 'Unknown error');
+
   return (
     <Warning severity="error" sx={{ mt: 4, mb: 0 }}>
       <Typography variant="description">
@@ -13,7 +28,7 @@ export const GasEstimationError = ({ txError }: { txError: TxErrorType }) => {
             <Button
               sx={{ verticalAlign: 'top' }}
               variant="text"
-              onClick={() => navigator.clipboard.writeText(txError.rawError.message.toString())}
+              onClick={() => navigator.clipboard.writeText(errorText)}
             >
               <Typography variant="description">
                 <Trans>copy the error</Trans>
@@ -25,7 +40,7 @@ export const GasEstimationError = ({ txError }: { txError: TxErrorType }) => {
             There was some error. Please try changing the parameters or{' '}
             <Button
               sx={{ verticalAlign: 'top' }}
-              onClick={() => navigator.clipboard.writeText(txError.rawError.message.toString())}
+              onClick={() => navigator.clipboard.writeText(errorText)}
             >
               <Typography variant="description">copy the error</Typography>
             </Button>

--- a/src/helpers/useTransactionHandler.tsx
+++ b/src/helpers/useTransactionHandler.tsx
@@ -248,7 +248,7 @@ export const useTransactionHandler = ({
                         txHash: hash,
                         loading: false,
                       });
-                      reject(error);
+                      reject();
                     },
                     approval: true,
                   });

--- a/src/helpers/useTransactionHandler.tsx
+++ b/src/helpers/useTransactionHandler.tsx
@@ -248,7 +248,7 @@ export const useTransactionHandler = ({
                         txHash: hash,
                         loading: false,
                       });
-                      reject();
+                      reject(error);
                     },
                     approval: true,
                   });
@@ -263,6 +263,8 @@ export const useTransactionHandler = ({
           });
         } catch (error) {
           if (!mounted.current) return;
+          // Skip if error was already handled by the inner errorCallback
+          if (error == null) return;
           const parsedError = getErrorTextFromError(error, TxAction.GAS_ESTIMATION, false);
           setTxError(parsedError);
           setApprovalTxState({

--- a/src/ui-config/errorMapping.tsx
+++ b/src/ui-config/errorMapping.tsx
@@ -27,13 +27,17 @@ export const isTxErrorType = (error: any): error is TxErrorType => {
 };
 
 export const getErrorTextFromError = (
-  error: Error,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error: any,
   txAction: TxAction,
   blocking = true
 ): TxErrorType => {
   let errorNumber = 1;
 
-  if (error.message.toLowerCase().startsWith('user rejected')) {
+  const errorMessage: string =
+    (error instanceof Error ? error.message : error?.message ?? String(error ?? '')) || '';
+
+  if (errorMessage.toLowerCase().startsWith('user rejected')) {
     return {
       error: errorMapping[4001],
       blocking: false,

--- a/src/utils/sentryFilters.ts
+++ b/src/utils/sentryFilters.ts
@@ -78,9 +78,15 @@ const IGNORED_CULPRIT_PATTERNS: RegExp[] = [
 ];
 
 export function shouldIgnoreError(event: Event): boolean {
-  const message = event.exception?.values?.[0]?.value ?? event.message ?? '';
+  const exceptionValue = event.exception?.values?.[0];
+  const errorType = exceptionValue?.type ?? '';
+  const errorMessage = exceptionValue?.value ?? event.message ?? '';
+  // Combine type + message so patterns can match either field.
+  // Sentry stores the class name in `type` and the description in `value`,
+  // but many wallet errors only populate one of the two.
+  const message = errorType ? `${errorType}: ${errorMessage}` : errorMessage;
   const culprit = (event as Record<string, unknown>).culprit as string | undefined;
-  const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+  const frames = exceptionValue?.stacktrace?.frames ?? [];
   const topFilename = frames.length > 0 ? frames[frames.length - 1]?.filename : undefined;
 
   // Unconditional message-based filters (safe regardless of source)


### PR DESCRIPTION
## Summary
- GasEstimationError.tsx crashed when `rawError` wasn't a standard Error object (e.g. wallet rejection objects from ethers/viem), causing `TypeError: Cannot read properties of undefined (reading 'message')` to be sent to Sentry on every wallet rejection. This was the main source of Sentry noise.
- Wallet rejections now show as info ("You cancelled the transaction") instead of a red error banner
- `getErrorTextFromError` now safely handles non-Error catch values
- Fixed `reject()` in useTransactionHandler passing `undefined` to the outer catch, which overwrote the correctly parsed rejection with a generic error
- Sentry filter now combines exception `type` + `value` so patterns can match error class names (e.g. `UserRejectedRequestError`)

## Test plan
- [x] Reject a wallet transaction locally, verify info banner shows (not error)
- [x] Verify no TypeError sent to Sentry on rejection
- [x] Verify Sentry filter drops matching errors (`setTimeout(() => { throw new Error("User rejected the request") }, 0)`)
- [x] Verify real errors still pass through to Sentry