### PR TITLE
feat: route CoW partner fee to market COLLECTOR address

### DIFF
--- a/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActionsViaCoWAdapters.tsx
+++ b/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActionsViaCoWAdapters.tsx
@@ -54,7 +54,9 @@ export const CollateralSwapActionsViaCowAdapters = ({
   setState: Dispatch<Partial<SwapState>>;
   trackingHandlers: TrackAnalyticsHandlers;
 }) => {
-  const [user] = useRootStore(useShallow((state) => [state.account]));
+  const [user, currentMarket] = useRootStore(
+    useShallow((state) => [state.account, state.currentMarket])
+  );
 
   const collateralsAmount = useCollateralsAmount();
 
@@ -83,6 +85,7 @@ export const CollateralSwapActionsViaCowAdapters = ({
       validTo,
       type: AaveFlashLoanType.CollateralSwap,
       state,
+      market: currentMarket,
     })
       .catch((error) => {
         console.error('calculateInstanceAddress error', error);
@@ -203,7 +206,8 @@ export const CollateralSwapActionsViaCowAdapters = ({
         partnerFee: COW_PARTNER_FEE(
           state.sellAmountToken.symbol,
           state.buyAmountToken.symbol,
-          state.swapType
+          state.swapType,
+          currentMarket
         ),
       };
 

--- a/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActionsViaCoWAdapters.tsx
+++ b/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActionsViaCoWAdapters.tsx
@@ -110,6 +110,7 @@ export const CollateralSwapActionsViaCowAdapters = ({
     state.slippage,
     state.orderType,
     state.chainId,
+    currentMarket,
   ]);
 
   // Approval is aToken ERC20 Approval

--- a/src/components/transactions/Swap/actions/DebtSwap/DebtSwapActionsViaCoW.tsx
+++ b/src/components/transactions/Swap/actions/DebtSwap/DebtSwapActionsViaCoW.tsx
@@ -122,6 +122,7 @@ export const DebtSwapActionsViaCoW = ({
     APP_CODE_PER_SWAP_TYPE[state.swapType],
     approvalTxState.loading,
     approvalTxState.success,
+    currentMarket,
   ]);
 
   const amountToApprove = useMemo(() => {

--- a/src/components/transactions/Swap/actions/DebtSwap/DebtSwapActionsViaCoW.tsx
+++ b/src/components/transactions/Swap/actions/DebtSwap/DebtSwapActionsViaCoW.tsx
@@ -60,7 +60,9 @@ export const DebtSwapActionsViaCoW = ({
   setState: Dispatch<Partial<SwapState>>;
   trackingHandlers: TrackAnalyticsHandlers;
 }) => {
-  const [user] = useRootStore(useShallow((state) => [state.account]));
+  const [user, currentMarket] = useRootStore(
+    useShallow((state) => [state.account, state.currentMarket])
+  );
 
   const debtAmount = useCollateralsAmount();
 
@@ -92,6 +94,7 @@ export const DebtSwapActionsViaCoW = ({
       validTo,
       type: AaveFlashLoanType.DebtSwap,
       state,
+      market: currentMarket,
     })
       .catch((error) => {
         console.error('calculateInstanceAddress error', error);
@@ -230,7 +233,8 @@ export const DebtSwapActionsViaCoW = ({
         partnerFee: COW_PARTNER_FEE(
           state.sellAmountToken.symbol,
           state.buyAmountToken.symbol,
-          state.swapType
+          state.swapType,
+          currentMarket
         ),
       };
 

--- a/src/components/transactions/Swap/actions/RepayWithCollateral/RepayWithCollateralActionsViaCoW.tsx
+++ b/src/components/transactions/Swap/actions/RepayWithCollateral/RepayWithCollateralActionsViaCoW.tsx
@@ -122,6 +122,7 @@ export const RepayWithCollateralActionsViaCoW = ({
     APP_CODE_PER_SWAP_TYPE[state.swapType],
     approvalTxState.loading,
     approvalTxState.success,
+    currentMarket,
   ]);
 
   // Approval is aToken ERC20 Approval

--- a/src/components/transactions/Swap/actions/RepayWithCollateral/RepayWithCollateralActionsViaCoW.tsx
+++ b/src/components/transactions/Swap/actions/RepayWithCollateral/RepayWithCollateralActionsViaCoW.tsx
@@ -60,7 +60,9 @@ export const RepayWithCollateralActionsViaCoW = ({
   setState: Dispatch<Partial<SwapState>>;
   trackingHandlers: TrackAnalyticsHandlers;
 }) => {
-  const [user] = useRootStore(useShallow((state) => [state.account]));
+  const [user, currentMarket] = useRootStore(
+    useShallow((state) => [state.account, state.currentMarket])
+  );
 
   const collateralsAmount = useCollateralsAmount();
 
@@ -92,6 +94,7 @@ export const RepayWithCollateralActionsViaCoW = ({
       validTo,
       type: AaveFlashLoanType.RepayCollateral,
       state,
+      market: currentMarket,
     })
       .catch((error) => {
         console.error('calculateInstanceAddress error', error);
@@ -228,7 +231,8 @@ export const RepayWithCollateralActionsViaCoW = ({
         partnerFee: COW_PARTNER_FEE(
           state.sellAmountToken.symbol,
           state.buyAmountToken.symbol,
-          state.swapType
+          state.swapType,
+          currentMarket
         ),
       };
 

--- a/src/components/transactions/Swap/actions/SwapActions/SwapActionsViaCoW.tsx
+++ b/src/components/transactions/Swap/actions/SwapActions/SwapActionsViaCoW.tsx
@@ -68,8 +68,13 @@ export const SwapActionsViaCoW = ({
   setState: Dispatch<Partial<SwapState>>;
   trackingHandlers: TrackAnalyticsHandlers;
 }) => {
-  const [user, estimateGasLimit, addTransaction] = useRootStore(
-    useShallow((state) => [state.account, state.estimateGasLimit, state.addTransaction])
+  const [user, estimateGasLimit, addTransaction, currentMarket] = useRootStore(
+    useShallow((state) => [
+      state.account,
+      state.estimateGasLimit,
+      state.addTransaction,
+      state.currentMarket,
+    ])
   );
 
   const { mainTxState, loadingTxns, setMainTxState, setTxError, approvalTxState } =
@@ -187,6 +192,7 @@ export const SwapActionsViaCoW = ({
             appCode,
             state.orderType,
             params.swapType,
+            currentMarket,
             state.swapRate.quoteId
           );
           const txWithGasEstimation = await estimateGasLimit(ethFlowTx, state.chainId);
@@ -222,6 +228,7 @@ export const SwapActionsViaCoW = ({
               orderType: state.orderType,
               validTo,
               swapType: params.swapType,
+              market: currentMarket,
             });
             const calculatedOrderId = await calculateUniqueOrderId(state.chainId, unsignerOrder);
 
@@ -235,7 +242,8 @@ export const SwapActionsViaCoW = ({
                   smartSlippage,
                   state.orderType,
                   APP_CODE_PER_SWAP_TYPE[params.swapType],
-                  params.swapType
+                  params.swapType,
+                  currentMarket
                 )
               ),
               state.chainId
@@ -292,6 +300,7 @@ export const SwapActionsViaCoW = ({
                 orderBookQuote: state.swapRate?.orderBookQuote,
                 orderType: state.orderType,
                 swapType: params.swapType,
+                market: currentMarket,
                 kind:
                   state.orderType === OrderType.MARKET
                     ? OrderKind.SELL
@@ -338,6 +347,7 @@ export const SwapActionsViaCoW = ({
                 smartSlippage,
                 orderType: state.orderType,
                 swapType: params.swapType,
+                market: currentMarket,
                 kind:
                   state.orderType === OrderType.MARKET
                     ? OrderKind.SELL

--- a/src/components/transactions/Swap/constants/cow.constants.ts
+++ b/src/components/transactions/Swap/constants/cow.constants.ts
@@ -1,5 +1,7 @@
 import { CowEnv, OrderClass, SupportedChainId } from '@cowprotocol/cow-sdk';
 import { AaveFlashLoanType } from '@cowprotocol/sdk-flash-loans';
+import { CustomMarket } from 'src/ui-config/marketsConfig';
+import { marketsData } from 'src/utils/marketsAndNetworksConfig';
 
 import { getAssetGroup } from '../helpers/shared/assetCorrelation.helpers';
 import { OrderType, SwapType } from '../types';
@@ -156,10 +158,16 @@ const PARTNER_FEE_BPS_BY_SWAP_TYPE: Partial<Record<SwapType, number>> = {
   [SwapType.DebtSwap]: 0,
 };
 
+const getPartnerFeeRecipient = (market: CustomMarket): string => {
+  const collector = marketsData[market]?.addresses?.COLLECTOR;
+  return collector || COW_EVM_RECIPIENT;
+};
+
 export const COW_PARTNER_FEE = (
   tokenFromSymbol: string,
   tokenToSymbol: string,
-  swapType?: SwapType
+  swapType: SwapType,
+  market: CustomMarket
 ) => {
   const swapTypeBps = swapType !== undefined ? PARTNER_FEE_BPS_BY_SWAP_TYPE[swapType] : undefined;
 
@@ -170,7 +178,7 @@ export const COW_PARTNER_FEE = (
 
   return {
     volumeBps: swapTypeBps !== undefined ? swapTypeBps : defaultBps,
-    recipient: COW_EVM_RECIPIENT,
+    recipient: getPartnerFeeRecipient(market),
   };
 };
 
@@ -183,7 +191,8 @@ export const COW_APP_DATA = (
   smartSlippage: boolean,
   orderType: OrderType,
   appCode: string,
-  swapType?: SwapType,
+  swapType: SwapType,
+  market: CustomMarket,
   hooks?: Record<string, unknown>
 ) => ({
   appCode: appCode,
@@ -196,7 +205,7 @@ export const COW_APP_DATA = (
       ? { quote: { slippageBips, smartSlippage } }
       : // Slippage is not used in limit orders
         {}),
-    partnerFee: COW_PARTNER_FEE(tokenFromSymbol, tokenToSymbol, swapType),
+    partnerFee: COW_PARTNER_FEE(tokenFromSymbol, tokenToSymbol, swapType, market),
     hooks,
   },
 });

--- a/src/components/transactions/Swap/helpers/cow/adapters.helpers.ts
+++ b/src/components/transactions/Swap/helpers/cow/adapters.helpers.ts
@@ -14,6 +14,7 @@ import {
   FlashLoanHookAmounts,
   HASH_ZERO,
 } from '@cowprotocol/sdk-flash-loans';
+import { CustomMarket } from 'src/ui-config/marketsConfig';
 
 import {
   COW_PARTNER_FEE,
@@ -39,11 +40,13 @@ export const calculateInstanceAddress = async ({
   validTo,
   type,
   state,
+  market,
 }: {
   user: string;
   validTo: number;
   type: AaveFlashLoanType;
   state: SwapState;
+  market: CustomMarket;
 }) => {
   if (!user) return;
   if (
@@ -83,7 +86,8 @@ export const calculateInstanceAddress = async ({
     partnerFee: COW_PARTNER_FEE(
       state.sellAmountToken.symbol,
       state.buyAmountToken.symbol,
-      state.swapType
+      state.swapType,
+      market
     ),
   };
 

--- a/src/components/transactions/Swap/helpers/cow/orders.helpers.ts
+++ b/src/components/transactions/Swap/helpers/cow/orders.helpers.ts
@@ -19,6 +19,7 @@ import { AnyAppDataDocVersion, AppDataParams, MetadataApi } from '@cowprotocol/s
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { BigNumber, ethers, PopulatedTransaction } from 'ethers';
 import { isSmartContractWallet } from 'src/helpers/provider';
+import { CustomMarket } from 'src/ui-config/marketsConfig';
 
 import { SignedParams } from '../../actions/approval/useSwapTokenApproval';
 import {
@@ -74,7 +75,8 @@ export type CowProtocolActionParams = {
   signatureParams?: SignedParams;
   estimateGasLimit?: (tx: PopulatedTransaction, chainId?: number) => Promise<PopulatedTransaction>;
   validTo: number;
-  swapType?: SwapType;
+  swapType: SwapType;
+  market: CustomMarket;
 };
 
 export const getPreSignTransaction = async ({
@@ -96,6 +98,7 @@ export const getPreSignTransaction = async ({
   kind,
   validTo,
   swapType,
+  market,
 }: CowProtocolActionParams) => {
   if (!isChainIdSupportedByCoWProtocol(chainId)) {
     throw new Error('Chain not supported.');
@@ -128,7 +131,8 @@ export const getPreSignTransaction = async ({
         smartSlippage,
         orderType,
         appCode,
-        swapType
+        swapType,
+        market
       ),
       additionalParams: {
         signingScheme: SigningScheme.PRESIGN,
@@ -169,6 +173,7 @@ export const sendOrder = async ({
   estimateGasLimit,
   validTo,
   swapType,
+  market,
 }: CowProtocolActionParams) => {
   const signer = provider?.getSigner();
 
@@ -204,6 +209,7 @@ export const sendOrder = async ({
     orderType,
     appCode,
     swapType,
+    market,
     hooks
   );
 
@@ -295,6 +301,7 @@ export const getUnsignerOrder = async ({
   srcToken,
   receiver,
   swapType,
+  market,
 }: {
   sellAmount: string;
   buyAmount: string;
@@ -310,7 +317,8 @@ export const getUnsignerOrder = async ({
   validTo: number;
   srcToken?: string;
   receiver?: string;
-  swapType?: SwapType;
+  swapType: SwapType;
+  market: CustomMarket;
 }) => {
   const metadataApi = new MetadataApi();
   const { appDataHex } = await metadataApi.getAppDataInfo(
@@ -321,7 +329,8 @@ export const getUnsignerOrder = async ({
       smartSlippage,
       orderType,
       appCode,
-      swapType
+      swapType,
+      market
     )
   );
 
@@ -361,7 +370,8 @@ export const populateEthFlowTx = async (
   smartSlippage: boolean,
   appCode: string,
   orderType: OrderType,
-  swapType?: SwapType,
+  swapType: SwapType,
+  market: CustomMarket,
   quoteId?: number
 ): Promise<PopulatedTransaction> => {
   const appDataHex = await hashAppData(
@@ -372,7 +382,8 @@ export const populateEthFlowTx = async (
       smartSlippage,
       orderType,
       appCode,
-      swapType
+      swapType,
+      market
     )
   );
 

--- a/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
+++ b/src/components/transactions/Swap/helpers/cow/rates.helpers.ts
@@ -56,6 +56,7 @@ export async function getCowProtocolSellRates({
   isInputTokenCustom,
   isOutputTokenCustom,
   appCode,
+  market,
   setError,
   side = 'sell',
   invertedQuoteRoute = false,
@@ -103,7 +104,7 @@ export async function getCowProtocolSellRates({
             buyTokenDecimals: destDecimals,
             signer,
             appCode: appCode,
-            partnerFee: COW_PARTNER_FEE(inputSymbol, outputSymbol, swapType),
+            partnerFee: COW_PARTNER_FEE(inputSymbol, outputSymbol, swapType, market),
           },
           {
             // Price Quality is set to OPTIMAL by default

--- a/src/components/transactions/Swap/hooks/useSwapOrderAmounts.ts
+++ b/src/components/transactions/Swap/hooks/useSwapOrderAmounts.ts
@@ -1,6 +1,7 @@
 import { normalize, normalizeBN, valueToBigNumber } from '@aave/math-utils';
 import { OrderKind } from '@cowprotocol/cow-sdk';
 import { Dispatch, useEffect } from 'react';
+import { useRootStore } from 'src/store/root';
 
 import { COW_PARTNER_FEE, FLASH_LOAN_FEE_BPS } from '../constants/cow.constants';
 import { PARASWAP_FLASH_LOAN_FEE_BPS } from '../constants/paraswap.constants';
@@ -48,6 +49,8 @@ export const useSwapOrderAmounts = ({
   state: SwapState;
   setState: Dispatch<Partial<SwapState>>;
 }) => {
+  const currentMarket = useRootStore((state) => state.currentMarket);
+
   useEffect(() => {
     if (
       !state.swapRate?.afterFeesAmount ||
@@ -79,8 +82,12 @@ export const useSwapOrderAmounts = ({
     let networkFeeAmountInBuyFormatted = '0';
     const partnetFeeBps =
       state.provider === SwapProvider.COW_PROTOCOL
-        ? COW_PARTNER_FEE(state.sourceToken.symbol, state.destinationToken.symbol, state.swapType)
-            .volumeBps
+        ? COW_PARTNER_FEE(
+            state.sourceToken.symbol,
+            state.destinationToken.symbol,
+            state.swapType,
+            currentMarket
+          ).volumeBps
         : 0;
     const partnerFeeAmount =
       state.side === 'sell'

--- a/src/components/transactions/Swap/hooks/useSwapQuote.ts
+++ b/src/components/transactions/Swap/hooks/useSwapQuote.ts
@@ -420,7 +420,8 @@ const useMultiProviderSwapQuoteQuery = ({
       requiresQuoteInverted,
       srcToken,
       destToken,
-      state.user
+      state.user,
+      currentMarket
     ),
     enabled: (() => {
       // Allow fetch when user has entered a positive amount, even if normalization rounded to '0'

--- a/src/components/transactions/Swap/hooks/useSwapQuote.ts
+++ b/src/components/transactions/Swap/hooks/useSwapQuote.ts
@@ -2,6 +2,7 @@ import { normalizeBN } from '@aave/math-utils';
 import { useQuery } from '@tanstack/react-query';
 import { Dispatch, useEffect, useMemo } from 'react';
 import { useModalContext } from 'src/hooks/useModal';
+import { useRootStore } from 'src/store/root';
 import { isTxErrorType, TxErrorType } from 'src/ui-config/errorMapping';
 import { queryKeysFactory } from 'src/ui-config/queries';
 
@@ -289,6 +290,7 @@ const useMultiProviderSwapQuoteQuery = ({
   requiresQuoteInverted: boolean;
 }) => {
   const { approvalTxState } = useModalContext();
+  const currentMarket = useRootStore((state) => state.currentMarket);
 
   // Amount to quote depends on side (sell uses input amount, buy uses output amount)
   const amount = useMemo(() => {
@@ -382,6 +384,7 @@ const useMultiProviderSwapQuoteQuery = ({
             isInputTokenCustom,
             isOutputTokenCustom,
             appCode,
+            market: currentMarket,
             setError,
             side,
             invertedQuoteRoute: requiresQuoteInverted,
@@ -398,6 +401,7 @@ const useMultiProviderSwapQuoteQuery = ({
             destDecimals,
             side,
             appCode,
+            market: currentMarket,
             options: {
               partner: appCode,
             },

--- a/src/components/transactions/Swap/types/quote.types.ts
+++ b/src/components/transactions/Swap/types/quote.types.ts
@@ -1,6 +1,7 @@
 import { OrderParameters, QuoteAmountsAndCosts, QuoteAndPost } from '@cowprotocol/cow-sdk';
 import { OptimalRate } from '@paraswap/core';
 import { TxErrorType } from 'src/ui-config/errorMapping';
+import { CustomMarket } from 'src/ui-config/marketsConfig';
 
 import { SwapProvider, SwapType } from './shared.types';
 
@@ -29,6 +30,7 @@ export type ProviderRatesParams = {
   isInputTokenCustom?: boolean;
   isOutputTokenCustom?: boolean;
   appCode: string;
+  market: CustomMarket;
 
   setError?: (error: Error | TxErrorType) => void;
 };

--- a/src/ui-config/queries.ts
+++ b/src/ui-config/queries.ts
@@ -98,7 +98,8 @@ export const queryKeysFactory = {
     requiresQuoteInverted: boolean,
     srcToken: string,
     destToken: string,
-    user: string
+    user: string,
+    market?: string
   ) => [
     ...queryKeysFactory.user(user),
     chainId,
@@ -107,6 +108,7 @@ export const queryKeysFactory = {
     requiresQuoteInverted,
     srcToken,
     destToken,
+    market,
     'swapQuote',
   ],
   gasPrices: (chainId: number) => [chainId, 'gasPrices'],


### PR DESCRIPTION
## Summary
- CoW Swap partner fee recipient was hardcoded to a single address (`COW_EVM_RECIPIENT`) for all markets
- Each Aave market has its own COLLECTOR contract, so fees should route to the correct one
- `COW_PARTNER_FEE` and `COW_APP_DATA` now take a required `CustomMarket` param, resolve the COLLECTOR from `marketsData`, and fall back to `COW_EVM_RECIPIENT` when no COLLECTOR is configured (e.g. Ink)

## Test plan
- [ ] Verify a swap quote on Ethereum Core market includes `0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c` as partner fee recipient
- [ ] Verify a swap quote on Ethereum Horizon market includes `0x70CC725B8f05e0f230B05C4e91ABc651E121354f` as partner fee recipient
- [ ] Verify a swap on Arbitrum includes `0x053D55f9B5AF8694c503EB288a1B7E552f590710`
- [ ] Verify adapter flows (collateral swap, debt swap, repay with collateral) also use the correct COLLECTOR