### PR TITLE
feat: use ParaSwap as sole swap provider, pause CoW Protocol

### DIFF
--- a/src/components/transactions/Swap/helpers/shared/provider.helpers.ts
+++ b/src/components/transactions/Swap/helpers/shared/provider.helpers.ts
@@ -1,65 +1,14 @@
-import {
-  COW_UNSUPPORTED_ASSETS,
-  isChainIdSupportedByCoWProtocol,
-} from '../../constants/cow.constants';
 import { ParaswapSupportedNetworks } from '../../constants/paraswap.constants';
 import { SwapProvider, SwapType } from '../../types';
-
-/**
- * Returns whether CoW Protocol can handle the given pair/swapType on the chain.
- * Checks chain support and a per-flow unsupported assets list.
- */
-export const isSwapSupportedByCowProtocol = (
-  chainId: number,
-  assetFrom: string,
-  assetTo: string,
-  swapType: SwapType,
-  useFlashloan: boolean
-) => {
-  if (!isChainIdSupportedByCoWProtocol(chainId)) return false;
-
-  let swapTypeToUse = swapType;
-  if (useFlashloan == false && swapType === SwapType.CollateralSwap) {
-    swapTypeToUse = SwapType.Swap;
-  }
-
-  // Helper to normalize values that can be string[] or 'ALL' to always be an array
-  const normalizeToArray = (value: string[] | 'ALL' | undefined): string[] => {
-    if (!value) return [];
-    if (value === 'ALL') return ['ALL'];
-    return value;
-  };
-
-  const unsupportedAssetsPerChainAndModalType = [
-    ...normalizeToArray(COW_UNSUPPORTED_ASSETS['ALL']?.[chainId]),
-    ...normalizeToArray(COW_UNSUPPORTED_ASSETS[swapTypeToUse]?.[chainId]),
-  ];
-
-  if (unsupportedAssetsPerChainAndModalType.length === 0) return true; // No unsupported assets for this chain and modal type
-
-  if (unsupportedAssetsPerChainAndModalType.includes('ALL')) return false; // All assets are unsupported
-
-  if (
-    unsupportedAssetsPerChainAndModalType.includes(assetFrom.toLowerCase()) ||
-    unsupportedAssetsPerChainAndModalType.includes(assetTo.toLowerCase())
-  )
-    return false;
-
-  return true;
-};
 
 /**
  * Picks the provider for the current swap based on chain, assets and flow.
  *
  * Notes:
- * - CoW is preferred when supported; fallback to ParaSwap if supported on chain
+ * - ParaSwap is the sole provider; CoW Protocol is paused.
  */
 export const getSwitchProvider = ({
   chainId,
-  assetFrom,
-  assetTo,
-  shouldUseFlashloan,
-  swapType,
 }: {
   chainId: number;
   assetFrom: string;
@@ -67,13 +16,6 @@ export const getSwitchProvider = ({
   shouldUseFlashloan?: boolean;
   swapType: SwapType;
 }): SwapProvider | undefined => {
-  if (
-    isSwapSupportedByCowProtocol(chainId, assetFrom, assetTo, swapType, shouldUseFlashloan ?? false)
-  ) {
-    return SwapProvider.COW_PROTOCOL;
-  }
-
-  // Fallback to ParaSwap only if supported on this chain
   if (ParaswapSupportedNetworks.includes(chainId)) {
     return SwapProvider.PARASWAP;
   }

--- a/src/components/transactions/Swap/helpers/shared/provider.helpers.ts
+++ b/src/components/transactions/Swap/helpers/shared/provider.helpers.ts
@@ -1,14 +1,65 @@
+import {
+  COW_UNSUPPORTED_ASSETS,
+  isChainIdSupportedByCoWProtocol,
+} from '../../constants/cow.constants';
 import { ParaswapSupportedNetworks } from '../../constants/paraswap.constants';
 import { SwapProvider, SwapType } from '../../types';
+
+/**
+ * Returns whether CoW Protocol can handle the given pair/swapType on the chain.
+ * Checks chain support and a per-flow unsupported assets list.
+ */
+export const isSwapSupportedByCowProtocol = (
+  chainId: number,
+  assetFrom: string,
+  assetTo: string,
+  swapType: SwapType,
+  useFlashloan: boolean
+) => {
+  if (!isChainIdSupportedByCoWProtocol(chainId)) return false;
+
+  let swapTypeToUse = swapType;
+  if (useFlashloan == false && swapType === SwapType.CollateralSwap) {
+    swapTypeToUse = SwapType.Swap;
+  }
+
+  // Helper to normalize values that can be string[] or 'ALL' to always be an array
+  const normalizeToArray = (value: string[] | 'ALL' | undefined): string[] => {
+    if (!value) return [];
+    if (value === 'ALL') return ['ALL'];
+    return value;
+  };
+
+  const unsupportedAssetsPerChainAndModalType = [
+    ...normalizeToArray(COW_UNSUPPORTED_ASSETS['ALL']?.[chainId]),
+    ...normalizeToArray(COW_UNSUPPORTED_ASSETS[swapTypeToUse]?.[chainId]),
+  ];
+
+  if (unsupportedAssetsPerChainAndModalType.length === 0) return true; // No unsupported assets for this chain and modal type
+
+  if (unsupportedAssetsPerChainAndModalType.includes('ALL')) return false; // All assets are unsupported
+
+  if (
+    unsupportedAssetsPerChainAndModalType.includes(assetFrom.toLowerCase()) ||
+    unsupportedAssetsPerChainAndModalType.includes(assetTo.toLowerCase())
+  )
+    return false;
+
+  return true;
+};
 
 /**
  * Picks the provider for the current swap based on chain, assets and flow.
  *
  * Notes:
- * - ParaSwap is the sole provider; CoW Protocol is paused.
+ * - CoW is preferred when supported; fallback to ParaSwap if supported on chain
  */
 export const getSwitchProvider = ({
   chainId,
+  assetFrom,
+  assetTo,
+  shouldUseFlashloan,
+  swapType,
 }: {
   chainId: number;
   assetFrom: string;
@@ -16,6 +67,16 @@ export const getSwitchProvider = ({
   shouldUseFlashloan?: boolean;
   swapType: SwapType;
 }): SwapProvider | undefined => {
+  // Temporary: route all swaps through ParaSwap
+  return SwapProvider.PARASWAP;
+
+  if (
+    isSwapSupportedByCowProtocol(chainId, assetFrom, assetTo, swapType, shouldUseFlashloan ?? false)
+  ) {
+    return SwapProvider.COW_PROTOCOL;
+  }
+
+  // Fallback to ParaSwap only if supported on this chain
   if (ParaswapSupportedNetworks.includes(chainId)) {
     return SwapProvider.PARASWAP;
   }


### PR DESCRIPTION
Remove CoW Protocol from the swap provider selection logic and use ParaSwap exclusively. Chains without ParaSwap support (linea, plasma, ink) will have swaps disabled until re-enabled.

## General Changes

- Fixes XYZ bug
- Adds XYZ feature
- …

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
