### PR TITLE
fix: expand Sentry filters for wallet extensions and browser noise

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,6 +1,5 @@
-// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
-// The config you add here will be used whenever one of the edge features is loaded.
-// Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
+// This file configures the initialization of Sentry on the client (browser).
+// The config you add here will be used whenever a user loads the app in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';

--- a/src/utils/sentryFilters.ts
+++ b/src/utils/sentryFilters.ts
@@ -40,8 +40,8 @@ const IGNORED_ERROR_PATTERNS: RegExp[] = [
   // WalletConnect
   /websocket connection closed abnormally with code: 3000/i,
   /websocket connection failed for host: wss:\/\/relay\.walletconnect\.org/i,
-  /no matching key\. session topic doesn't exist/i,
-  /walletconnect.+proposal expired/i,
+  /no matching key\. session/i,
+  /proposal expired/i,
   /request expired\. please try again/i,
   /failed to execute 'transaction' on 'idbdatabase': the database connection is closing/i,
 
@@ -71,6 +71,27 @@ const IGNORED_ERROR_PATTERNS: RegExp[] = [
 
   // Origin not allowed (wallet content scripts)
   /^Error: Origin not allowed$/i,
+
+  // RainbowKit connector initialization failure
+  /not found rainbowkit/i,
+
+  // AbortError / user navigation
+  /signal is aborted without reason/i,
+  /the user aborted a request/i,
+
+  // WalletConnect / connectivity noise
+  /no internet connection detected/i,
+  /could not detect network/i,
+  /missing or invalid\. record was recently deleted/i,
+
+  // Restricted browser environments
+  /failed to read the 'localstorage'/i,
+
+  // Third-party service network errors
+  /launchdarkly.*network error/i,
+
+  // Next.js internal navigation
+  /attempted to hard navigate to the same url/i,
 ];
 
 // Culprit / stack-frame patterns. These catch errors that have generic
@@ -83,16 +104,20 @@ const INJECTED_SCRIPT_PATTERNS: RegExp[] = [
   /window-provider/i,
   /injected\/injected/i,
   /frame_ant\/frame_ant/i,
-  /\/inpage$/i,
-  /\/inject$/i,
-  /\/injector$/i,
-  /\/btc$/i,
-  /\/sui$/i,
-  /\/solana$/i,
+  /[\/\(]inpage\)?$/i,
+  /[\/\(]inject\)?$/i,
+  /[\/\(]injector\)?$/i,
+  /[\/\(]btc\)?$/i,
+  /[\/\(]sui\)?$/i,
+  /[\/\(]solana\)?$/i,
   /chrome-extension:\/\//i,
   /moz-extension:\/\//i,
   /safari-extension:\/\//i,
   /window\.fetch\(inspector\)/i,
+  /proxy-injected-providers/i,
+  /injected\/hook/i,
+  /[\/\(]inapp\)?$/i,
+  /requestProvider/i,
 ];
 
 function matchesAnyPattern(value: string, patterns: RegExp[]): boolean {

--- a/src/utils/sentryFilters.ts
+++ b/src/utils/sentryFilters.ts
@@ -107,10 +107,10 @@ function hasInjectedFrame(event: Event): boolean {
   const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
   return frames.some((frame) => {
     const filename = frame.filename ?? '';
-    const module = frame.module ?? '';
+    const frameModule = frame.module ?? '';
     return (
       (filename !== '' && matchesAnyPattern(filename, INJECTED_SCRIPT_PATTERNS)) ||
-      (module !== '' && matchesAnyPattern(module, INJECTED_SCRIPT_PATTERNS))
+      (frameModule !== '' && matchesAnyPattern(frameModule, INJECTED_SCRIPT_PATTERNS))
     );
   });
 }

--- a/src/utils/sentryFilters.ts
+++ b/src/utils/sentryFilters.ts
@@ -26,6 +26,9 @@ const IGNORED_ERROR_PATTERNS: RegExp[] = [
   /bitvisionweb is not defined/i,
   /shouldsetpelagusforcurrentprovider is not a function/i,
   /the request by this web3 provider is timeout/i,
+  /cannot redefine property: station/i,
+  /cannot assign to read only property 'tronlink'/i,
+  /wallet must has at least one account/i,
 
   // wagmi / RainbowKit connector noise
   /providernotfounderror: provider not found/i,
@@ -57,11 +60,22 @@ const IGNORED_ERROR_PATTERNS: RegExp[] = [
 
   // Network / browser noise
   /can't find variable: eip155/i,
+
+  // Browser-specific network errors (no stack, pure connectivity noise)
+  /^TypeError: Load failed$/,
+  /^TypeError: NetworkError when attempting to fetch resource\.?$/,
+  /^TypeError: cancelled$/i,
+
+  // React Native WebView (not our environment)
+  /window\.webkit\.messagehandlers\.reactnativewebview/i,
+
+  // Origin not allowed (wallet content scripts)
+  /^Error: Origin not allowed$/i,
 ];
 
 // Culprit / stack-frame patterns. These catch errors that have generic
 // messages (e.g. "Failed to fetch") but originate from injected scripts.
-const IGNORED_CULPRIT_PATTERNS: RegExp[] = [
+const INJECTED_SCRIPT_PATTERNS: RegExp[] = [
   /injectLeap/i,
   /inject\.chrome/i,
   /extensionServiceWorker/i,
@@ -75,7 +89,31 @@ const IGNORED_CULPRIT_PATTERNS: RegExp[] = [
   /\/btc$/i,
   /\/sui$/i,
   /\/solana$/i,
+  /chrome-extension:\/\//i,
+  /moz-extension:\/\//i,
+  /safari-extension:\/\//i,
+  /window\.fetch\(inspector\)/i,
 ];
+
+function matchesAnyPattern(value: string, patterns: RegExp[]): boolean {
+  return patterns.some((p) => p.test(value));
+}
+
+/** Returns true if ANY stack frame originates from an injected / extension script. */
+function hasInjectedFrame(event: Event): boolean {
+  const culprit = (event as Record<string, unknown>).culprit as string | undefined;
+  if (culprit != null && matchesAnyPattern(culprit, INJECTED_SCRIPT_PATTERNS)) return true;
+
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+  return frames.some((frame) => {
+    const filename = frame.filename ?? '';
+    const module = frame.module ?? '';
+    return (
+      (filename !== '' && matchesAnyPattern(filename, INJECTED_SCRIPT_PATTERNS)) ||
+      (module !== '' && matchesAnyPattern(module, INJECTED_SCRIPT_PATTERNS))
+    );
+  });
+}
 
 export function shouldIgnoreError(event: Event): boolean {
   const exceptionValue = event.exception?.values?.[0];
@@ -85,19 +123,12 @@ export function shouldIgnoreError(event: Event): boolean {
   // Sentry stores the class name in `type` and the description in `value`,
   // but many wallet errors only populate one of the two.
   const message = errorType ? `${errorType}: ${errorMessage}` : errorMessage;
-  const culprit = (event as Record<string, unknown>).culprit as string | undefined;
-  const frames = exceptionValue?.stacktrace?.frames ?? [];
-  const topFilename = frames.length > 0 ? frames[frames.length - 1]?.filename : undefined;
 
   // Unconditional message-based filters (safe regardless of source)
   if (IGNORED_ERROR_PATTERNS.some((p) => p.test(message))) return true;
 
-  const isFromInjectedScript =
-    (culprit != null && IGNORED_CULPRIT_PATTERNS.some((p) => p.test(culprit))) ||
-    (topFilename != null && IGNORED_CULPRIT_PATTERNS.some((p) => p.test(topFilename)));
-
-  // Drop any error whose stack originates from an injected script
-  if (isFromInjectedScript) return true;
+  // Drop any error where any frame originates from an injected / extension script
+  if (hasInjectedFrame(event)) return true;
 
   return false;
 }


### PR DESCRIPTION
## Summary
- Add message-based filters for Station wallet, TronLink, wallet account errors, Safari/Firefox connectivity noise, React Native WebView, and wallet "Origin not allowed" errors
- Scan all stack frames for extension origins (chrome-extension://, moz-extension://, safari-extension://, devtools inspector) instead of only checking the top frame and culprit
- Fix misleading comment in sentry.client.config.ts that said "edge features"

These patterns were identified by reviewing the last 3 days of unresolved Sentry issues and cross-referencing with stack traces to confirm they originate from browser extensions, wallet injected scripts, or user connectivity.

## Test plan
- [ ] Verify production Sentry event volume drops for the filtered issue categories after deploy