### PR TITLE
fix: guard borrowInfo access in reserve overview and market list

### DIFF
--- a/pages/reserve-overview.page.tsx
+++ b/pages/reserve-overview.page.tsx
@@ -5,11 +5,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import StyledToggleButton from 'src/components/StyledToggleButton';
 import StyledToggleButtonGroup from 'src/components/StyledToggleButtonGroup';
-import {
-  ComputedReserveData,
-  ReserveWithId,
-  useAppDataContext,
-} from 'src/hooks/app-data-provider/useAppDataProvider';
+import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
 import { AssetCapsProvider } from 'src/hooks/useAssetCaps';
 import { AssetCapsProviderSDK } from 'src/hooks/useAssetCapsSDK';
 import { MainLayout } from 'src/layouts/MainLayout';
@@ -55,12 +51,12 @@ export default function ReserveOverview() {
   //With SDK
   const reserve = supplyReserves.find((reserve) => {
     return reserve.underlyingToken.address.toLowerCase() === underlyingAsset?.toLowerCase();
-  }) as ReserveWithId;
+  });
 
   //With Reserves
   const reserveLegacy = reserves.find((reserve) => {
     return reserve.underlyingAsset.toLowerCase() === underlyingAsset?.toLowerCase();
-  }) as ComputedReserveData;
+  });
   const [pageEventCalled, setPageEventCalled] = useState(false);
 
   useEffect(() => {
@@ -75,6 +71,15 @@ export default function ReserveOverview() {
   }, [trackEvent, reserve, underlyingAsset, pageEventCalled]);
 
   const isOverview = mode === 'overview';
+
+  // Don't render reserve configuration until SDK data is loaded
+  if (!reserve || !reserveLegacy) {
+    return (
+      <>
+        <ReserveTopDetailsWrapper underlyingAsset={underlyingAsset} />
+      </>
+    );
+  }
 
   return (
     <AssetCapsProviderSDK asset={reserve}>

--- a/src/modules/markets/MarketAssetsListItem.tsx
+++ b/src/modules/markets/MarketAssetsListItem.tsx
@@ -164,7 +164,7 @@ export const MarketAssetsListItem = ({ ...reserve }: ReserveWithProtocolIncentiv
         {reserve.borrowInfo?.borrowingState === 'DISABLED' &&
           !reserve.isFrozen &&
           !reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed) &&
-          reserve.borrowInfo.total.amount.value !== '0' && <ReserveSubheader value={'Disabled'} />}
+          reserve.borrowInfo?.total.amount.value !== '0' && <ReserveSubheader value={'Disabled'} />}
       </ListColumn>
 
       <ListColumn minWidth={95} maxWidth={95} align="right">

--- a/src/modules/markets/MarketAssetsListMobileItem.tsx
+++ b/src/modules/markets/MarketAssetsListMobileItem.tsx
@@ -161,7 +161,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ReserveWithProtocolIn
         {reserve.borrowInfo?.borrowingState === 'DISABLED' &&
           !reserve.isFrozen &&
           !reserve.eModeInfo?.some((eMode) => eMode.canBeBorrowed) &&
-          reserve.borrowInfo.total.amount.value !== '0' && <ReserveSubheader value={'Disabled'} />}
+          reserve.borrowInfo?.total.amount.value !== '0' && <ReserveSubheader value={'Disabled'} />}
       </Row>
       <Button
         variant="outlined"


### PR DESCRIPTION
## Summary
- Remove unsafe type casts (`as ReserveWithId`, `as ComputedReserveData`) in reserve-overview page and add a loading guard when SDK data hasn't loaded yet
- Add optional chaining for `borrowInfo.total.amount.value` access in MarketAssetsListItem and MarketAssetsListMobileItem where the `&&` chain doesn't short-circuit properly

Fixes AAVE-V3-CS (593 users, 673 events).

## Test plan
- [ ] Load the markets page and verify borrow info columns render correctly
- [ ] Navigate to a reserve overview page and verify it loads without errors
- [ ] Check that reserves with disabled borrowing still show the "Disabled" label