### PR TITLE
fix: guard useTransactionHistory against markets without EVM addresses

### DIFF
--- a/src/hooks/useTransactionHistory.tsx
+++ b/src/hooks/useTransactionHistory.tsx
@@ -146,13 +146,16 @@ export const useTransactionHistory = ({ isFilterActive }: { isFilterActive: bool
   const [shouldKeepFetching, setShouldKeepFetching] = useState(false);
 
   const isAccountValid = account && account.length > 0;
+  const isValidEvmMarket = currentMarketData.addresses.LENDING_POOL.length > 0;
 
   const {
     data: sdkData,
     loading: sdkLoading,
     error: sdkError,
   } = useUserTransactionHistory({
-    market: evmAddress(currentMarketData.addresses.LENDING_POOL),
+    market: isValidEvmMarket
+      ? evmAddress(currentMarketData.addresses.LENDING_POOL)
+      : evmAddress('0x0000000000000000000000000000000000000000'),
     user: isAccountValid
       ? evmAddress(account as string)
       : evmAddress('0x0000000000000000000000000000000000000000'),
@@ -171,6 +174,14 @@ export const useTransactionHistory = ({ isFilterActive }: { isFilterActive: bool
   }, [account, currentMarketData.addresses.LENDING_POOL, currentMarketData.chainId]);
 
   useEffect(() => {
+    if (!isValidEvmMarket) {
+      setIsFetchingAllSdkPages(false);
+      setHasLoadedInitialSdkPage(true);
+    }
+  }, [isValidEvmMarket]);
+
+  useEffect(() => {
+    if (!isValidEvmMarket) return;
     if (!sdkData?.items?.length) {
       if (!sdkLoading && !sdkData?.pageInfo?.next) {
         setIsFetchingAllSdkPages(false);
@@ -196,9 +207,10 @@ export const useTransactionHistory = ({ isFilterActive }: { isFilterActive: bool
         setHasLoadedInitialSdkPage(true);
       }
     }
-  }, [sdkData, sdkLoading, hasLoadedInitialSdkPage]);
+  }, [sdkData, sdkLoading, hasLoadedInitialSdkPage, isValidEvmMarket]);
 
   useEffect(() => {
+    if (!isValidEvmMarket) return;
     if (sdkLoading) {
       setIsFetchingAllSdkPages(true);
       return;
@@ -214,7 +226,7 @@ export const useTransactionHistory = ({ isFilterActive }: { isFilterActive: bool
     if (!nextCursor) {
       setIsFetchingAllSdkPages(false);
     }
-  }, [sdkData?.pageInfo?.next, sdkLoading, sdkCursor]);
+  }, [sdkData?.pageInfo?.next, sdkLoading, sdkCursor, isValidEvmMarket]);
 
   useEffect(() => {
     if (sdkError && !hasLoadedInitialSdkPage) {

--- a/src/hooks/useTransactionHistory.tsx
+++ b/src/hooks/useTransactionHistory.tsx
@@ -178,7 +178,7 @@ export const useTransactionHistory = ({ isFilterActive }: { isFilterActive: bool
       setIsFetchingAllSdkPages(false);
       setHasLoadedInitialSdkPage(true);
     }
-  }, [isValidEvmMarket]);
+  }, [isValidEvmMarket, account]);
 
   useEffect(() => {
     if (!isValidEvmMarket) return;


### PR DESCRIPTION
## Summary
- Guard `useTransactionHistory` against markets with empty `LENDING_POOL` address (like the Aptos redirect market)
- Pass a placeholder address to satisfy React hook ordering, but immediately resolve to empty state
- Fixes AAVE-V3-1M (24 events/day, 635 total)

## Test plan
- [ ] Switch to Aptos market in UI, verify no console errors
- [ ] Verify transaction history still works on EVM markets (e.g. Ethereum mainnet)