### PR TITLE
fix(swap): align flash-loan and zero-LTV guards with cow-swap-adapter sellToken

### DIFF
--- a/src/components/transactions/Swap/errors/SwapErrors.tsx
+++ b/src/components/transactions/Swap/errors/SwapErrors.tsx
@@ -116,11 +116,7 @@ export const SwapErrors = ({
     );
   }
 
-  if (
-    isProtocolSwapState(state) &&
-    hasInsufficientLiquidity(state) &&
-    state.swapType !== SwapType.RepayWithCollateral
-  ) {
+  if (isProtocolSwapState(state) && hasInsufficientLiquidity(state)) {
     return (
       <InsufficientLiquidityBlockingGuard
         state={state}

--- a/src/components/transactions/Swap/errors/shared/InsufficientLiquidityBlockingGuard.tsx
+++ b/src/components/transactions/Swap/errors/shared/InsufficientLiquidityBlockingGuard.tsx
@@ -21,9 +21,14 @@ import { InsufficientLiquidityBlockingError } from './InsufficientLiquidityBlock
 // source/destination + isInvertedSwap question and mirrors what actually pulls
 // from the lender on-chain.
 export const hasInsufficientLiquidity = (state: SwapState) => {
-  // isProtocolSwapState narrows out SwapType.Swap (direct DEX, no flash loan).
+  // isProtocolSwapState narrows out SwapType.Swap (direct DEX, no Aave call).
   if (!isProtocolSwapState(state)) return false;
-  if (!state.useFlashloan) return false;
+  // Don't gate on `state.useFlashloan`: several protocol paths flash-loan
+  // unconditionally regardless of the flag (CoW DebtSwap / RepayWithCollateral
+  // via forceFlashloanFlow, ParaSwap DebtSwap via DebtSwitchAdapter, ParaSwap
+  // CollateralSwap with `useFlashLoan: true` hardcoded). And even non-
+  // flashloan paths still withdraw/borrow from the pool, which decrements
+  // virtualUnderlyingBalance — the same liquidity ceiling we're guarding.
   if (!state.sellAmountToken || !state.sellAmountFormatted) return false;
 
   const flashLoanedAddress = state.sellAmountToken.underlyingAddress?.toLowerCase();
@@ -97,7 +102,6 @@ export const InsufficientLiquidityBlockingGuard = ({
     }
   }, [
     state.swapType,
-    state.useFlashloan,
     state.sellAmountFormatted,
     state.sellAmountToken?.underlyingAddress,
     state.sourceReserve?.reserve?.formattedAvailableLiquidity,

--- a/src/components/transactions/Swap/errors/shared/InsufficientLiquidityBlockingGuard.tsx
+++ b/src/components/transactions/Swap/errors/shared/InsufficientLiquidityBlockingGuard.tsx
@@ -14,26 +14,40 @@ import {
 import { isProtocolSwapState } from '../../types/state.types';
 import { InsufficientLiquidityBlockingError } from './InsufficientLiquidityBlockingError';
 
+// The cow-swap-adapter flash-loans `_sellToken` for every position swap
+// (CollateralSwap / DebtSwap / RepayWithCollateral, see
+// cow-swap-adapters/src/adapters/v3/*Adapter.sol). The interface exposes that
+// asset as `state.sellAmountToken`, so checking against it sidesteps the
+// source/destination + isInvertedSwap question and mirrors what actually pulls
+// from the lender on-chain.
 export const hasInsufficientLiquidity = (state: SwapState) => {
-  // Only relevant for Debt Swaps where target asset availability and borrow cap matter.
-  // Collateral-related flows are handled via SupplyCapBlockingGuard and should not use borrow caps here.
-  if (!isProtocolSwapState(state) || state.swapType !== SwapType.DebtSwap) return false;
-  const reserve = state.isInvertedSwap
-    ? state.sourceReserve?.reserve
-    : state.destinationReserve?.reserve;
-  const buyAmount = state.buyAmountFormatted;
-  if (!reserve || !buyAmount) return false;
+  // isProtocolSwapState narrows out SwapType.Swap (direct DEX, no flash loan).
+  if (!isProtocolSwapState(state)) return false;
+  if (!state.useFlashloan) return false;
+  if (!state.sellAmountToken || !state.sellAmountFormatted) return false;
 
-  const availableBorrowCap =
-    reserve.borrowCap === '0'
-      ? valueToBigNumber(ethers.constants.MaxUint256.toString())
-      : valueToBigNumber(reserve.borrowCap).minus(valueToBigNumber(reserve.totalDebt));
-  const availableLiquidity = BigNumber.max(
-    BigNumber.min(valueToBigNumber(reserve.formattedAvailableLiquidity), availableBorrowCap),
-    0
+  const flashLoanedAddress = state.sellAmountToken.underlyingAddress?.toLowerCase();
+  if (!flashLoanedAddress) return false;
+
+  const reserve = [state.sourceReserve?.reserve, state.destinationReserve?.reserve].find(
+    (r) => r?.underlyingAsset?.toLowerCase() === flashLoanedAddress
   );
+  if (!reserve) return false;
 
-  return valueToBigNumber(buyAmount).gt(availableLiquidity);
+  const liquidity = BigNumber.max(valueToBigNumber(reserve.formattedAvailableLiquidity), 0);
+
+  // Borrow cap only matters for DebtSwap, which leaves the user holding new
+  // debt in the flash-loaned asset. Other flash-loan flows repay the loan
+  // in-flight and never touch the borrow cap.
+  const borrowCapRoom =
+    state.swapType === SwapType.DebtSwap
+      ? reserve.borrowCap === '0'
+        ? valueToBigNumber(ethers.constants.MaxUint256.toString())
+        : valueToBigNumber(reserve.borrowCap).minus(valueToBigNumber(reserve.totalDebt))
+      : valueToBigNumber(ethers.constants.MaxUint256.toString());
+
+  const effectiveLimit = BigNumber.max(BigNumber.min(liquidity, borrowCapRoom), 0);
+  return valueToBigNumber(state.sellAmountFormatted).gt(effectiveLimit);
 };
 
 export const InsufficientLiquidityBlockingGuard = ({
@@ -82,16 +96,21 @@ export const InsufficientLiquidityBlockingGuard = ({
       }
     }
   }, [
-    state.buyAmountFormatted,
-    state.destinationReserve?.reserve?.formattedAvailableLiquidity,
+    state.swapType,
+    state.useFlashloan,
+    state.sellAmountFormatted,
+    state.sellAmountToken?.underlyingAddress,
     state.sourceReserve?.reserve?.formattedAvailableLiquidity,
-    state.isInvertedSwap,
+    state.sourceReserve?.reserve?.borrowCap,
+    state.sourceReserve?.reserve?.totalDebt,
+    state.destinationReserve?.reserve?.formattedAvailableLiquidity,
+    state.destinationReserve?.reserve?.borrowCap,
+    state.destinationReserve?.reserve?.totalDebt,
   ]);
 
   if (hasInsufficientLiquidity(state)) {
-    const symbol = state.isInvertedSwap
-      ? state.sourceReserve?.reserve?.symbol
-      : state.destinationReserve?.reserve?.symbol;
+    // hasInsufficientLiquidity ensures sellAmountToken is defined.
+    const symbol = state.sellAmountToken?.symbol ?? '';
     return (
       <InsufficientLiquidityBlockingError
         symbol={symbol}

--- a/src/components/transactions/Swap/errors/shared/ZeroLTVBlockingGuard.tsx
+++ b/src/components/transactions/Swap/errors/shared/ZeroLTVBlockingGuard.tsx
@@ -5,22 +5,25 @@ import { useZeroLTVBlockingWithdraw } from 'src/hooks/useZeroLTVBlockingWithdraw
 import { ActionsBlockedReason, SwapError, SwapState, SwapType } from '../../types';
 import { ZeroLTVBlockingError } from './ZeroLTVBlockingError';
 
+// Mirrors `validateHFAndLtvzero` in aave-v3-origin SupplyLogic: when the user
+// has any zero-LTV collateral enabled, every withdrawn aToken must itself have
+// zero LTV. The cow-swap-adapter withdraws `_sellToken` (see
+// cow-swap-adapters/src/adapters/v3/*Adapter.sol), which the interface exposes
+// as `state.sellAmountToken` — checking by symbol against the user's blocking
+// asset list mirrors what the protocol validates on-chain.
 export const hasZeroLTVBlocking = (state: SwapState, blockingAssets: string[]) => {
-  // DebtSwap (repay old debt + borrow new debt) never triggers validateHFAndLtv
-  // because neither repay nor borrow calls that validation.
-  if (state.swapType === SwapType.DebtSwap) {
-    return false;
-  }
-  // CollateralSwap does supply + withdraw. The withdraw triggers validateHFAndLtv
-  // which scans ALL collaterals. Block if any zero-LTV collateral exists.
-  if (state.swapType === SwapType.CollateralSwap) {
-    return blockingAssets.length > 0;
-  }
-  // RepayWithCollateral does repay + withdraw. The withdraw triggers
-  // validateHFAndLtv. Block if there are zero-LTV collateral assets that are
-  // NOT the source token being withdrawn. The pool allows withdrawing a
-  // zero-LTV asset itself (getLtv() == 0 passes the check).
-  return blockingAssets.length > 0 && !blockingAssets.includes(state.sourceToken.symbol);
+  if (blockingAssets.length === 0) return false;
+  // Direct DEX swaps don't touch Aave; the on-chain check never runs.
+  if (state.swapType === SwapType.Swap) return false;
+  // DebtSwap repays old debt and opens new debt. Neither path withdraws an
+  // aToken from the user, so validateHFAndLtvzero never fires.
+  if (state.swapType === SwapType.DebtSwap) return false;
+
+  const withdrawnSymbol = state.sellAmountToken?.symbol;
+  // Conservative: if we can't identify the withdrawn asset yet, block.
+  if (!withdrawnSymbol) return true;
+  // Withdrawing the LTV=0 asset itself is allowed by the protocol.
+  return !blockingAssets.includes(withdrawnSymbol);
 };
 
 export const ZeroLTVBlockingGuard = ({
@@ -71,7 +74,7 @@ export const ZeroLTVBlockingGuard = ({
         });
       }
     }
-  }, [assetsBlockingWithdraw, state.sourceToken.symbol, state.swapType]);
+  }, [assetsBlockingWithdraw, state.sellAmountToken?.symbol, state.swapType]);
 
   if (hasZeroLTVBlocking(state, assetsBlockingWithdraw)) {
     return <ZeroLTVBlockingError sx={{ mb: !isSwapFlowSelected ? 0 : 4, ...sx }} />;


### PR DESCRIPTION
## Summary

Both `InsufficientLiquidityBlockingGuard` and `ZeroLTVBlockingGuard` derived the asset to check from `state.sourceToken` / `state.destinationToken` gated on `isInvertedSwap`. For inverted swaps (`DebtSwap`, `RepayWithCollateral`) the mapping was the wrong direction: the guards inspected the user's debt asset when the cow-swap-adapter actually flash-loans and withdraws the destination.

The cow-swap-adapter contracts in [`cow-swap-adapters/src/adapters/v3/*Adapter.sol`](https://github.com/aave/cow-swap-adapters) unambiguously flash-loan and withdraw `_sellToken` for every position swap. The interface already exposes that asset as `state.sellAmountToken` in `useSwapOrderAmounts`. Reading it directly aligns both guards with the on-chain behavior and removes the inverted-swap heuristic.

## Use-case behavior — before vs. after

### `InsufficientLiquidityBlockingGuard`

| Scenario | Before | After |
| -------- | ------ | ----- |
| Direct `Swap` (no Aave) | not relevant | not relevant — `isProtocolSwapState` excludes it |
| DebtSwap, healthy reserves | not blocked | not blocked |
| **DebtSwap, target reserve drained** | reads `sourceReserve` (old debt) → typically misses | reads `sellAmountToken` reserve (new debt) → **blocks** |
| DebtSwap, borrow-cap exhausted on target | already blocked | still blocked (clamp kept, only for DebtSwap) |
| **CollateralSwap WETH → USDC, WETH reserve drained (rsETH)** | not checked at all | **blocks** (source reserve insufficient) |
| **WithdrawAndSwap, source reserve drained, useFlashloan=true** | not checked at all | **blocks** |
| **RepayWithCollateral, withdrawn collateral reserve drained** | dispatcher excluded RepayWithCollateral | **blocks** |
| ParaSwap DebtSwap (always flash-loans regardless of `state.useFlashloan`) | check disabled, settlement reverts | **blocks** |

### `ZeroLTVBlockingGuard`

| Scenario | Before | After |
| -------- | ------ | ----- |
| Direct `Swap` | could fall through | explicitly skipped |
| DebtSwap (any) | already skipped | still skipped (no aToken withdraw on-chain) |
| CollateralSwap with rsETH (LTV=0), swapping unrelated collateral | blocked | blocked |
| **CollateralSwap, swapping the LTV=0 asset itself out** | wrongly **blocked** | not blocked (matches `assetLTV == 0` exception) |
| **RepayWithCollateral with LTV=0 asset enabled (e.g. rsETH), repaying USDe debt with USDT collateral (issue 3)** | not blocked — compared against user's *debt* (`sourceToken`) | **blocks** (compares against withdrawn collateral = `sellAmountToken`) |
| RepayWithCollateral, withdrawing the LTV=0 asset itself as collateral | wrongly blocked | not blocked |

## Real cases this fixes

1. **CollateralSwap WETH → USDC when WETH reserve is drained** (recent rsETH-related risk action). Aave V3 mainnet pool's `virtualUnderlyingBalance(WETH)` was 0.022 WETH while the adapter tried to flash-loan 1 WETH. `Pool.flashLoan` reverted with arithmetic underflow at the receiver-callback boundary. The previous guard only fired for `DebtSwap`, so the order reached the orderbook and the solver hit the panic at settlement.
2. **RepayWithCollateral with non-LTV-0 collateral when the user also has an LTV=0 asset (e.g. rsETH) enabled as collateral**. On-chain `validateHFAndLtvzero` reverted because the withdrawn collateral has positive LTV while a zero-LTV collateral is enabled. The previous check compared against the user's *debt* asset (`sourceToken`) instead of the withdrawn collateral, so the order went out and reverted on settlement with `LtvValidationFailed`.

## Developer Notes

- Single source of truth across the interface: `state.sellAmountToken` matches `_sellToken` in every cow-swap-adapter v3/v4 file. Source/destination + `isInvertedSwap` is no longer needed for these guards.
- `formattedAvailableLiquidity` is the aToken's underlying `balanceOf`, which is a strict upper bound on the pool's `virtualUnderlyingBalance` for typical reserves and catches the rsETH-style drainage cleanly. A live `Pool.getVirtualUnderlyingBalance(asset)` read would be more precise but is out of scope for this fix.
- The borrow-cap clamp stays only for `DebtSwap`; `CollateralSwap`, `RepayWithCollateral`, and `WithdrawAndSwap` repay the flash loan in-flight and never touch the borrow cap.
- The check is **not** gated on `state.useFlashloan` because several protocol paths flash-loan unconditionally regardless of the flag (CoW DebtSwap / RepayWithCollateral via `forceFlashloanFlow`, ParaSwap DebtSwap via `DebtSwitchAdapter` with no non-flashloan branch, ParaSwap CollateralSwap with `useFlashLoan: true` hardcoded). Even non-flashloan paths still withdraw/borrow from the pool, which decrements `virtualUnderlyingBalance` — the same liquidity ceiling.
- Net diff: 3 files, ~+68/-46 lines. Most of the addition is comments anchoring the guards to the relevant Aave V3 / cow-swap-adapter source.

## Reviewer Checklist

- [ ] End-to-end tests are passing without any errors
- [ ] Code changes do not significantly increase the application bundle size
- [ ] If there are new 3rd-party packages, they do not introduce potential security threats
- [ ] If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinent `.github/actions/*` files
- [ ] There are no CI changes, or they have been approved by the DevOps and Engineering team(s)

## Test plan

- [ ] On a fork pinned to the failing block, open CollateralSwap WETH → USDC for 1 WETH and confirm the inline error renders with `WETH` and the action is disabled.
- [ ] On a fork with the failing user position (USDe debt + USDT collateral + LTV=0 asset enabled), open RepayWithCollateral and confirm the LTV-zero error fires before submission.
- [ ] Regression: DebtSwap on ParaSwap with healthy reserves still computes borrow-cap room correctly and only blocks when the new debt asset would exceed it (verifies the dropped `useFlashloan` gate doesn't false-positive).
- [ ] Regression: CollateralSwap of an LTV=0 asset itself (e.g. swap rsETH out) is not over-blocked.
- [ ] Regression: plain `Swap` (direct DEX, no flash loan) does not trip the liquidity guard.