### PR TITLE
fix(analytics): drive walletType from wagmi useAccount

### DIFF
--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -26,7 +26,6 @@ import { useRootStore } from 'src/store/root';
 import { SharedDependenciesProvider } from 'src/ui-config/SharedDependenciesProvider';
 import { wagmiConfig } from 'src/ui-config/wagmiConfig';
 import { WagmiProvider } from 'wagmi';
-import { useShallow } from 'zustand/shallow';
 
 import createEmotionCache from '../src/createEmotionCache';
 import { AppGlobalStyles } from '../src/layouts/AppGlobalStyles';
@@ -112,9 +111,7 @@ interface MyAppProps extends AppProps {
 export default function MyApp(props: MyAppProps) {
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
   const getLayout = Component.getLayout ?? ((page: ReactNode) => page);
-  const [initializeEventsTracking, setWalletType] = useRootStore(
-    useShallow((store) => [store.initializeEventsTracking, store.setWalletType])
-  );
+  const initializeEventsTracking = useRootStore((store) => store.initializeEventsTracking);
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -155,10 +152,7 @@ export default function MyApp(props: MyAppProps) {
           <LanguageProvider>
             <WagmiProvider config={wagmiConfig}>
               <QueryClientProvider client={queryClient}>
-                <ConnectKitProvider
-                  onDisconnect={cleanLocalStorage}
-                  onConnect={({ connectorId }) => setWalletType(connectorId)}
-                >
+                <ConnectKitProvider onDisconnect={cleanLocalStorage}>
                   <Web3ContextProvider>
                     <AppGlobalStyles>
                       <ComplianceProvider>

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -44,13 +44,17 @@ let didAutoConnectForCypress = false;
 export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ children }) => {
   const { switchChainAsync } = useSwitchChain();
   const { watchAssetAsync } = useWatchAsset();
-  const { chainId, address } = useAccount();
+  const { chainId, address, status, connector } = useAccount();
   const { connect, connectors } = useConnect();
 
   const [readOnlyModeAddress, setReadOnlyModeAddress] = useState<string | undefined>();
   const [switchNetworkError, setSwitchNetworkError] = useState<Error>();
-  const [setAccount, setConnectedAccountIsContract] = useRootStore(
-    useShallow((store) => [store.setAccount, store.setConnectedAccountIsContract])
+  const [setAccount, setConnectedAccountIsContract, setWalletType] = useRootStore(
+    useShallow((store) => [
+      store.setAccount,
+      store.setConnectedAccountIsContract,
+      store.setWalletType,
+    ])
   );
 
   const account = address;
@@ -202,6 +206,17 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   useEffect(() => {
     setAccount(account?.toLowerCase());
   }, [account, setAccount]);
+
+  // Drive walletType from wagmi's account state so it survives page reloads.
+  // ConnectKit's `onConnect` prop only fires on fresh connect (not on reconnect),
+  // which caused most transaction events to be tracked with walletType=undefined.
+  useEffect(() => {
+    if (status === 'connected' && connector?.id) {
+      setWalletType(connector.id);
+    } else if (status === 'disconnected') {
+      setWalletType(undefined);
+    }
+  }, [status, connector?.id, setWalletType]);
 
   useEffect(() => {
     if (readOnlyModeAddress) {


### PR DESCRIPTION
## Summary

ConnectKit's `onConnect` callback only fires on the initial connect — wagmi auto-reconnects (every page reload with a saved session, every redirect-back from Aave Accounts) are suppressed via the `isReconnected` flag. `setWalletType` was wired to that callback, so on most sessions `walletType` stayed `undefined`.

Drive `walletType` from `useAccount()` in `Web3Provider` instead. It now stays accurate across reconnects, page reloads, and the Aave Accounts redirect-back flow.

## Impact

Verified against production Amplitude (project 697123, last 30 days):

- 125,939 of 145,425 Transaction events (**86.6%**) currently emit `walletType: undefined`
- Tx/connect ratio is `0.05` for `familyAccountsProvider` vs `0.67` for `io.metamask` — Aave Accounts users are sticky and reload more, so a disproportionate share of their transactions leak into the `(none)` bucket
- After this fix, `walletType` is set on every `connected` status and cleared on `disconnected`, regardless of how the connection was established

## How it works

`useAccountEffect` exposes `isReconnected: true` to detect new vs returning sessions. ConnectKit's `useConnectCallback` early-returns on that case before invoking the user-supplied `onConnect` prop. Reading `useAccount().connector?.id` directly bypasses that filter — wagmi knows the current connector regardless of how we got connected.

The effect is gated on `status === 'connected'` to avoid clearing `walletType` during the transient `reconnecting` state (which would otherwise wipe it briefly on every page load).

## Test plan

- [ ] In Redux DevTools, connect with any wallet → `walletSlice.walletType` reflects the connector id
- [ ] Reload the page while connected → `walletType` is repopulated (was previously cleared to `undefined`)
- [ ] Disconnect → `walletType` returns to `undefined`
- [ ] Connect with Aave Accounts via the accounts.aave.com redirect → `walletType` is set after landing back
- [ ] Trigger a Transaction event — confirm the Amplitude payload contains `walletType: <connector id>` instead of `null`