### PR TITLE
fix: truncate repay-max display to token decimals

### DIFF
--- a/src/components/transactions/Repay/RepayModalContent.tsx
+++ b/src/components/transactions/Repay/RepayModalContent.tsx
@@ -102,12 +102,21 @@ export const RepayModalContent = ({
     maxAmountToRepay = BigNumber.min(normalizedWalletBalance, debt);
   }
 
+  // Truncate to token decimals for any value that may flow back into the input
+  // or into parseUnits(). variableBorrows carries RAY-level precision, so when
+  // wallet >= debt the max collapses to debt with 18+ decimals and parseUnits
+  // throws on submission if the user edits the field. ROUND_DOWN keeps us at
+  // or below wallet balance; the "repay all" path still uses -1 / safeAmountToRepayAll.
+  const maxAmountToRepayDisplay = maxAmountToRepay
+    .decimalPlaces(poolReserve.decimals, BigNumber.ROUND_DOWN)
+    .toString(10);
+
   const isMaxSelected = _amount === '-1';
-  const amount = isMaxSelected ? maxAmountToRepay.toString(10) : _amount;
+  const amount = isMaxSelected ? maxAmountToRepayDisplay : _amount;
 
   const handleChange = (value: string) => {
     const maxSelected = value === '-1';
-    amountRef.current = maxSelected ? maxAmountToRepay.toString(10) : value;
+    amountRef.current = maxSelected ? maxAmountToRepayDisplay : value;
     setAmount(value);
     if (maxSelected && (repayWithATokens || maxAmountToRepay.eq(debt))) {
       if (
@@ -131,7 +140,7 @@ export const RepayModalContent = ({
       setRepayMax(
         safeAmountToRepayAll.lt(balance)
           ? safeAmountToRepayAll.toString(10)
-          : maxAmountToRepay.toString(10)
+          : maxAmountToRepayDisplay
       );
     }
   };
@@ -193,7 +202,11 @@ export const RepayModalContent = ({
     .multipliedBy(marketReferencePriceInUsd)
     .shiftedBy(-USD_DECIMALS);
 
-  const maxRepayWithDustRemaining = isMaxSelected && amountAfterRepayInUsd.toNumber() > 0;
+  // After truncating maxAmountToRepayDisplay to token decimals, the displayed
+  // amount can leave a sub-decimal residual against the full-precision debt
+  // even though the actual submission (-1 / safeAmountToRepayAll) repays it all.
+  // Compare against the untruncated maxAmountToRepay to detect a real shortfall.
+  const maxRepayWithDustRemaining = isMaxSelected && maxAmountToRepay.lt(debt);
 
   // health factor calculations
   // we use usd values instead of MarketreferenceCurrency so it has same precision
@@ -245,7 +258,7 @@ export const RepayModalContent = ({
         assets={assets}
         onSelect={setTokenToRepayWith}
         isMaxSelected={isMaxSelected}
-        maxValue={maxAmountToRepay.toString(10)}
+        maxValue={maxAmountToRepayDisplay}
         balanceText={<Trans>Wallet balance</Trans>}
       />
 
@@ -304,7 +317,7 @@ export const RepayModalContent = ({
         repayWithATokens={repayWithATokens}
         setShowUSDTResetWarning={setShowUSDTResetWarning}
         chainId={currentChainId}
-        maxAmountToRepay={maxAmountToRepay.toString(10)}
+        maxAmountToRepay={maxAmountToRepayDisplay}
       />
     </>
   );


### PR DESCRIPTION
## Summary

`userReserve.variableBorrows` carries RAY-level precision (`scaledDebt * variableBorrowIndex / RAY`), so when the wallet covers the full debt, the max repay value collapses to `debt` and the input is prefilled with 18+ decimal places (e.g. `5.123456789012345678` for a USDC debt). If the user edits that prefilled value at all, `isMaxSelected` flips off and the raw string is forwarded to `parseUnits(amount, poolReserve.decimals)`, which throws `fractional component exceeds decimals`. Users were working around this by manually deleting digits until parseUnits succeeded.

The clean-max path (click Max → click Repay without touching the field) was unaffected because the submission uses `repayMax` (`-1` or `safeAmountToRepayAll`). The bug only fires once the user interacts with the input.

## Change

- Add `maxAmountToRepayDisplay`: `maxAmountToRepay` rounded down to `poolReserve.decimals`. Use it for the rendered amount, `maxValue`, `amountRef`, the wallet-cannot-cover-debt fallback in `handleChange`, and the metadata passed to `RepayActions`.
- Keep the untruncated `maxAmountToRepay` BigNumber for `maxAmountToRepay.eq(debt)` so the full-debt branch still resolves to `-1` (v3) or `safeAmountToRepayAll` (native/synthetix) — full-repay UX is unchanged.
- Switch `maxRepayWithDustRemaining` from `amountAfterRepayInUsd.toNumber() > 0` to `maxAmountToRepay.lt(debt)` so the "small borrowing position left" warning fires only on a genuine wallet shortfall, not on the sub-decimal residual the new truncation introduces against full-precision `debt`.

`ROUND_DOWN` guarantees we never display more than the wallet can cover.

## Verified flows

- Wallet ≥ debt + Max: `maxAmountToRepay.eq(debt)` still true on the untruncated BigNumber → submission still `-1` (v3) or `safeAmountToRepayAll` (native/synthetix). No dust warning.
- Wallet < debt + Max: submission becomes `maxAmountToRepayDisplay` (truncated wallet balance); dust warning shown.
- Manual input below max: unchanged.
- Native repay / synthetix: still uses `safeAmountToRepayAll` (rounded up) on submission.
- aToken repay: branch logic unchanged.

## Test plan

- [ ] Repay max with `wallet > debt` for a token where `variableBorrows` has > token-decimals (e.g. USDC, WBTC, USDT) — confirm input shows token-precision amount, Repay submits and succeeds without editing the field.
- [ ] Edit the prefilled max value after clicking Max — confirm parseUnits no longer throws.
- [ ] Repay max with `wallet < debt` — confirm dust warning still shows and partial repay submits.
- [ ] Repay max with ETH (native) — confirm `safeAmountToRepayAll` path still used.
- [ ] Repay with aTokens — confirm full repay still works.