### PR TITLE
fix(swap): route EIP-7702 wallets to ParaSwap

### DIFF
--- a/src/components/transactions/Swap/actions/approval/useSwapTokenApproval.ts
+++ b/src/components/transactions/Swap/actions/approval/useSwapTokenApproval.ts
@@ -109,7 +109,11 @@ export const useSwapTokenApproval = ({
   const { sendTx, signTxData } = useWeb3Context();
   const [loadingPermitData, setLoadingPermitData] = useState(true);
 
-  const { isSmartContractWallet, isLoading: isLoadingWalletType } = useGetConnectedWalletType();
+  const {
+    isSmartContractWallet,
+    isEip7702Wallet,
+    isLoading: isLoadingWalletType,
+  } = useGetConnectedWalletType();
 
   const [
     user,
@@ -263,8 +267,16 @@ export const useSwapTokenApproval = ({
     };
   }, [chainId, token]);
 
+  // EIP-7702 delegates (Alchemy MA v2, etc.) intercept signTypedData with replay-safe
+  // wrapping (ERC-7739), so ERC-2612 permits and credit-delegation sigs don't ecrecover
+  // to the EOA on-chain. Force these wallets through direct approve / approveDelegation
+  // transactions instead.
   const tryPermit =
-    allowPermit && permitSupported === true && !isSmartContractWallet && !isLoadingWalletType;
+    allowPermit &&
+    permitSupported === true &&
+    !isSmartContractWallet &&
+    !isEip7702Wallet &&
+    !isLoadingWalletType;
   const usePermit = tryPermit && walletApprovalMethodPreference === ApprovalMethod.PERMIT;
 
   const approval = async () => {

--- a/src/components/transactions/Swap/helpers/shared/provider.helpers.ts
+++ b/src/components/transactions/Swap/helpers/shared/provider.helpers.ts
@@ -53,6 +53,10 @@ export const isSwapSupportedByCowProtocol = (
  *
  * Notes:
  * - CoW is preferred when supported; fallback to ParaSwap if supported on chain
+ * - EIP-7702 delegated EOAs always fall back to ParaSwap. Smart-account delegates
+ *   (Alchemy MA v2, etc.) intercept signTypedData and return wrapped signatures
+ *   that don't ecrecover to the EOA, breaking both EIP-712 order signing and the
+ *   flash-loan adapter's EIP-1271 wrapper.
  */
 export const getSwitchProvider = ({
   chainId,
@@ -60,14 +64,17 @@ export const getSwitchProvider = ({
   assetTo,
   shouldUseFlashloan,
   swapType,
+  userIsEip7702Wallet,
 }: {
   chainId: number;
   assetFrom: string;
   assetTo: string;
   shouldUseFlashloan?: boolean;
   swapType: SwapType;
+  userIsEip7702Wallet?: boolean;
 }): SwapProvider | undefined => {
   if (
+    !userIsEip7702Wallet &&
     isSwapSupportedByCowProtocol(chainId, assetFrom, assetTo, swapType, shouldUseFlashloan ?? false)
   ) {
     return SwapProvider.COW_PROTOCOL;

--- a/src/components/transactions/Swap/hooks/useSwapQuote.ts
+++ b/src/components/transactions/Swap/hooks/useSwapQuote.ts
@@ -126,6 +126,7 @@ export const useSwapQuote = ({
       assetTo: state.destinationToken.addressToSwap,
       swapType: params.swapType,
       shouldUseFlashloan: state.useFlashloan,
+      userIsEip7702Wallet: state.userIsEip7702Wallet,
     });
   }, [
     state.mainTxState.success,
@@ -135,6 +136,7 @@ export const useSwapQuote = ({
     state.destinationToken.addressToSwap,
     params.swapType,
     state.useFlashloan,
+    state.userIsEip7702Wallet,
   ]);
 
   const requiresQuoteInverted = useMemo(

--- a/src/components/transactions/Swap/hooks/useUserContext.ts
+++ b/src/components/transactions/Swap/hooks/useUserContext.ts
@@ -12,23 +12,33 @@ export const useUserContext = ({ setState }: { setState: Dispatch<Partial<SwapSt
   const { chainId: connectedChainId } = useWeb3Context();
 
   useEffect(() => {
-    try {
-      if (user && connectedChainId) {
-        setState({ user });
-        getEthersProvider(wagmiConfig, { chainId: connectedChainId }).then((provider) => {
-          Promise.all([
-            isSmartContractWallet(user, provider),
-            isSafeWallet(user, provider),
-            isEip7702Wallet(user, provider),
-          ]).then(([isSmartContract, isSafe, isEip7702]) => {
-            setState({ userIsSmartContractWallet: isSmartContract });
-            setState({ userIsSafeWallet: isSafe });
-            setState({ userIsEip7702Wallet: isEip7702 });
-          });
+    if (!user || !connectedChainId) return;
+
+    let cancelled = false;
+    setState({ user });
+
+    getEthersProvider(wagmiConfig, { chainId: connectedChainId })
+      .then((provider) =>
+        Promise.all([
+          isSmartContractWallet(user, provider),
+          isSafeWallet(user, provider),
+          isEip7702Wallet(user, provider),
+        ])
+      )
+      .then(([isSmartContract, isSafe, isEip7702]) => {
+        if (cancelled) return;
+        setState({
+          userIsSmartContractWallet: isSmartContract,
+          userIsSafeWallet: isSafe,
+          userIsEip7702Wallet: isEip7702,
         });
-      }
-    } catch (error) {
-      console.error(error);
-    }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [user, connectedChainId]);
 };

--- a/src/components/transactions/Swap/hooks/useUserContext.ts
+++ b/src/components/transactions/Swap/hooks/useUserContext.ts
@@ -1,23 +1,31 @@
 import { Dispatch, useEffect } from 'react';
 import { isEip7702Wallet, isSafeWallet, isSmartContractWallet } from 'src/helpers/provider';
-import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { getEthersProvider } from 'src/libs/web3-data-provider/adapters/EthersAdapter';
 import { useRootStore } from 'src/store/root';
 import { wagmiConfig } from 'src/ui-config/wagmiConfig';
 
 import { SwapState } from '../types';
 
-export const useUserContext = ({ setState }: { setState: Dispatch<Partial<SwapState>> }) => {
+// Detect on the swap's target chain, not the wallet's currently connected chain.
+// EIP-7702 delegation is per-chain (the authorization tuple includes chainId), so
+// a user can be 7702 on the swap chain while connected to a different one.
+// Checking the wrong chain would misclassify and route through CoW.
+export const useUserContext = ({
+  chainId,
+  setState,
+}: {
+  chainId: number;
+  setState: Dispatch<Partial<SwapState>>;
+}) => {
   const user = useRootStore((store) => store.account);
-  const { chainId: connectedChainId } = useWeb3Context();
 
   useEffect(() => {
-    if (!user || !connectedChainId) return;
+    if (!user || !chainId) return;
 
     let cancelled = false;
     setState({ user });
 
-    getEthersProvider(wagmiConfig, { chainId: connectedChainId })
+    getEthersProvider(wagmiConfig, { chainId })
       .then((provider) =>
         Promise.all([
           isSmartContractWallet(user, provider),
@@ -40,5 +48,5 @@ export const useUserContext = ({ setState }: { setState: Dispatch<Partial<SwapSt
     return () => {
       cancelled = true;
     };
-  }, [user, connectedChainId]);
+  }, [user, chainId]);
 };

--- a/src/components/transactions/Swap/hooks/useUserContext.ts
+++ b/src/components/transactions/Swap/hooks/useUserContext.ts
@@ -1,5 +1,5 @@
 import { Dispatch, useEffect } from 'react';
-import { isSafeWallet, isSmartContractWallet } from 'src/helpers/provider';
+import { isEip7702Wallet, isSafeWallet, isSmartContractWallet } from 'src/helpers/provider';
 import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { getEthersProvider } from 'src/libs/web3-data-provider/adapters/EthersAdapter';
 import { useRootStore } from 'src/store/root';
@@ -16,12 +16,15 @@ export const useUserContext = ({ setState }: { setState: Dispatch<Partial<SwapSt
       if (user && connectedChainId) {
         setState({ user });
         getEthersProvider(wagmiConfig, { chainId: connectedChainId }).then((provider) => {
-          Promise.all([isSmartContractWallet(user, provider), isSafeWallet(user, provider)]).then(
-            ([isSmartContract, isSafe]) => {
-              setState({ userIsSmartContractWallet: isSmartContract });
-              setState({ userIsSafeWallet: isSafe });
-            }
-          );
+          Promise.all([
+            isSmartContractWallet(user, provider),
+            isSafeWallet(user, provider),
+            isEip7702Wallet(user, provider),
+          ]).then(([isSmartContract, isSafe, isEip7702]) => {
+            setState({ userIsSmartContractWallet: isSmartContract });
+            setState({ userIsSafeWallet: isSafe });
+            setState({ userIsEip7702Wallet: isEip7702 });
+          });
         });
       }
     } catch (error) {

--- a/src/components/transactions/Swap/modals/request/BaseSwapModalContent.tsx
+++ b/src/components/transactions/Swap/modals/request/BaseSwapModalContent.tsx
@@ -108,7 +108,7 @@ export const BaseSwapModalContent = ({
     setState({ mainTxState });
   }, [mainTxState]);
   const trackingHandlers = useHandleAnalytics({ state });
-  useUserContext({ setState });
+  useUserContext({ chainId: state.chainId, setState });
   useMaxNativeAmount({ params, state, setState });
   useSlippageSelector({ params, state, setState });
   useFlowSelector({ params, state, setState });

--- a/src/components/transactions/Swap/types/state.types.ts
+++ b/src/components/transactions/Swap/types/state.types.ts
@@ -118,6 +118,8 @@ export type TokensSwapState = {
   userIsSmartContractWallet: boolean;
   /** True if the user is a Safe wallet. */
   userIsSafeWallet: boolean;
+  /** True if the user is an EIP-7702 delegated EOA (CoW signature flow incompatible). */
+  userIsEip7702Wallet: boolean;
   /** Token list for the source picker. */
   sourceTokens: SwappableToken[];
   /** Token list for the destination picker. */
@@ -261,6 +263,7 @@ export const swapDefaultState: SwapState = {
   forcedMaxValue: '',
   userIsSmartContractWallet: false,
   userIsSafeWallet: false,
+  userIsEip7702Wallet: false,
   sourceTokens: [],
   destinationTokens: [],
   isMaxSelected: false,

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -10,6 +10,19 @@ export const isSmartContractWallet = async (user: string, provider: JsonRpcProvi
   return code !== '0x';
 };
 
+export const isEip7702Wallet = async (
+  user: string,
+  provider: JsonRpcProvider
+): Promise<boolean> => {
+  try {
+    const code = await provider.getCode(user);
+    return isEip7702EOA(code, user);
+  } catch (error) {
+    console.error('Error detecting EIP-7702 delegation:', error);
+    return false;
+  }
+};
+
 // https://eips.ethereum.org/EIPS/eip-7702#abstract
 function isEip7702EOA(code: string, account: string): boolean {
   return code.startsWith('0xef0100') || code.toLowerCase() === account.toLowerCase();

--- a/src/hooks/useGetConnectedWalletType.ts
+++ b/src/hooks/useGetConnectedWalletType.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
+  isEip7702Wallet as getIsEip7702Wallet,
   isSafeWallet as getIsSafeWallet,
   isSmartContractWallet as getIsSmartContractWallet,
 } from 'src/helpers/provider';
@@ -13,6 +14,7 @@ export const useGetConnectedWalletType = () => {
   const user = useRootStore((store) => store.account);
   const [isSmartContractWallet, setUserIsSmartContractWallet] = useState(false);
   const [isSafeWallet, setUserIsSafeWallet] = useState(false);
+  const [isEip7702Wallet, setUserIsEip7702Wallet] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -21,25 +23,34 @@ export const useGetConnectedWalletType = () => {
       return;
     }
 
+    let cancelled = false;
     setIsLoading(true);
     getEthersProvider(wagmiConfig, { chainId })
       .then((provider) => {
         return Promise.all([
           getIsSmartContractWallet(user, provider),
           getIsSafeWallet(user, provider),
+          getIsEip7702Wallet(user, provider),
         ]);
       })
-      .then(([isSmartContract, isSafe]) => {
+      .then(([isSmartContract, isSafe, isEip7702]) => {
+        if (cancelled) return;
         setUserIsSmartContractWallet(isSmartContract);
         setUserIsSafeWallet(isSafe);
+        setUserIsEip7702Wallet(isEip7702);
       })
       .catch((error) => {
         console.error('Error fetching wallet type:', error);
       })
       .finally(() => {
+        if (cancelled) return;
         setIsLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [chainId, user]);
 
-  return { isSmartContractWallet, isSafeWallet, isLoading };
+  return { isSmartContractWallet, isSafeWallet, isEip7702Wallet, isLoading };
 };


### PR DESCRIPTION
## Summary

Users on EIP-7702 delegated EOAs (Robinhood Wallet → Alchemy Modular Account v2, etc.) hit `InvalidEip1271Signature` from the CoW orderbook when running Aave's collateral swap / debt swap / repay-with-collateral / withdraw-and-swap flows.

Root cause: `@cowprotocol/sdk-flash-loans` hardcodes `SigningScheme.EIP1271` and a `customEIP1271Signature` that assumes `signer.signTypedData()` returns a plain ECDSA signature recoverable to the EOA. 7702 smart-account delegates intercept `signTypedData` at the wallet layer and return wrapped/module-encoded sigs, so the adapter's `isValidSignature` recovers the wrong address and CoW rejects. The simple EIP-712 `sendOrder` path likely breaks the same way on these wallets.

This change detects 7702 delegation (code prefix `0xef0100`) in the swap user context and forces ParaSwap for those users — ParaSwap is on-chain and doesn't depend on off-chain signature verification, so it works for any wallet regardless of delegate behavior.

## Changes

- `src/helpers/provider.ts`: export `isEip7702Wallet` helper (wraps the existing `isEip7702EOA` predicate)
- `src/components/transactions/Swap/types/state.types.ts`: add `userIsEip7702Wallet` to `SwapState`
- `src/components/transactions/Swap/hooks/useUserContext.ts`: detect 7702 alongside `isSmartContractWallet` / `isSafeWallet`
- `src/components/transactions/Swap/helpers/shared/provider.helpers.ts`: `getSwitchProvider` skips CoW when `userIsEip7702Wallet`
- `src/components/transactions/Swap/hooks/useSwapQuote.ts`: thread the flag through

## Repro

Support ticket: wallet `0x50fcB386A45633cda069dB74c64f7E8c2bf90C56` on BSC, BNB→USDT collateral swap, returned order hash `0xb450a1d3b86bc9be05a7f47ae356a06788ec82ad45180c20a1bcb6bd122f7364`. Delegate at `0x69007702764179f14F51cdce752f4f775d74E139` is Alchemy Modular Account v2.

## Follow-ups

- Flagged the SDK-side incompatibility to CoW; long-term fix is ERC-6492 / 7702-aware validation in `@cowprotocol/sdk-flash-loans` so we can re-enable CoW for these wallets.
- Worth a sanity check whether the second branch of `isEip7702EOA` (`code === account.toLowerCase()`) was intentional — it doesn't match any standard 7702 delegation pattern. Not changed here.

## Test plan

- Manual: connect a 7702-delegated wallet (Robinhood Wallet, or MetaMask Smart Account on Sepolia) and verify the swap UI picks ParaSwap, not CoW, for collateral / debt / withdraw / repay-with-collateral flows.
- Regression: connect a plain EOA and a Safe wallet, verify provider selection is unchanged (CoW for EOA where supported, PRESIGN/Safe path for Safe).