### PR TITLE
fix: truncate balances to token decimals across all swap modals

### DIFF
--- a/src/components/transactions/Swap/helpers/shared/misc.helpers.ts
+++ b/src/components/transactions/Swap/helpers/shared/misc.helpers.ts
@@ -1,9 +1,17 @@
+import { BigNumber } from 'bignumber.js';
 import { BaseNetworkConfig } from 'src/ui-config/networksConfig';
 import {
   getSupportedChainIds,
   marketsData,
   networkConfigs,
 } from 'src/utils/marketsAndNetworksConfig';
+
+// Reserve values from @aave/math-utils (variableBorrows, underlyingBalance)
+// carry RAY-level precision (scaledBalance * index / RAY), which can exceed
+// the token's native decimals. Truncate down so downstream parseUnits calls
+// accept the Max value the user sees.
+export const truncateToTokenDecimals = (value: string, decimals: number) =>
+  new BigNumber(value).decimalPlaces(decimals, BigNumber.ROUND_DOWN).toString(10);
 
 export interface SupportedNetworkWithChainId extends BaseNetworkConfig {
   chainId: number;

--- a/src/components/transactions/Swap/modals/request/CollateralSwapModalContent.tsx
+++ b/src/components/transactions/Swap/modals/request/CollateralSwapModalContent.tsx
@@ -12,7 +12,7 @@ import { TOKEN_LIST, TokenInfo } from 'src/ui-config/TokenList';
 import { displayGhoForMintableMarket } from 'src/utils/ghoUtilities';
 import { useShallow } from 'zustand/shallow';
 
-import { invalidateAppStateForSwap } from '../../helpers/shared';
+import { invalidateAppStateForSwap, truncateToTokenDecimals } from '../../helpers/shared';
 import { SwappableToken, SwapParams, SwapType, TokenType } from '../../types';
 import { BaseSwapModalContent } from './BaseSwapModalContent';
 
@@ -169,6 +169,7 @@ const getTokensFrom = (
             balance = balanceBN.minus(oneWei).toString();
           }
         }
+        balance = truncateToTokenDecimals(balance, baseToken.decimals);
 
         return {
           addressToSwap: position.reserve.aTokenAddress,
@@ -255,7 +256,7 @@ const getTokensTo = (
         decimals: baseToken.decimals,
         symbol: nativeToken?.symbol ?? baseToken.symbol,
         name: baseToken.name,
-        balance: currentCollateral,
+        balance: truncateToTokenDecimals(currentCollateral, baseToken.decimals),
         chainId,
         usdPrice: reserve.priceInUSD,
         supplyAPY: reserve.supplyAPY,

--- a/src/components/transactions/Swap/modals/request/DebtSwapModalContent.tsx
+++ b/src/components/transactions/Swap/modals/request/DebtSwapModalContent.tsx
@@ -20,7 +20,7 @@ import {
 } from 'src/utils/getMaxAmountAvailableToBorrow';
 import { useShallow } from 'zustand/shallow';
 
-import { invalidateAppStateForSwap } from '../../helpers/shared';
+import { invalidateAppStateForSwap, truncateToTokenDecimals } from '../../helpers/shared';
 import { SwappableToken, SwapParams, SwapType } from '../../types';
 import { BaseSwapModalContent } from './BaseSwapModalContent';
 
@@ -139,7 +139,10 @@ const getTokensFrom = (
         addressForUsdPrice: borrowPosition.underlyingAsset,
         underlyingAddress: borrowPosition.underlyingAsset,
         name: borrowPosition.reserve.name,
-        balance: borrowPosition.variableBorrows,
+        balance: truncateToTokenDecimals(
+          borrowPosition.variableBorrows,
+          borrowPosition.reserve.decimals
+        ),
         chainId,
         decimals: borrowPosition.reserve.decimals,
         symbol: nativeToken?.symbol ?? tokenFromList?.symbol ?? borrowPosition.reserve.symbol,

--- a/src/components/transactions/Swap/modals/request/RepayWithCollateralModalContent.tsx
+++ b/src/components/transactions/Swap/modals/request/RepayWithCollateralModalContent.tsx
@@ -1,7 +1,6 @@
 import { API_ETH_MOCK_ADDRESS, InterestRate } from '@aave/contract-helpers';
 import { SupportedChainId, WRAPPED_NATIVE_CURRENCIES } from '@cowprotocol/cow-sdk';
 import { useQueryClient } from '@tanstack/react-query';
-import { BigNumber } from 'bignumber.js';
 import {
   ComputedUserReserveData,
   ExtendedFormattedUser,
@@ -14,7 +13,7 @@ import { fetchIconSymbolAndName } from 'src/ui-config/reservePatches';
 import { TOKEN_LIST, TokenInfo } from 'src/ui-config/TokenList';
 import { useShallow } from 'zustand/shallow';
 
-import { invalidateAppStateForSwap } from '../../helpers/shared';
+import { invalidateAppStateForSwap, truncateToTokenDecimals } from '../../helpers/shared';
 import { SwappableToken, SwapParams, SwapType } from '../../types';
 import { BaseSwapModalContent } from './BaseSwapModalContent';
 
@@ -102,11 +101,6 @@ export const RepayWithCollateralModalContent = ({
 
   return <BaseSwapModalContent params={params} />;
 };
-
-// variableBorrows / underlyingBalance carry RAY-level precision; truncate to
-// the token's decimals so parseUnits downstream doesn't reject the Max value.
-const truncateToTokenDecimals = (value: string, decimals: number) =>
-  new BigNumber(value).decimalPlaces(decimals, BigNumber.ROUND_DOWN).toString(10);
 
 // Tokens from are all current open debt positions
 const getTokensFrom = (

--- a/src/components/transactions/Swap/modals/request/RepayWithCollateralModalContent.tsx
+++ b/src/components/transactions/Swap/modals/request/RepayWithCollateralModalContent.tsx
@@ -103,13 +103,8 @@ export const RepayWithCollateralModalContent = ({
   return <BaseSwapModalContent params={params} />;
 };
 
-// variableBorrows and underlyingBalance carry RAY-level precision
-// (scaledBalance * index / RAY), so their decimal strings can exceed the
-// token's native decimals. Clicking Max pipes that raw string into
-// inputAmount/outputAmount, and the Paraswap action layer forwards it to
-// parseUnits when the value isn't recomputed via safeAmountToRepayAll
-// (e.g. once the user edits the prefilled max) -- parseUnits then throws on
-// the excess decimals. Truncate down to what the token can represent.
+// variableBorrows / underlyingBalance carry RAY-level precision; truncate to
+// the token's decimals so parseUnits downstream doesn't reject the Max value.
 const truncateToTokenDecimals = (value: string, decimals: number) =>
   new BigNumber(value).decimalPlaces(decimals, BigNumber.ROUND_DOWN).toString(10);
 

--- a/src/components/transactions/Swap/modals/request/RepayWithCollateralModalContent.tsx
+++ b/src/components/transactions/Swap/modals/request/RepayWithCollateralModalContent.tsx
@@ -1,6 +1,7 @@
 import { API_ETH_MOCK_ADDRESS, InterestRate } from '@aave/contract-helpers';
 import { SupportedChainId, WRAPPED_NATIVE_CURRENCIES } from '@cowprotocol/cow-sdk';
 import { useQueryClient } from '@tanstack/react-query';
+import { BigNumber } from 'bignumber.js';
 import {
   ComputedUserReserveData,
   ExtendedFormattedUser,
@@ -102,6 +103,16 @@ export const RepayWithCollateralModalContent = ({
   return <BaseSwapModalContent params={params} />;
 };
 
+// variableBorrows and underlyingBalance carry RAY-level precision
+// (scaledBalance * index / RAY), so their decimal strings can exceed the
+// token's native decimals. Clicking Max pipes that raw string into
+// inputAmount/outputAmount, and the Paraswap action layer forwards it to
+// parseUnits when the value isn't recomputed via safeAmountToRepayAll
+// (e.g. once the user edits the prefilled max) -- parseUnits then throws on
+// the excess decimals. Truncate down to what the token can represent.
+const truncateToTokenDecimals = (value: string, decimals: number) =>
+  new BigNumber(value).decimalPlaces(decimals, BigNumber.ROUND_DOWN).toString(10);
+
 // Tokens from are all current open debt positions
 const getTokensFrom = (
   user: ExtendedFormattedUser | undefined,
@@ -163,7 +174,10 @@ const getTokensFrom = (
         addressForUsdPrice: borrowPosition.underlyingAsset,
         underlyingAddress: borrowPosition.underlyingAsset,
         name: borrowPosition.reserve.name,
-        balance: borrowPosition.variableBorrows,
+        balance: truncateToTokenDecimals(
+          borrowPosition.variableBorrows,
+          borrowPosition.reserve.decimals
+        ),
         chainId,
         decimals: borrowPosition.reserve.decimals,
         symbol: nativeToken?.symbol ?? tokenFromList?.symbol ?? borrowPosition.reserve.symbol,
@@ -216,7 +230,7 @@ const getTokensTo = (
           decimals: baseToken.decimals,
           symbol: nativeToken?.symbol ?? baseToken.symbol,
           name: baseToken.name,
-          balance: position.underlyingBalance,
+          balance: truncateToTokenDecimals(position.underlyingBalance, baseToken.decimals),
           chainId,
           usdPrice: position.reserve.priceInUSD,
           supplyAPY: position.reserve.supplyAPY,

--- a/src/components/transactions/Swap/modals/request/WithdrawAndSwapModalContent.tsx
+++ b/src/components/transactions/Swap/modals/request/WithdrawAndSwapModalContent.tsx
@@ -9,7 +9,7 @@ import { useRootStore } from 'src/store/root';
 import { TOKEN_LIST, TokenInfo } from 'src/ui-config/TokenList';
 import { useShallow } from 'zustand/shallow';
 
-import { invalidateAppStateForSwap } from '../../helpers/shared';
+import { invalidateAppStateForSwap, truncateToTokenDecimals } from '../../helpers/shared';
 import { SwappableToken, SwapParams, SwapType, TokenType } from '../../types';
 import { BaseSwapModalContent } from './BaseSwapModalContent';
 import { getDefaultOutputToken, getFilteredTokensForSwitch } from './SwapModalContent';
@@ -148,7 +148,7 @@ const getTokensFrom = (
           decimals: baseToken.decimals,
           symbol: nativeToken?.symbol ?? baseToken.symbol,
           name: baseToken.name,
-          balance: position.underlyingBalance,
+          balance: truncateToTokenDecimals(position.underlyingBalance, baseToken.decimals),
           chainId,
           usdPrice: position.reserve.priceInUSD,
           logoURI: nativeToken?.logoURI ?? baseToken.logoURI,


### PR DESCRIPTION
## Problem

Reserve-derived strings from \`@aave/math-utils\` (\`variableBorrows\`, \`underlyingBalance\`) are computed as \`scaledBalance * index / RAY\`, so their decimal representation can exceed the token's native decimals (USDC = 6, WBTC = 8 etc. all surface 18+ decimal places). Every swap modal was attaching one of those strings directly to the \`SwappableToken.balance\` field, and clicking **Max** piped the raw string into \`inputAmount\` / \`outputAmount\` via [SwapInputs.tsx:91](src/components/transactions/Swap/inputs/SwapInputs.tsx:91) / [SwapInputs.tsx:150](src/components/transactions/Swap/inputs/SwapInputs.tsx:150).

If the user nudged the prefilled value, \`isMaxSelected\` flipped off and downstream \`parseUnits(value, decimals)\` calls — e.g. the Paraswap action layer's sell-side fallback and [useMaxNativeAmount.ts:33](src/components/transactions/Swap/hooks/useMaxNativeAmount.ts:33) — rejected the excess decimals with \`fractional component exceeds decimals (code=NUMERIC_FAULT)\`. Users were working around it by deleting digits by hand.

Regular Repay isn't affected because its submission shortcuts through the \`-1\` (max-uint256) sentinel or the already-rounded \`safeAmountToRepayAll\`.

## Change

Hoist a single \`truncateToTokenDecimals(value, decimals)\` helper into [helpers/shared/misc.helpers.ts](src/components/transactions/Swap/helpers/shared/misc.helpers.ts) and apply it everywhere a reserve-derived string becomes a \`SwappableToken.balance\`:

- [RepayWithCollateralModalContent.tsx:172,228](src/components/transactions/Swap/modals/request/RepayWithCollateralModalContent.tsx:172) — debt + collateral sides.
- [DebtSwapModalContent.tsx:142](src/components/transactions/Swap/modals/request/DebtSwapModalContent.tsx:142) — debt side.
- [CollateralSwapModalContent.tsx:172,259](src/components/transactions/Swap/modals/request/CollateralSwapModalContent.tsx:172) — both collateral sides.
- [WithdrawAndSwapModalContent.tsx:151](src/components/transactions/Swap/modals/request/WithdrawAndSwapModalContent.tsx:151) — supplied position.

CollateralSwap's existing \`supplyAPY === '0'\` dust workaround (subtracts one wei when the underlying value was rounded up) is preserved in place; truncation runs after it. ROUND_DOWN throughout, so the visible balance is at or below what the token can actually represent.

## Safety against regressions

Submission paths don't go through the truncated string for any of the actually-paying amounts:

- **RepayWithCollateral**: action layer recomputes \`safeAmountToRepayAll\` from \`state.sourceReserve.variableBorrows\` directly (full precision) for the Max+Confirm path. Truncated value only flows in when the user has edited the field, and now it's parseUnits-safe.
- **DebtSwap / CollateralSwap / WithdrawAndSwap**: action layers submit via \`state.sellAmountBigInt\` / \`buyAmountBigInt\`, derived in [useSwapOrderAmounts.ts:340](src/components/transactions/Swap/hooks/useSwapOrderAmounts.ts:340) as \`BigInt(normalizeBN(...).toFixed(0))\`. The BigInt path was already collapsing precision; the displayed string just couldn't survive parseUnits.
- **InsufficientBalanceGuard**: compares \`payingToken.balance\` against the formatted required amount; both come from the same (now truncated) source when Max is selected, so the equality still holds.
- **\`repayAllDebt\` decision** in [RepayWithCollateralActionsViaParaswap.tsx:149](src/components/transactions/Swap/actions/RepayWithCollateral/RepayWithCollateralActionsViaParaswap.tsx:149): compares the now-truncated \`destinationToken.balance\` against \`collateralAmountRequiredToCoverDebt\` which embeds slippage. The truncation is sub-cent — orders of magnitude smaller than the slippage tolerance — so the boolean does not flip in any realistic balance.

## Local verification

- \`yarn lint:code\` — clean.
- \`npx prettier --check\` on all touched files — clean.
- \`npx tsc --noEmit -p tsconfig.json\` — clean.
- \`yarn build\` — production build succeeded, every page compiled.
- \`yarn dev\` — server boots, 18k modules compile, homepage 200.
- Jest test suites have a pre-existing viem ESM import failure on \`main\`; confirmed via \`git stash && yarn test:ci\` that the same suites fail without these changes.

\`yarn test:ci\` baseline failures (unrelated, on \`main\`):

\`\`\`
Test Suites: 3 failed, 3 total
SyntaxError: Unexpected token 'export'  (viem/chains)
\`\`\`

## Test plan

- [ ] Repay with collateral, Max on a USDC/USDT/WBTC debt — input shows token-precision, Repay succeeds.
- [ ] Same flow, click Max then edit the input — tx still submits without manual digit trimming.
- [ ] Debt swap, Max on a non-18-decimal debt — input is parseUnits-safe.
- [ ] Collateral swap, Max on aUSDC / aUSDT collateral — input shows token-precision; the existing supplyAPY=0 dust workaround on 18-decimal tokens (DAI/WETH) is preserved.
- [ ] Withdraw and swap, Max on a non-18-decimal supplied position — input is parseUnits-safe.