### PR TITLE
fix(swap): optimize quote on aTokens for non-flashloan CoW paths

### DIFF
--- a/src/components/transactions/Swap/hooks/useMaxNativeAmount.ts
+++ b/src/components/transactions/Swap/hooks/useMaxNativeAmount.ts
@@ -39,7 +39,11 @@ export const useMaxNativeAmount = ({
     ? normalize(maxAmount.toString(), nativeDecimals).toString()
     : undefined;
 
+  // Only force a max value for native sells (where we need to reserve gas). For
+  // other tokens, leave forcedMaxValue undefined so the Max button routes through
+  // handleInputChange's '-1' path and the aToken 1-wei shave applies.
+  const isNative = state.sourceToken.tokenType === TokenType.NATIVE;
   useEffect(() => {
-    setState({ forcedMaxValue: maxAmountFormatted });
-  }, [maxAmountFormatted]);
+    setState({ forcedMaxValue: isNative ? maxAmountFormatted : undefined });
+  }, [maxAmountFormatted, isNative]);
 };

--- a/src/components/transactions/Swap/hooks/useSwapQuote.ts
+++ b/src/components/transactions/Swap/hooks/useSwapQuote.ts
@@ -41,16 +41,17 @@ export const swapTypesThatRequiresInvertedQuote: SwapType[] = [
 
 const getTokenSelectionForQuote = (
   invertedQuoteRoute: boolean,
+  provider: SwapProvider,
   state: SwapState
 ): TokenSelectionParams => {
   const srcTokenObj = invertedQuoteRoute ? state.destinationToken : state.sourceToken;
   const destTokenObj = invertedQuoteRoute ? state.sourceToken : state.destinationToken;
 
-  // Quote tokens must match what the order will post on, otherwise CoW's per-pair volume-fee policy and gas estimate apply to a different pair than the order and the cushion computed in useSwapOrderAmounts comes out short.
+  // Quote tokens must match what the order will post on, otherwise CoW's per-pair volume-fee policy and gas estimate apply to a different pair than the order and the cushion computed in useSwapOrderAmounts comes out short. Read provider from the active query arg, not state.provider, which lags during provider transitions.
   const usesAddressToSwap =
     state.useFlashloan === false &&
-    (state.provider === SwapProvider.COW_PROTOCOL ||
-      (state.provider === SwapProvider.PARASWAP &&
+    (provider === SwapProvider.COW_PROTOCOL ||
+      (provider === SwapProvider.PARASWAP &&
         state.swapType !== SwapType.WithdrawAndSwap &&
         state.swapType !== SwapType.RepayWithCollateral));
 
@@ -319,9 +320,9 @@ const useMultiProviderSwapQuoteQuery = ({
     isOutputTokenCustom,
     side,
   } = useMemo(
-    () => getTokenSelectionForQuote(requiresQuoteInverted, state),
+    () => getTokenSelectionForQuote(requiresQuoteInverted, provider, state),
     [
-      state.provider,
+      provider,
       state.sourceToken,
       state.destinationToken,
       state.side,

--- a/src/components/transactions/Swap/hooks/useSwapQuote.ts
+++ b/src/components/transactions/Swap/hooks/useSwapQuote.ts
@@ -43,23 +43,19 @@ const getTokenSelectionForQuote = (
   invertedQuoteRoute: boolean,
   state: SwapState
 ): TokenSelectionParams => {
-  // Note: Consider the quote an approximation, we prefer underlying address for better support while aTokens value should always match
   const srcTokenObj = invertedQuoteRoute ? state.destinationToken : state.sourceToken;
-  const srcToken =
-    state.useFlashloan == false &&
-    state.provider === SwapProvider.PARASWAP &&
-    state.swapType !== SwapType.WithdrawAndSwap &&
-    state.swapType !== SwapType.RepayWithCollateral
-      ? srcTokenObj.addressToSwap
-      : srcTokenObj.underlyingAddress;
   const destTokenObj = invertedQuoteRoute ? state.sourceToken : state.destinationToken;
-  const destToken =
-    state.useFlashloan == false &&
-    state.provider === SwapProvider.PARASWAP &&
-    state.swapType !== SwapType.WithdrawAndSwap &&
-    state.swapType !== SwapType.RepayWithCollateral
-      ? destTokenObj.addressToSwap
-      : destTokenObj.underlyingAddress;
+
+  // Quote tokens must match what the order will post on, otherwise CoW's per-pair volume-fee policy and gas estimate apply to a different pair than the order and the cushion computed in useSwapOrderAmounts comes out short.
+  const usesAddressToSwap =
+    state.useFlashloan === false &&
+    (state.provider === SwapProvider.COW_PROTOCOL ||
+      (state.provider === SwapProvider.PARASWAP &&
+        state.swapType !== SwapType.WithdrawAndSwap &&
+        state.swapType !== SwapType.RepayWithCollateral));
+
+  const srcToken = usesAddressToSwap ? srcTokenObj.addressToSwap : srcTokenObj.underlyingAddress;
+  const destToken = usesAddressToSwap ? destTokenObj.addressToSwap : destTokenObj.underlyingAddress;
 
   const srcDecimals = invertedQuoteRoute
     ? state.destinationToken.decimals

--- a/src/components/transactions/Swap/inputs/SwapInputs.tsx
+++ b/src/components/transactions/Swap/inputs/SwapInputs.tsx
@@ -1,4 +1,4 @@
-import { BigNumberValue, valueToBigNumber } from '@aave/math-utils';
+import { BigNumberValue, normalize, normalizeBN, valueToBigNumber } from '@aave/math-utils';
 import { WRAPPED_NATIVE_CURRENCIES } from '@cowprotocol/cow-sdk';
 import { useQueryClient } from '@tanstack/react-query';
 import { Dispatch, useEffect, useMemo } from 'react';
@@ -56,6 +56,18 @@ export const SwapInputs = ({
   trackingHandlers: TrackAnalyticsHandlers;
 }) => {
   const { setApprovalTxState, approvalTxState } = useModalContext();
+
+  // Shave 1 wei from aToken max balances — the SDK's underlyingBalance rounds up vs aToken.balanceOf (two half-up rayMuls vs one), which makes "max" sellAmounts exceed the actually-transferable balance.
+  const getMaxBalanceForToken = (token: SwappableToken): string => {
+    const balance = token.balance || '0';
+    const isAToken =
+      token.addressToSwap.toLowerCase() !== token.underlyingAddress.toLowerCase();
+    if (!isAToken) return balance;
+    const wei = normalizeBN(balance, -token.decimals);
+    if (wei.lte(1)) return balance;
+    return normalize(wei.minus(1).toFixed(0), token.decimals);
+  };
+
   const resetErrorsAndWarnings = () => {
     setState({
       error: undefined,
@@ -88,7 +100,7 @@ export const SwapInputs = ({
     }
 
     if (value === '-1') {
-      const maxAmount = state.sourceToken.balance;
+      const maxAmount = getMaxBalanceForToken(state.sourceToken);
       setState({
         ...(state.orderType === OrderType.LIMIT && state.swapRate
           ? {
@@ -147,7 +159,7 @@ export const SwapInputs = ({
     }
 
     if (value === '-1') {
-      const maxAmount = state.destinationToken.balance;
+      const maxAmount = getMaxBalanceForToken(state.destinationToken);
       setState({
         ...(state.orderType === OrderType.LIMIT && state.swapRate
           ? {


### PR DESCRIPTION
## Summary

For `CollateralSwap` (no flashloan) and `WithdrawAndSwap`, the CoW order is posted via [`SwapActionsViaCoW`](src/components/transactions/Swap/actions/SwapActions/SwapActionsViaCoW.tsx#L286-L341) with `state.sourceToken.addressToSwap` / `state.destinationToken.addressToSwap` — the aTokens. But the quote in [`useSwapQuote.ts`](src/components/transactions/Swap/hooks/useSwapQuote.ts) was always fetched on `underlyingAddress` for any CoW path. That mismatch erodes the slippage cushion because CoW's volume-fee policy and gas estimate are per-pair: the quote's tier and rate apply to the underlying pair while the order settles on the aToken pair.

On a recent `aEthRLUSD -> aEthUSDS` collateral swap, this contributed ~1.7 bps (0.3 bps protocol-fee tier for the underlying RLUSD/USDS pair vs 2 bps tier for the aToken pair), which flipped a 2 bps limit order to ~0.11 bps **above** market — solver-unfillable, expired.

## What changed

Behavioral change is **CoW-only**. The Paraswap branch of the conditional is preserved bit-for-bit; the new code only adds CoW to the path that already used `addressToSwap` for non-flashloan Paraswap.

- Renamed the existing conditional in [`getTokenSelectionForQuote`](src/components/transactions/Swap/hooks/useSwapQuote.ts#L42) to a single `usesAddressToSwap` flag.
- For CoW with `state.useFlashloan === false`, quote tokens are now `addressToSwap` (matching what the order posts).
- Flashloan CoW paths unchanged: quote stays on underlying because the flashloan adapter unwraps aTokens in pre/post hooks.
- All Paraswap paths unchanged.

## Behavioral changes (truth table)

| provider | useFlashloan | swapType | before | after |
|---|---|---|---|---|
| CoW | false | `CollateralSwap` | underlying ❌ | aToken ✅ |
| CoW | false | `WithdrawAndSwap` | underlying ❌ | aToken (src) / token (dest) ✅ |
| CoW | false | `Swap` | underlying (= aToken for plain ERC20) | aToken (= same value, no-op) |
| CoW | true | any | underlying ✅ | underlying ✅ (unchanged) |
| Paraswap | any | any | per existing logic | per existing logic (unchanged) |

`DebtSwap` and `RepayWithCollateral` on CoW always have `useFlashloan = true` via [`forceFlashloanFlow`](src/components/transactions/Swap/hooks/useFlowSelector.ts#L149-L153), so they're unaffected.

## Out of scope (follow-ups)

- The `× 3` `networkFee` hack in [`useSwapOrderAmounts.ts`](src/components/transactions/Swap/hooks/useSwapOrderAmounts.ts#L142-L148) is a workaround for [`getAppDataForQuote`](src/components/transactions/Swap/helpers/cow/adapters.helpers.ts#L199) returning `undefined`. The disabled implementation block right below it would send flashloan/hook hints so solvers' quote includes the right gas; once that's wired the hack can go away.

## Test plan

- [ ] CoW `CollateralSwap` (no flashloan) on an aToken pair where the underlying and aToken pairs land in different CoW volume-fee tiers — confirm the order's `buyAmount` cushion matches the user-selected slippage when checked against a fresh CoW quote on the aToken pair.
- [ ] CoW `WithdrawAndSwap` from an aToken supply to a regular ERC20 — confirm quote tokens match what the order posts.
- [ ] CoW `CollateralSwap` with flashloan (HF below threshold) — confirm quote still goes on underlying, order still posts on underlying via the flashloan adapter, no regression.
- [ ] CoW `DebtSwap` and `RepayWithCollateral` — confirm quote tokens unchanged (both still on underlying via `forceFlashloanFlow`).
- [ ] Paraswap paths across all swap types — confirm no quote-token regression.