### PR TITLE
fix(web3): use useAccountEffect for walletType to fix tab-switch slowdown

### DIFF
--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -207,12 +207,8 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     setAccount(account?.toLowerCase());
   }, [account, setAccount]);
 
-  // Drive walletType from wagmi's account events. useAccountEffect fires for both
-  // fresh connects and reconnects (page reload, redirect-back), so analytics keeps
-  // a real connector id instead of falling back to undefined after a refresh.
-  // It uses watchAccount under the hood and does not subscribe this component to
-  // account state, so destructuring extra fields here would force wagmi's tracked
-  // subscription to deep-equal the connector object on every store tick.
+  // useAccountEffect fires on connect AND reconnect (so analytics survives reloads)
+  // without subscribing this component to wagmi's tracked re-renders.
   useAccountEffect({
     onConnect({ connector }) {
       setWalletType(connector.id);

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -8,7 +8,7 @@ import { useRootStore } from 'src/store/root';
 import { wagmiConfig } from 'src/ui-config/wagmiConfig';
 import { hexToAscii } from 'src/utils/utils';
 import { UserRejectedRequestError } from 'viem';
-import { useAccount, useConnect, useSwitchChain, useWatchAsset } from 'wagmi';
+import { useAccount, useAccountEffect, useConnect, useSwitchChain, useWatchAsset } from 'wagmi';
 import { useShallow } from 'zustand/shallow';
 
 import { Web3Context } from '../hooks/useWeb3Context';
@@ -44,7 +44,7 @@ let didAutoConnectForCypress = false;
 export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ children }) => {
   const { switchChainAsync } = useSwitchChain();
   const { watchAssetAsync } = useWatchAsset();
-  const { chainId, address, status, connector } = useAccount();
+  const { chainId, address } = useAccount();
   const { connect, connectors } = useConnect();
 
   const [readOnlyModeAddress, setReadOnlyModeAddress] = useState<string | undefined>();
@@ -207,16 +207,20 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     setAccount(account?.toLowerCase());
   }, [account, setAccount]);
 
-  // Drive walletType from wagmi's account state so it survives page reloads.
-  // ConnectKit's `onConnect` prop only fires on fresh connect (not on reconnect),
-  // which caused most transaction events to be tracked with walletType=undefined.
-  useEffect(() => {
-    if (status === 'connected' && connector?.id) {
+  // Drive walletType from wagmi's account events. useAccountEffect fires for both
+  // fresh connects and reconnects (page reload, redirect-back), so analytics keeps
+  // a real connector id instead of falling back to undefined after a refresh.
+  // It uses watchAccount under the hood and does not subscribe this component to
+  // account state, so destructuring extra fields here would force wagmi's tracked
+  // subscription to deep-equal the connector object on every store tick.
+  useAccountEffect({
+    onConnect({ connector }) {
       setWalletType(connector.id);
-    } else if (status === 'disconnected') {
+    },
+    onDisconnect() {
       setWalletType(undefined);
-    }
-  }, [status, connector?.id, setWalletType]);
+    },
+  });
 
   useEffect(() => {
     if (readOnlyModeAddress) {

--- a/src/libs/web3-data-provider/Web3Provider.tsx
+++ b/src/libs/web3-data-provider/Web3Provider.tsx
@@ -1,6 +1,7 @@
 import { API_ETH_MOCK_ADDRESS, ERC20Service, transactionType } from '@aave/contract-helpers';
 import { SignatureLike } from '@ethersproject/bytes';
 import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers';
+import { getAccount, watchAccount } from '@wagmi/core';
 import { BigNumber, PopulatedTransaction, utils } from 'ethers';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useIsContractAddress } from 'src/hooks/useIsContractAddress';
@@ -8,7 +9,7 @@ import { useRootStore } from 'src/store/root';
 import { wagmiConfig } from 'src/ui-config/wagmiConfig';
 import { hexToAscii } from 'src/utils/utils';
 import { UserRejectedRequestError } from 'viem';
-import { useAccount, useAccountEffect, useConnect, useSwitchChain, useWatchAsset } from 'wagmi';
+import { useAccount, useConnect, useSwitchChain, useWatchAsset } from 'wagmi';
 import { useShallow } from 'zustand/shallow';
 
 import { Web3Context } from '../hooks/useWeb3Context';
@@ -207,16 +208,27 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     setAccount(account?.toLowerCase());
   }, [account, setAccount]);
 
-  // useAccountEffect fires on connect AND reconnect (so analytics survives reloads)
-  // without subscribing this component to wagmi's tracked re-renders.
-  useAccountEffect({
-    onConnect({ connector }) {
+  // Drive walletType from a direct wagmi store subscription. watchAccount fires for
+  // every state transition into `connected` (including the `connecting(address) ->
+  // connected` path that useAccountEffect.onConnect misses, see wagmi#4221), and
+  // it does not subscribe this component to React renders. Seed once on mount via
+  // getAccount in case the store is already `connected` before the effect installs.
+  useEffect(() => {
+    const { status, connector } = getAccount(wagmiConfig);
+    if (status === 'connected' && connector?.id) {
       setWalletType(connector.id);
-    },
-    onDisconnect() {
-      setWalletType(undefined);
-    },
-  });
+    }
+
+    return watchAccount(wagmiConfig, {
+      onChange(data) {
+        if (data.status === 'connected' && data.connector?.id) {
+          setWalletType(data.connector.id);
+        } else if (data.status === 'disconnected') {
+          setWalletType(undefined);
+        }
+      },
+    });
+  }, [setWalletType]);
 
   useEffect(() => {
     if (readOnlyModeAddress) {


### PR DESCRIPTION
## Summary

#2974 destructured `status` and `connector` from `useAccount()` to drive `walletType` from wagmi's account state. That destructure is what slowed `app.aave.com` down.

Wagmi v2's `useAccount` uses `useSyncExternalStoreWithTracked` ([source](https://github.com/wevm/wagmi/blob/main/packages/react/src/hooks/useSyncExternalStoreWithTracked.ts)): each property you destructure is pushed into a tracked-key set, and the snapshot equality function deep-equals every tracked key on every wagmi store tick. Adding `connector` to that set forced a per-tick `deepEqual` over a multi-property object with an internal event emitter, re-rendering `Web3ContextProvider` on every wagmi update. Since `Web3Context.Provider` builds its `value` object fresh on each render, every context consumer re-rendered too, which is what tab switching paid for.

The replacement: `useAccountEffect`, which calls `watchAccount` inside a plain `useEffect` and does not subscribe the component to renders. It fires `onConnect` for both fresh connect and reconnect (page reload, redirect-back), so the original analytics fix from #2974 still holds.

## Verification

Local A/B with Playwright. 20 samples per variant, dev mode, wallet disconnected, top-nav click → URL commit → next paint:

| variant | commit | min | **p50** | p95 | mean |
|---|---|---|---|---|---|
| main before #2974 | 06a69eb77 | 18 | **24** | 100 | 31 |
| main with #2974 (today) | b0890e211 | 52 | **66** | 222 | 84 |
| this branch | — | 19 | **25** | 95 | 32 |

I bisected inside #2974: reverting just the `status, connector` destructure restores baseline; removing only the new `useEffect` does not. So the destructure is the cause, not the effect.

## Out of scope

Other consumers in the codebase that destructure a wide field set from `useAccount()` may have the same shape of overhead. Not changing them here, but worth a sweep.