### PR TITLE
fix: add better security tags to links for opening in separate tabs

### DIFF
--- a/src/modules/governance/proposal/ProposalOverview.tsx
+++ b/src/modules/governance/proposal/ProposalOverview.tsx
@@ -201,7 +201,7 @@ export const ProposalOverview = ({ proposal, loading, error }: ProposalOverviewP
                   return <CenterAlignedImage src={src} alt={alt} />;
                 },
                 a({ node, ...rest }) {
-                  return <StyledLink {...rest} />;
+                  return <StyledLink {...rest} target="_blank" rel="noopener noreferrer" />;
                 },
                 h1({ node, ...rest }) {
                   return <Typography variant="h2" sx={{ mt: 8, mb: 2 }} {...rest} />;


### PR DESCRIPTION
## Summary

- Add `target="_blank"` and `rel="noopener noreferrer"` to markdown-rendered `<a>` tags in `ProposalOverview`, so external links in proposal descriptions (including untrusted IPFS content rendered by `/governance/ipfs-preview`) open in a new tab and cannot access `window.opener`.

Linear: AAV-15

## Test plan

- [ ] Open a proposal on `/governance/v3/proposal/...` with markdown links in the description — links open in a new tab.
- [ ] Inspect a rendered link's DOM and confirm `target="_blank"` and `rel="noopener noreferrer"`.
- [ ] Visit `/governance/ipfs-preview?ipfsHash=<valid hash>` and confirm description links also carry the safety attributes.
