### PR TITLE
fix: block alchemy_ prefixed methods

### DIFF
--- a/pages/api/rpc-proxy.ts
+++ b/pages/api/rpc-proxy.ts
@@ -90,6 +90,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const { chainId, method, params } = req.body;
+
+    if (typeof method !== 'string' || method.startsWith('alchemy_')) {
+      return res.status(400).json({ error: 'Method not allowed' });
+    }
+
     const chainIdNumber = typeof chainId === 'string' ? parseInt(chainId) : chainId;
     const rpcUrl = getRpcUrl(chainIdNumber);
 


### PR DESCRIPTION
## Summary
- Reject any `/api/rpc-proxy` request whose `method` is missing, non-string, or starts with `alchemy_`, so callers can't use the proxy to hit Alchemy-only RPCs

## Test plan
- [ ] `curl -X POST .../api/rpc-proxy -d '{"chainId":1,"method":"alchemy_getTokenBalances","params":[...]}'` returns 400 `{"error":"Method not allowed"}`
- [ ] `curl -X POST .../api/rpc-proxy -d '{"chainId":1,"method":"eth_blockNumber","params":[]}'` still returns a block number
