### PR TITLE
feat: add sGHO to swap widget assets

### DIFF
--- a/src/ui-config/TokenList.ts
+++ b/src/ui-config/TokenList.ts
@@ -13020,6 +13020,14 @@ export const TOKEN_LIST: TokenList = {
       logoURI: 'https://assets.coingecko.com/coins/images/34849/standard/staked-gho.png?1736975912',
     },
     {
+      name: 'Savings GHO',
+      address: '0xe1753f2e00940cc31213dd92013cf019dfe4ca1d',
+      symbol: 'sGHO',
+      decimals: 18,
+      chainId: 1,
+      logoURI: '/icons/tokens/sgho.svg',
+    },
+    {
       name: 'USDS Stablecoin',
       address: '0xdc035d45d973e3ec169d2276ddab16f1e407384f',
       symbol: 'USDS',


### PR DESCRIPTION
## Summary
- Adds `Savings GHO` (sGHO) at `0xe1753f2e00940cc31213dd92013cf019dfe4ca1d` on mainnet to the swap widget's token list so the modal asset picker can surface it.

## Test plan
- Open the Swap modal while holding sGHO; confirm it appears in source and destination pickers.
- Without a balance, paste the sGHO address into the picker search and confirm the custom-token import resolves it.