### PR TITLE
fix: make ENS resolution ENSv2-ready

### DIFF
--- a/src/components/WalletConnection/ReadOnlyModal.tsx
+++ b/src/components/WalletConnection/ReadOnlyModal.tsx
@@ -38,13 +38,9 @@ export const ReadOnlyModal = () => {
       saveAndClose(inputMockWalletAddress);
     } else {
       // Check if address could be valid ENS before trying to resolve
-      if (inputMockWalletAddress.slice(-4) === '.eth') {
-        const resolvedAddress = await resolveEnsAddress(inputMockWalletAddress);
-        if (resolvedAddress && isAddress(resolvedAddress)) {
-          saveAndClose(resolvedAddress);
-        } else {
-          setValidAddressError(true);
-        }
+      const resolvedAddress = await resolveEnsAddress(inputMockWalletAddress);
+      if (resolvedAddress && isAddress(resolvedAddress)) {
+        saveAndClose(resolvedAddress);
       } else {
         setValidAddressError(true);
       }
@@ -118,9 +114,6 @@ export const ReadOnlyModal = () => {
             size="large"
             fullWidth
             onClick={() => trackEvent(AUTH.MOCK_WALLET)}
-            disabled={
-              !isAddress(inputMockWalletAddress) && inputMockWalletAddress.slice(-4) !== '.eth'
-            }
             aria-label="read-only mode address"
           >
             <Trans>Track wallet</Trans>

--- a/src/components/WalletConnection/ReadOnlyModal.tsx
+++ b/src/components/WalletConnection/ReadOnlyModal.tsx
@@ -8,15 +8,14 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import { utils } from 'ethers';
 import { useState } from 'react';
 import { ReadOnlyModeTooltip } from 'src/components/infoTooltips/ReadOnlyModeTooltip';
 import { ModalType, useModalContext } from 'src/hooks/useModal';
 import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { useRootStore } from 'src/store/root';
+import { resolveEnsAddress } from 'src/utils/ensClient';
 import { AUTH } from 'src/utils/events';
-import { getENSProvider } from 'src/utils/marketsAndNetworksConfig';
-import { normalize } from 'viem/ens';
+import { isAddress } from 'viem';
 import { useAccount, useDisconnect } from 'wagmi';
 
 import { BasicModal } from '../primitives/BasicModal';
@@ -31,20 +30,17 @@ export const ReadOnlyModal = () => {
   const { type, close } = useModalContext();
   const { breakpoints } = useTheme();
   const sm = useMediaQuery(breakpoints.down('sm'));
-  const mainnetProvider = getENSProvider();
   const trackEvent = useRootStore((store) => store.trackEvent);
 
   const handleReadAddress = async (inputMockWalletAddress: string): Promise<void> => {
     if (validAddressError) setValidAddressError(false);
-    if (utils.isAddress(inputMockWalletAddress)) {
+    if (isAddress(inputMockWalletAddress)) {
       saveAndClose(inputMockWalletAddress);
     } else {
       // Check if address could be valid ENS before trying to resolve
       if (inputMockWalletAddress.slice(-4) === '.eth') {
-        const normalizedENS = normalize(inputMockWalletAddress);
-        // Attempt to resolve ENS name and use resolved address if valid
-        const resolvedAddress = await mainnetProvider.resolveName(normalizedENS);
-        if (resolvedAddress && utils.isAddress(resolvedAddress)) {
+        const resolvedAddress = await resolveEnsAddress(inputMockWalletAddress);
+        if (resolvedAddress && isAddress(resolvedAddress)) {
           saveAndClose(resolvedAddress);
         } else {
           setValidAddressError(true);
@@ -123,8 +119,7 @@ export const ReadOnlyModal = () => {
             fullWidth
             onClick={() => trackEvent(AUTH.MOCK_WALLET)}
             disabled={
-              !utils.isAddress(inputMockWalletAddress) &&
-              inputMockWalletAddress.slice(-4) !== '.eth'
+              !isAddress(inputMockWalletAddress) && inputMockWalletAddress.slice(-4) !== '.eth'
             }
             aria-label="read-only mode address"
           >

--- a/src/components/transactions/Bridge/BridgeDestinationInput.tsx
+++ b/src/components/transactions/Bridge/BridgeDestinationInput.tsx
@@ -7,10 +7,10 @@ import {
   Switch,
   Typography,
 } from '@mui/material';
-import { isAddress } from 'ethers/lib/utils';
 import { useEffect, useState } from 'react';
 import { useIsContractAddress } from 'src/hooks/useIsContractAddress';
-import { getENSProvider } from 'src/utils/marketsAndNetworksConfig';
+import { resolveEnsAddress } from 'src/utils/ensClient';
+import { isAddress } from 'viem';
 
 export const BridgeDestinationInput = ({
   connectedAccount,
@@ -49,7 +49,7 @@ export const BridgeDestinationInput = ({
   useEffect(() => {
     const checkENS = async () => {
       setValidatingENS(true);
-      const resolvedAddress = await getENSProvider().resolveName(destinationAccount);
+      const resolvedAddress = await resolveEnsAddress(destinationAccount);
       if (resolvedAddress) {
         setDestinationAccount(resolvedAddress.toLowerCase());
       }

--- a/src/components/transactions/Bridge/BridgeDestinationInput.tsx
+++ b/src/components/transactions/Bridge/BridgeDestinationInput.tsx
@@ -56,7 +56,7 @@ export const BridgeDestinationInput = ({
       setValidatingENS(false);
     };
 
-    if (destinationAccount.slice(-4) === '.eth') {
+    if (!isAddress(destinationAccount)) {
       checkENS();
     }
   }, [destinationAccount]);

--- a/src/libs/hooks/use-get-ens.tsx
+++ b/src/libs/hooks/use-get-ens.tsx
@@ -1,9 +1,7 @@
 import { blo } from 'blo';
-import { utils } from 'ethers';
 import { useEffect, useState } from 'react';
-import { getENSProvider } from 'src/utils/marketsAndNetworksConfig';
-
-const mainnetProvider = getENSProvider();
+import { lookupEnsName } from 'src/utils/ensClient';
+import { keccak256, toBytes } from 'viem';
 
 interface EnsResponse {
   name?: string;
@@ -13,10 +11,11 @@ interface EnsResponse {
 const useGetEns = (address: string): EnsResponse => {
   const [ensName, setEnsName] = useState<string | undefined>(undefined);
   const [ensAvatar, setEnsAvatar] = useState<string | undefined>(undefined);
+
   const getName = async (address: string) => {
     try {
-      const name = await mainnetProvider.lookupAddress(address);
-      setEnsName(name ? name : undefined);
+      const name = await lookupEnsName(address);
+      setEnsName(name ?? undefined);
     } catch (error) {
       console.error('ENS name lookup error', error);
     }
@@ -24,14 +23,14 @@ const useGetEns = (address: string): EnsResponse => {
 
   const getAvatar = async (name: string) => {
     try {
-      const labelHash = utils.keccak256(utils.toUtf8Bytes(name?.replace('.eth', '')));
+      const labelHash = keccak256(toBytes(name.replace('.eth', '')));
       const result: { background_image: string } = await (
         await fetch(
           `https://metadata.ens.domains/mainnet/0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85/${labelHash}/`
         )
       ).json();
       setEnsAvatar(
-        result && result.background_image ? result.background_image : blo(address as `0x${string}`)
+        result?.background_image ? result.background_image : blo(address as `0x${string}`)
       );
     } catch (error) {
       console.error('ENS avatar lookup error', error);

--- a/src/libs/hooks/use-get-ens.tsx
+++ b/src/libs/hooks/use-get-ens.tsx
@@ -2,6 +2,7 @@ import { blo } from 'blo';
 import { useEffect, useState } from 'react';
 import { lookupEnsName } from 'src/utils/ensClient';
 import { keccak256, toBytes } from 'viem';
+import { normalize } from 'viem/ens';
 
 interface EnsResponse {
   name?: string;
@@ -23,7 +24,7 @@ const useGetEns = (address: string): EnsResponse => {
 
   const getAvatar = async (name: string) => {
     try {
-      const labelHash = keccak256(toBytes(name.replace('.eth', '')));
+      const labelHash = keccak256(toBytes(normalize(name).replace('.eth', '')));
       const result: { background_image: string } = await (
         await fetch(
           `https://metadata.ens.domains/mainnet/0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85/${labelHash}/`

--- a/src/store/utils/domain-fetchers/ens.ts
+++ b/src/store/utils/domain-fetchers/ens.ts
@@ -1,18 +1,6 @@
 import { DomainType, WalletDomain } from 'src/store/walletDomains';
-import { getENSProvider } from 'src/utils/marketsAndNetworksConfig';
+import { lookupEnsName } from 'src/utils/ensClient';
 import { tFetch } from 'src/utils/tFetch';
-
-const mainnetProvider = getENSProvider();
-
-const getEnsName = async (address: string): Promise<string | null> => {
-  try {
-    const name = await mainnetProvider.lookupAddress(address);
-    return name;
-  } catch (error) {
-    console.error('ENS name lookup error', error);
-  }
-  return null;
-};
 
 const getEnsAvatar = async (name: string): Promise<string | undefined> => {
   try {
@@ -25,7 +13,7 @@ const getEnsAvatar = async (name: string): Promise<string | undefined> => {
 };
 
 export const getEnsDomain = async (address: string): Promise<WalletDomain | null> => {
-  const name = await getEnsName(address);
+  const name = await lookupEnsName(address);
   if (!name) return null;
   const avatar = await getEnsAvatar(name);
   return { name, avatar, type: DomainType.ENS };

--- a/src/utils/ensClient.ts
+++ b/src/utils/ensClient.ts
@@ -1,0 +1,42 @@
+import { type Address, type Chain, type PublicClient, createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+import { normalize } from 'viem/ens';
+
+import { getNetworkConfig } from './marketsAndNetworksConfig';
+
+let ensPublicClient: PublicClient | undefined;
+
+const getEnsPublicClient = (): PublicClient => {
+  if (!ensPublicClient) {
+    const { publicJsonRPCUrl } = getNetworkConfig(mainnet.id);
+    ensPublicClient = createPublicClient({
+      transport: http(publicJsonRPCUrl[0]),
+      chain: mainnet as Chain,
+    });
+  }
+  return ensPublicClient;
+};
+
+export const lookupEnsName = async (address: string): Promise<string | null> => {
+  try {
+    const name = await getEnsPublicClient().getEnsName({
+      address: address as Address,
+    });
+    return name ?? null;
+  } catch (error) {
+    console.error('ENS name lookup error', error);
+    return null;
+  }
+};
+
+export const resolveEnsAddress = async (name: string): Promise<Address | null> => {
+  try {
+    const address = await getEnsPublicClient().getEnsAddress({
+      name: normalize(name),
+    });
+    return address ?? null;
+  } catch (error) {
+    console.error('ENS address lookup error', error);
+    return null;
+  }
+};

--- a/src/utils/ensClient.ts
+++ b/src/utils/ensClient.ts
@@ -1,4 +1,11 @@
-import { type Address, type Chain, type PublicClient, createPublicClient, http } from 'viem';
+import {
+  type Address,
+  type Chain,
+  type PublicClient,
+  createPublicClient,
+  http,
+  isAddress,
+} from 'viem';
 import { mainnet } from 'viem/chains';
 import { normalize } from 'viem/ens';
 
@@ -18,9 +25,11 @@ const getEnsPublicClient = (): PublicClient => {
 };
 
 export const lookupEnsName = async (address: string): Promise<string | null> => {
+  if (!isAddress(address)) return null;
+
   try {
     const name = await getEnsPublicClient().getEnsName({
-      address: address as Address,
+      address,
     });
     return name ?? null;
   } catch (error) {
@@ -30,9 +39,16 @@ export const lookupEnsName = async (address: string): Promise<string | null> => 
 };
 
 export const resolveEnsAddress = async (name: string): Promise<Address | null> => {
+  let normalizedName: string;
+  try {
+    normalizedName = normalize(name);
+  } catch {
+    return null;
+  }
+
   try {
     const address = await getEnsPublicClient().getEnsAddress({
-      name: normalize(name),
+      name: normalizedName,
     });
     return address ?? null;
   } catch (error) {

--- a/src/utils/marketsAndNetworksConfig.ts
+++ b/src/utils/marketsAndNetworksConfig.ts
@@ -188,12 +188,6 @@ export const getProvider = (chainId: ChainId): ProviderWithSend => {
   return providers[chainId];
 };
 
-export const getENSProvider = () => {
-  const chainId = 1;
-  const config = getNetworkConfig(chainId);
-  return new StaticJsonRpcProvider(config.publicJsonRPCUrl[0], chainId);
-};
-
 const ammDisableProposal = 'https://governance-v2.aave.com/governance/proposal/44';
 const ustDisableProposal = 'https://governance-v2.aave.com/governance/proposal/75';
 const kncDisableProposal = 'https://governance-v2.aave.com/governance/proposal/69';


### PR DESCRIPTION
## General Changes

- Replaces the app's Ethers v5 ENS resolution paths with viem-based ENS lookups so V3 uses Universal Resolver-compatible resolution.
- Adds a shared `ensClient` utility for mainnet ENS forward and reverse resolution, using the configured mainnet RPC URL and viem's mainnet Universal Resolver address.
- Updates read-only wallet mode, bridge destination ENS input, profile ENS display, and wallet domain fetching to use the shared viem ENS helpers.
- Removes the Ethers-backed `getENSProvider` helper now that ENS lookups no longer depend on `StaticJsonRpcProvider.resolveName` / `lookupAddress`.
- Remove check what an ENS ends with '.eth' to add support for offchain DNS resolution (CCIP-Read).

## Developer Notes

- Context: ENS Labs flagged that Aave V3 still resolved ENS names through Ethers v5, which does not use the Universal Resolver and is not ENSv2-ready.
- Routing ENS reads through viem moves these flows onto the Universal Resolver path. That is the path needed for ENSIP-10 wildcard resolution and EIP-3668 CCIP-Read records, including ENSv2 names rolling out now.
- No new package is introduced. The implementation uses the existing direct `viem` dependency.
- ENS normalization is centralized in `resolveEnsAddress`, so invalid `.eth` input is handled as a failed resolution instead of throwing from UI handlers/effects.

## Validation

- `ur.integration-tests.eth` resolves to `0x2222222222222222222222222222222222222222` through a viem Universal Resolver smoke test.
- Legacy resolution returns `0x1111111111111111111111111111111111111111` for the same sentinel, so `0x2222222222222222222222222222222222222222` confirms the Universal Resolver path is being used.
- The lint command completes successfully, with existing repository warnings unrelated to this PR.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x]  Code changes do not significantly increase the application bundle size
- [x]  If there are new 3rd-party packages, they do not introduce potential security threats
- [x]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
