### PR TITLE
fix: show 0 for available liquidity if borrowing not enabled

### DIFF
--- a/src/modules/reserve-overview/ReserveTopDetails.tsx
+++ b/src/modules/reserve-overview/ReserveTopDetails.tsx
@@ -56,7 +56,11 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
 
       <TopInfoPanelItem title={<Trans>Available liquidity</Trans>} loading={loading} hideIcon>
         <FormattedNumber
-          value={Math.max(Number(poolReserve?.availableLiquidityUSD), 0)}
+          value={
+            poolReserve?.borrowingEnabled
+              ? Math.max(Number(poolReserve?.availableLiquidityUSD), 0)
+              : 0
+          }
           symbol="USD"
           variant={valueTypographyVariant}
           symbolsVariant={symbolsTypographyVariant}


### PR DESCRIPTION
## General Changes

- Shows '0' for the Available Liquidity item on reserve overview header is borrowing is not enabled on the reserve

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
