### PR TITLE
fix(swap): route Paraswap collateral swaps through the adapter

### DIFF
--- a/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActions.tsx
+++ b/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActions.tsx
@@ -3,7 +3,6 @@ import { Dispatch } from 'react';
 import { TrackAnalyticsHandlers } from '../../analytics/useTrackAnalytics';
 import { ProtocolSwapParams, ProtocolSwapState, SwapProvider, SwapState } from '../../types';
 import { SwapActionsViaCoW } from '../SwapActions/SwapActionsViaCoW';
-import { SwapActionsViaParaswap } from '../SwapActions/SwapActionsViaParaswap';
 import { CollateralSwapActionsViaCowAdapters } from './CollateralSwapActionsViaCoWAdapters';
 import { CollateralSwapActionsViaParaswapAdapters } from './CollateralSwapActionsViaParaswapAdapters';
 
@@ -41,25 +40,16 @@ export const CollateralSwapActions = ({
         );
       }
     case SwapProvider.PARASWAP:
-      if (state.useFlashloan) {
-        return (
-          <CollateralSwapActionsViaParaswapAdapters
-            params={params}
-            state={state}
-            setState={setState}
-            trackingHandlers={trackingHandlers}
-          />
-        );
-      } else {
-        // Essentially traditional aTokens swap
-        return (
-          <SwapActionsViaParaswap
-            params={params}
-            state={state}
-            setState={setState}
-            trackingHandlers={trackingHandlers}
-          />
-        );
-      }
+      // Paraswap can't swap aTokens directly, so always use the adapter. It runs swapAndDeposit
+      // (no flashloan) or a flashloan based on state.useFlashloan, which useFlowSelector sets from
+      // the health-factor impact.
+      return (
+        <CollateralSwapActionsViaParaswapAdapters
+          params={params}
+          state={state}
+          setState={setState}
+          trackingHandlers={trackingHandlers}
+        />
+      );
   }
 };

--- a/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActionsViaParaswapAdapters.tsx
+++ b/src/components/transactions/Swap/actions/CollateralSwap/CollateralSwapActionsViaParaswapAdapters.tsx
@@ -139,7 +139,7 @@ export const CollateralSwapActionsViaParaswapAdapters = ({
         symbol: state.sourceToken.symbol,
         blocked: areActionsBlocked(state),
         isMaxSelected: isMaxSelected,
-        useFlashLoan: true,
+        useFlashLoan: state.useFlashloan ?? false,
         swapCallData: swapCallData,
         augustus: augustus,
         signature: signatureParams?.splitedSignature,

--- a/src/components/transactions/Swap/hooks/useSwapQuote.ts
+++ b/src/components/transactions/Swap/hooks/useSwapQuote.ts
@@ -48,12 +48,14 @@ const getTokenSelectionForQuote = (
   const destTokenObj = invertedQuoteRoute ? state.sourceToken : state.destinationToken;
 
   // Quote tokens must match what the order will post on, otherwise CoW's per-pair volume-fee policy and gas estimate apply to a different pair than the order and the cushion computed in useSwapOrderAmounts comes out short. Read provider from the active query arg, not state.provider, which lags during provider transitions.
+  // Paraswap collateral swaps go through the adapter (swapAndDeposit or flashloan), which operates on the underlying tokens, so quote the underlying. Quoting the aToken depends on Paraswap pricing it correctly, which it doesn't for every chain (e.g. Sonic aUSDC comes back as 18 decimals / $0).
   const usesAddressToSwap =
     state.useFlashloan === false &&
     (provider === SwapProvider.COW_PROTOCOL ||
       (provider === SwapProvider.PARASWAP &&
         state.swapType !== SwapType.WithdrawAndSwap &&
-        state.swapType !== SwapType.RepayWithCollateral));
+        state.swapType !== SwapType.RepayWithCollateral &&
+        state.swapType !== SwapType.CollateralSwap));
 
   const srcToken = usesAddressToSwap ? srcTokenObj.addressToSwap : srcTokenObj.underlyingAddress;
   const destToken = usesAddressToSwap ? destTokenObj.addressToSwap : destTokenObj.underlyingAddress;


### PR DESCRIPTION
## General Changes

- Fixes Paraswap collateral swaps failing on Sonic — `Source Decimals Mismatch` (swap out of USDC) and `Price impact too high` / `ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT` (swap into USDC).

## Developer Notes

**Root cause.** The Swaps refactor (#2739) changed non-flashloan collateral swaps to render the plain `SwapActionsViaParaswap` path, which swaps the **aTokens** directly through Paraswap. That depends on Paraswap pricing the aTokens correctly, which it doesn't on every chain. On Sonic, Paraswap has wrong metadata for aUSDC — it reports `srcDecimals/destDecimals: 18` (aUSDC is 6) and values it at `$0`:

```
aToken  aWS  -> aUSDC : destDecimals 18 (WRONG), destUSD $0.00  -> ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT (quote rejected)
aToken  aUSDC-> aWS   : srcDecimals  18 (WRONG), srcUSD  $0.00  -> buildTx -> Source Decimals Mismatch
underlying wS -> USDC : destDecimals  6 (right),  destUSD $0.46  -> OK
underlying USDC-> wS  : srcDecimals   6 (right),  srcUSD  $0.10  -> OK
```

So both directions break on Sonic, at different stages (quote vs build), and neither is fixable client-side — Paraswap mis-values the aToken server-side.

**Fix — restore the pre-refactor behavior.** Before #2739, Paraswap collateral swaps quoted and built on the **underlying** tokens and executed via the collateral-swap adapter with `flash` toggled by health factor (`pool.swapCollateral({ flash })`; `flash: false` = `swapAndDeposit`). This change restores that:

1. `useSwapQuote` — quote Paraswap collateral on the underlying tokens (exclude `CollateralSwap` from the Paraswap `usesAddressToSwap` branch), which Paraswap prices correctly.
2. `CollateralSwapActions` — Paraswap collateral always renders `CollateralSwapActionsViaParaswapAdapters` (the adapter operates on underlying), instead of the direct-aToken `SwapActionsViaParaswap`.
3. `CollateralSwapActionsViaParaswapAdapters` — `useFlashLoan: state.useFlashloan ?? false` (was hardcoded `true`), so a healthy HF runs `swapAndDeposit` (no flashloan) and a low HF flashloans — exactly the old behavior. `useFlowSelector` already computes `useFlashloan` from the HF impact.

**Scope / safety:**
- The non-flashloan path is preserved (it's `swapAndDeposit` via the adapter, not a flashloan), so no new flashloan fee for healthy positions.
- CoW collateral swaps are untouched (CoW prices/trades aTokens fine).
- `SwapActionsViaParaswap` is unchanged and still used for plain `Swap`.
- Earlier revisions of this PR (force-flashloan; then sourcing buildTx decimals from the route) were dropped — the first removed the cheaper non-flashloan path, the second only fixed one direction's build and couldn't fix the quote-stage rejection.