### PR TITLE
chore: add DebugCrashBoundary to capture funkit dashboard crash stack

### DIFF
--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -16,6 +16,7 @@ import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { ReactNode, useEffect, useState } from 'react';
 import { AddressBlocked } from 'src/components/AddressBlocked';
+import { DebugCrashBoundary } from 'src/components/DebugCrashBoundary';
 import { Meta } from 'src/components/Meta';
 import { TransactionEventHandler } from 'src/components/TransactionEventHandler';
 import { GasStationProvider } from 'src/components/transactions/GasStation/GasStationProvider';
@@ -161,56 +162,60 @@ export default function MyApp(props: MyAppProps) {
         imageUrl="https://app.aave.com/aave-com-opengraph.png"
       />
       <NoSsr>
-        <AaveProvider client={client}>
-          <LanguageProvider>
-            <WagmiProvider config={wagmiConfig}>
-              <QueryClientProvider client={queryClient}>
-                <ConnectKitProvider onDisconnect={cleanLocalStorage}>
-                  <Web3ContextProvider>
-                    <AppGlobalStyles>
-                      <ComplianceProvider>
-                        <AddressBlocked>
-                          <SwapOrdersTrackingProvider>
-                            <ModalContextProvider>
-                              <SharedDependenciesProvider>
-                                <AppDataProvider>
-                                  <GasStationProvider>
-                                    {getLayout(<Component {...pageProps} />)}
-                                    <SupplyModal />
-                                    <FunkitCheckout />
-                                    <WithdrawModal />
-                                    <BorrowModal />
-                                    <RepayModal />
-                                    <CollateralChangeModal />
-                                    <ClaimRewardsModal />
-                                    <EmodeModal />
-                                    <FaucetModal />
-                                    <TransactionEventHandler />
-                                    <StakingMigrateModal />
-                                    <BridgeModal />
-                                    <ReadOnlyModal />
+        <DebugCrashBoundary label="app">
+          <AaveProvider client={client}>
+            <LanguageProvider>
+              <WagmiProvider config={wagmiConfig}>
+                <QueryClientProvider client={queryClient}>
+                  <ConnectKitProvider onDisconnect={cleanLocalStorage}>
+                    <Web3ContextProvider>
+                      <AppGlobalStyles>
+                        <ComplianceProvider>
+                          <AddressBlocked>
+                            <SwapOrdersTrackingProvider>
+                              <ModalContextProvider>
+                                <SharedDependenciesProvider>
+                                  <AppDataProvider>
+                                    <GasStationProvider>
+                                      <DebugCrashBoundary label="page">
+                                        {getLayout(<Component {...pageProps} />)}
+                                        <SupplyModal />
+                                        <FunkitCheckout />
+                                        <WithdrawModal />
+                                        <BorrowModal />
+                                        <RepayModal />
+                                        <CollateralChangeModal />
+                                        <ClaimRewardsModal />
+                                        <EmodeModal />
+                                        <FaucetModal />
+                                        <TransactionEventHandler />
+                                        <StakingMigrateModal />
+                                        <BridgeModal />
+                                        <ReadOnlyModal />
 
-                                    {/* Swap Modals */}
-                                    <SwapModal />
-                                    <CollateralSwapModal />
-                                    <DebtSwapModal />
-                                    <CancelCowOrderModal />
-                                    <CowOrderToast />
-                                  </GasStationProvider>
-                                </AppDataProvider>
-                              </SharedDependenciesProvider>
-                            </ModalContextProvider>
-                          </SwapOrdersTrackingProvider>
-                        </AddressBlocked>
-                      </ComplianceProvider>
-                    </AppGlobalStyles>
-                  </Web3ContextProvider>
-                </ConnectKitProvider>
-                <ReactQueryDevtools initialIsOpen={false} />
-              </QueryClientProvider>
-            </WagmiProvider>
-          </LanguageProvider>
-        </AaveProvider>
+                                        {/* Swap Modals */}
+                                        <SwapModal />
+                                        <CollateralSwapModal />
+                                        <DebtSwapModal />
+                                        <CancelCowOrderModal />
+                                        <CowOrderToast />
+                                      </DebugCrashBoundary>
+                                    </GasStationProvider>
+                                  </AppDataProvider>
+                                </SharedDependenciesProvider>
+                              </ModalContextProvider>
+                            </SwapOrdersTrackingProvider>
+                          </AddressBlocked>
+                        </ComplianceProvider>
+                      </AppGlobalStyles>
+                    </Web3ContextProvider>
+                  </ConnectKitProvider>
+                  <ReactQueryDevtools initialIsOpen={false} />
+                </QueryClientProvider>
+              </WagmiProvider>
+            </LanguageProvider>
+          </AaveProvider>
+        </DebugCrashBoundary>
       </NoSsr>
     </CacheProvider>
   );

--- a/src/components/DebugCrashBoundary.tsx
+++ b/src/components/DebugCrashBoundary.tsx
@@ -1,0 +1,53 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+/**
+ * TEMPORARY diagnostic boundary (remove before merge). Catches any render-phase
+ * crash and surfaces the error + React componentStack — both to the console and
+ * visibly in the DOM so it's captured in the cypress failure screenshot. Used to
+ * pinpoint the exact component behind the CI "Application error" white-screen.
+ */
+export class DebugCrashBoundary extends Component<
+  { children: ReactNode; label?: string },
+  { error: Error | null; componentStack: string }
+> {
+  state = { error: null as Error | null, componentStack: '' };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error, componentStack: '' };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const label = this.props.label ?? 'app';
+    /* eslint-disable no-console */
+    console.error(`[DEBUG_CRASH:${label}] message=`, error?.message);
+    console.error(`[DEBUG_CRASH:${label}] stack=`, error?.stack);
+    console.error(`[DEBUG_CRASH:${label}] componentStack=`, info?.componentStack);
+    /* eslint-enable no-console */
+    this.setState({ componentStack: info?.componentStack ?? '' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__DEBUG_CRASH__ = {
+      label,
+      message: error?.message,
+      stack: error?.stack,
+      componentStack: info?.componentStack,
+    };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <pre
+          data-cy="DebugCrash"
+          style={{ whiteSpace: 'pre-wrap', padding: 16, fontSize: 11, color: '#b00' }}
+        >
+          {`DEBUG_CRASH[${this.props.label ?? 'app'}]: ${
+            this.state.error.message
+          }\n\nCOMPONENT STACK:${this.state.componentStack}\n\nERROR STACK:\n${
+            this.state.error.stack
+          }`}
+        </pre>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
TEMPORARY diagnostic (revert before merge). Wraps the app (label=app) and the page subtree (label=page) in error boundaries that log the React componentStack and render it into the DOM, so the crashing component shows in the cypress failure screenshot for the polygon smoke crash.

## General Changes

- Fixes XYZ bug
- Adds XYZ feature
- …

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
