### PR TITLE
fix: bump transitive ws off vulnerable 8.17.1 (dependency-review)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@types/react": "^18.3.30",
     "@types/react-dom": "^18.3.7",
     "bignumber.js": "^9.3.1",
-    "axios": "^1.18.0"
+    "axios": "^1.18.0",
+    "tronweb/ethers/ws": "^8.21.0"
   },
   "scripts": {
     "dev": "next dev",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15653,10 +15653,10 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.17.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+ws@8.17.1, ws@^8.11.0, ws@^8.19.0, ws@^8.21.0, ws@^8.5.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 ws@8.18.0:
   version "8.18.0"
@@ -15677,11 +15677,6 @@ ws@^7.3.1, ws@^7.5.1, ws@^7.5.10:
   version "7.5.11"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
   integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
-
-ws@^8.11.0, ws@^8.19.0, ws@^8.5.0:
-  version "8.21.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
-  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Problem
`dependency-review` fails on `ws@8.17.1` (pulled transitively: `@funkit/connect` → `@funkit/fun-relay` → `@relayprotocol/*` → `tronweb@6.3.0` → `ethers@6.13.5`, which pins `ws@8.17.1`). Two advisories apply, per the GitHub Advisory DB:

| Advisory | Severity | ws 8.x affected | First patched |
|---|---|---|---|
| GHSA-96hv-2xvq-fx4p | high | `< 8.21.0` | **8.21.0** |
| GHSA-58qx-3vcg-4xpx | medium | `< 8.20.1` | **8.20.1** |

`8.17.1` is the only net-new `ws@8.x` this branch line adds vs `main` (which already has 8.18.0/8.18.3/8.20.1/8.21.0).

## Fix
Scoped yarn resolution so `ethers`'s `ws` resolves to **`^8.21.0`** — patched for *both* advisories and already in the tree (clean dedupe, no net-new vulnerable version):

```json
"resolutions": { "tronweb/ethers/ws": "^8.21.0" }
```

- **Anchored at `tronweb`** (a direct dependency), not the transitive `ethers` — yarn-classic ignores a selective resolution anchored at a deeply-transitive package (`"ethers/ws"` had no effect).
- **Scoped, not global** — a global `"ws"` resolution would drag WalletConnect's `ws@7.x → 8.x`; this leaves `ws@7.5.11` (already patched for the 7.x range) untouched.

## Verification (post `yarn install`)
- no `ws` resolves to `8.17.1` (the only PR-net-new `ws@8.x`)
- `ethers`'s `ws` requirement now resolves to `8.21.0`
- `ws@7.5.11` (WalletConnect) unchanged

`ws` is Node-only; ethers/WalletConnect use native `WebSocket` in the browser — so runtime impact is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)