### PR TITLE
fix: race condition in theming

### DIFF
--- a/src/components/transactions/FunCheckout/FunkitCheckout.tsx
+++ b/src/components/transactions/FunCheckout/FunkitCheckout.tsx
@@ -44,8 +44,7 @@ function InnerCheckout() {
   const { setOpen: setConnectModalOpen } = useModal();
   const queryClient = useQueryClient();
   const muiTheme = useTheme();
-  const mode = muiTheme.palette.mode;
-  const { themeColorScheme, toggleTheme } = useActiveTheme();
+  const { toggleTheme } = useActiveTheme();
 
   const onSuccess = useCallback(() => {
     // Same refresh the native supply flow performs on tx success
@@ -83,15 +82,12 @@ function InnerCheckout() {
     }
   }, [address]);
 
-  // Keep the funkit modal's active theme in sync with the app's color mode.
-  // `toggleTheme`'s identity changes on every FunkitThemeProvider render and its
-  // body always sets state, so the `themeColorScheme !== mode` guard is what makes
-  // this effect converge instead of update-looping.
+  const colorMode = muiTheme.palette.mode;
+
   useEffect(() => {
-    if (themeColorScheme !== mode) {
-      toggleTheme(mode);
-    }
-  }, [mode, themeColorScheme, toggleTheme]);
+    const persisted = (localStorage?.getItem('colorMode') as 'light' | 'dark') || colorMode;
+    toggleTheme(persisted);
+  }, [colorMode, toggleTheme]);
 
   const beginSupply = async (reserve: FunSupplyReserve) => {
     // funkit checkout needs a connected wallet (read-only/watch mode has none);


### PR DESCRIPTION
## General Changes

Fixes a race condition where the FunKit modal renders in light mode after a page refresh when dark mode is active.

**Root cause:** `FunkitThemeProvider`'s mount effect sets `activeTheme` based on the OS system preference via `systemColorScheme`, which fires *after* (and clobbers) our `toggleTheme` call from `InnerCheckout`. Meanwhile, `muiTheme.palette.mode` initially reflects the system preference too — the persisted localStorage value is only restored in a deferred `useEffect` in `AppGlobalStyles`. When both `themeColorScheme` and `mode` temporarily agree on the wrong value (`'light'`), the `themeColorScheme !== mode` guard short-circuits, skipping the corrective `toggleTheme` call. The result: `themeColorScheme` eventually reads `'dark'` but `activeTheme` stays on the light theme object.

**Fix:** Match the pattern used by Polymarket's integration:
- Read `localStorage('colorMode')` directly as the source of truth (bypasses MUI's deferred restoration)
- Fall back to `muiTheme.palette.mode` when no persisted value exists
- Call `toggleTheme` unconditionally (no `themeColorScheme !== mode` guard that can short-circuit)

This ensures the first `toggleTheme` call always carries the correct persisted mode, regardless of the timing between `FunkitThemeProvider`'s system-preference initialization and MUI's localStorage restoration.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)