### PR TITLE
fix: darken funkit modal overlay backdrop

### DIFF
--- a/src/ui-config/funkit/aaveTheme.ts
+++ b/src/ui-config/funkit/aaveTheme.ts
@@ -80,6 +80,7 @@ const darkThemeObject = darkTheme({
   customFontFamily,
   customColors: {
     ...darkThemeColors,
+    modalBackdrop: 'rgba(0, 0, 0, 0.5)',
     modalBackgroundCheckoutComplete: aaveCheckoutCompleteGradient,
     modalHeaderDivider: darkThemeColors.mediumStroke,
     modalFooterDivider: darkThemeColors.mediumStroke,
@@ -149,6 +150,7 @@ const lightThemeObject = lightTheme({
   customFontFamily,
   customColors: {
     ...lightThemeColors,
+    modalBackdrop: 'rgba(0, 0, 0, 0.5)',
     modalBackgroundCheckoutComplete: aaveCheckoutCompleteGradient,
     modalHeaderDivider: lightThemeColors.mediumStroke,
     modalFooterDivider: lightThemeColors.mediumStroke,

--- a/src/ui-config/funkit/aaveTheme.ts
+++ b/src/ui-config/funkit/aaveTheme.ts
@@ -80,7 +80,7 @@ const darkThemeObject = darkTheme({
   customFontFamily,
   customColors: {
     ...darkThemeColors,
-    modalBackdrop: 'rgba(0, 0, 0, 0.5)',
+    modalBackdrop: 'rgba(0, 0, 0, 0.6)',
     modalBackgroundCheckoutComplete: aaveCheckoutCompleteGradient,
     modalHeaderDivider: darkThemeColors.mediumStroke,
     modalFooterDivider: darkThemeColors.mediumStroke,
@@ -150,7 +150,7 @@ const lightThemeObject = lightTheme({
   customFontFamily,
   customColors: {
     ...lightThemeColors,
-    modalBackdrop: 'rgba(0, 0, 0, 0.5)',
+    modalBackdrop: 'rgba(0, 0, 0, 0.6)',
     modalBackgroundCheckoutComplete: aaveCheckoutCompleteGradient,
     modalHeaderDivider: lightThemeColors.mediumStroke,
     modalFooterDivider: lightThemeColors.mediumStroke,


### PR DESCRIPTION
## Summary
- Override `modalBackdrop` in both dark and light Aave themes from the SDK default `rgba(0, 0, 0, 0.2)` to `rgba(0, 0, 0, 0.6)`
- The 20% opacity scrim was too light — users couldn't tell a modal was open and expected clicking the background to dismiss it

## Test plan
- [x] Open the funkit supply modal in dark mode — verify the backdrop is visibly darker
- [x] Open the funkit supply modal in light mode — same check
- [x] Confirm clicking outside the modal still behaves as expected

## Pics

Light mode
<img width="1728" height="800" alt="image" src="https://github.com/user-attachments/assets/de41958e-e202-4e12-87db-ca01d222abed" />



Dark Mode
<img width="1700" height="761" alt="image" src="https://github.com/user-attachments/assets/1bc9f5b5-22b6-4673-934f-d7949f79f952" />


