### PR TITLE
fix: refresh wallet balances after supply confirmation

### DIFF
--- a/src/components/transactions/Supply/SupplyActions.tsx
+++ b/src/components/transactions/Supply/SupplyActions.tsx
@@ -19,11 +19,11 @@ import { useWeb3Context } from 'src/libs/hooks/useWeb3Context';
 import { useRootStore } from 'src/store/root';
 import { ApprovalMethod } from 'src/store/walletSlice';
 import { getErrorTextFromError, TxAction } from 'src/ui-config/errorMapping';
-import { queryKeysFactory } from 'src/ui-config/queries';
 import { useShallow } from 'zustand/shallow';
 
 import { TxActionsWrapper } from '../TxActionsWrapper';
 import { APPROVAL_GAS_LIMIT, checkRequiresApproval } from '../utils';
+import { refetchSupplyPoolData } from './utils';
 
 // Minimal ABI for Pool multicall + setUserEMode + supply
 const POOL_MULTICALL_ABI = [
@@ -71,6 +71,7 @@ export const SupplyActions = React.memo(
       estimateGasLimit,
       addTransaction,
       currentMarketData,
+      account,
     ] = useRootStore(
       useShallow((state) => [
         state.tryPermit,
@@ -81,6 +82,7 @@ export const SupplyActions = React.memo(
         state.estimateGasLimit,
         state.addTransaction,
         state.currentMarketData,
+        state.account,
       ])
     );
     const { reserves } = useAppDataContext();
@@ -263,12 +265,6 @@ export const SupplyActions = React.memo(
           await response.wait(1);
         }
 
-        setMainTxState({
-          txHash: response.hash,
-          loading: false,
-          success: true,
-        });
-
         addTransaction(response.hash, {
           action,
           txState: 'success',
@@ -283,7 +279,13 @@ export const SupplyActions = React.memo(
           })(),
         });
 
-        queryClient.invalidateQueries({ queryKey: queryKeysFactory.pool });
+        await refetchSupplyPoolData(queryClient, account, currentMarketData);
+
+        setMainTxState({
+          txHash: response.hash,
+          loading: false,
+          success: true,
+        });
       } catch (error) {
         const parsedError = getErrorTextFromError(error, TxAction.GAS_ESTIMATION, false);
         setTxError(parsedError);

--- a/src/components/transactions/Supply/SupplyWrappedTokenActions.tsx
+++ b/src/components/transactions/Supply/SupplyWrappedTokenActions.tsx
@@ -20,6 +20,7 @@ import { useShallow } from 'zustand/shallow';
 
 import { TxActionsWrapper } from '../TxActionsWrapper';
 import { APPROVAL_GAS_LIMIT, checkRequiresApproval } from '../utils';
+import { refetchSupplyPoolData } from './utils';
 
 interface SignedParams {
   signature: SignatureLike;
@@ -166,12 +167,6 @@ export const SupplyWrappedTokenActions = ({
         await response.wait(1);
       }
 
-      setMainTxState({
-        txHash: response.hash,
-        loading: false,
-        success: true,
-      });
-
       addTransaction(response.hash, {
         action,
         txState: 'success',
@@ -181,7 +176,7 @@ export const SupplyWrappedTokenActions = ({
         amountUsd: valueToBigNumber(amountToSupply).multipliedBy(reserve.priceInUSD).toString(),
       });
 
-      queryClient.invalidateQueries({ queryKey: queryKeysFactory.pool });
+      await refetchSupplyPoolData(queryClient, user, marketData);
       queryClient.invalidateQueries({
         queryKey: queryKeysFactory.approvedAmount(
           user,
@@ -189,6 +184,12 @@ export const SupplyWrappedTokenActions = ({
           tokenWrapperAddress,
           marketData.chainId
         ),
+      });
+
+      setMainTxState({
+        txHash: response.hash,
+        loading: false,
+        success: true,
       });
     } catch (error) {
       const parsedError = getErrorTextFromError(error, TxAction.GAS_ESTIMATION, false);

--- a/src/components/transactions/Supply/utils.ts
+++ b/src/components/transactions/Supply/utils.ts
@@ -1,0 +1,18 @@
+import type { QueryClient } from '@tanstack/react-query';
+import type { MarketDataType } from 'src/ui-config/marketsConfig';
+import { queryKeysFactory } from 'src/ui-config/queries';
+
+export const refetchSupplyPoolData = async (
+  queryClient: QueryClient,
+  account: string,
+  marketData: MarketDataType
+) => {
+  await queryClient.invalidateQueries({ queryKey: queryKeysFactory.pool });
+
+  if (account) {
+    await queryClient.refetchQueries({
+      queryKey: queryKeysFactory.poolTokens(account, marketData),
+      type: 'active',
+    });
+  }
+};


### PR DESCRIPTION
## General Changes

- Fixes #2792
- Refreshes wallet balances after a successful supply transaction confirmation
- Explicitly refetches the active `poolTokens(account, market)` query used by `useWalletBalances`
- Applies the same balance refresh behavior to wrapped-token supply flows

## Developer Notes

The supply flow was only invalidating pool data after confirmation, which could leave the wallet balance shown inside the modal stale until the modal was closed and reopened.

This adds a shared `refetchSupplyPoolData` helper that invalidates pool data and explicitly refetches the active wallet balance query before marking the supply transaction as successful.

Validation run locally:

- `node_modules\.bin\eslint.cmd src/components/transactions/Supply/SupplyActions.tsx src/components/transactions/Supply/SupplyWrappedTokenActions.tsx src/components/transactions/Supply/utils.ts`
- `node_modules\.bin\tsc.cmd --noEmit --pretty false`

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)