### PR TITLE
Fix/2858/paraswap rate limit backoff

### DIFF
--- a/src/components/transactions/ClaimRewards/ClaimRewardsActions.tsx
+++ b/src/components/transactions/ClaimRewards/ClaimRewardsActions.tsx
@@ -5,7 +5,7 @@ import {
 } from '@aave/contract-helpers';
 import { chainId, evmAddress, useUserMeritRewards } from '@aave/react';
 import { Trans } from '@lingui/macro';
-import { BigNumber, PopulatedTransaction, utils } from 'ethers';
+import { BigNumber, PopulatedTransaction } from 'ethers';
 import { Reward } from 'src/helpers/types';
 import { useTransactionHandler } from 'src/helpers/useTransactionHandler';
 import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
@@ -70,9 +70,8 @@ export const ClaimRewardsActions = ({
         });
       }
 
-      // Use complex multicall logic only when needed
+      // Claim protocol and Merit rewards separately so each claim is sent by the wallet account.
       if (isClaimingAll && hasProtocolRewards && hasMeritRewards) {
-        // Get protocol rewards transaction
         const protocolTxns = await claimRewards({
           isWrongNetwork,
           blocked,
@@ -84,15 +83,13 @@ export const ClaimRewardsActions = ({
         if (!meritClaimRewards?.transaction) {
           throw new Error('Merit rewards transaction not available');
         }
-        const multicallTx = await createMulticallTransaction(
-          protocolTxns,
-          meritClaimRewards.transaction as unknown as PopulatedTransaction
-        );
 
-        // Check if there are approval transactions that need to be handled separately
-        const approvalTxns = protocolTxns.filter((tx) => tx.txType === 'ERC20_APPROVAL');
-
-        return approvalTxns.length > 0 ? [...approvalTxns, multicallTx] : [multicallTx];
+        return [
+          ...protocolTxns,
+          convertMeritTransactionToEthereum(
+            meritClaimRewards.transaction as unknown as PopulatedTransaction
+          ),
+        ];
       } else if ((isClaimingAll && !hasProtocolRewards && hasMeritRewards) || isClaimingMeritAll) {
         // Only merit rewards - use merit transaction directly
         if (!meritClaimRewards?.transaction) {
@@ -119,89 +116,6 @@ export const ClaimRewardsActions = ({
     skip: Object.keys(selectedReward).length === 0 || blocked,
     deps: [selectedReward, meritClaimRewards],
   });
-
-  // Helper function to create multicall transaction
-  const createMulticallTransaction = async (
-    protocolTxns: EthereumTransactionTypeExtended[],
-    meritTransaction: PopulatedTransaction
-  ): Promise<EthereumTransactionTypeExtended> => {
-    // Multicall3 contract address (same across chains)
-    const multicallAddress = '0xcA11bde05977b3631167028862bE2a173976CA11';
-
-    const calls = [];
-
-    for (const txExt of protocolTxns) {
-      if (txExt.txType === 'ERC20_APPROVAL') continue; // Skip approvals for multicall
-
-      const tx = await txExt.tx();
-      calls.push({
-        target: tx.to,
-        callData: tx.data,
-        value: tx.value ? (BigNumber.isBigNumber(tx.value) ? tx.value.toString() : tx.value) : '0',
-      });
-    }
-
-    calls.push({
-      target: meritTransaction.to,
-      callData: meritTransaction.data,
-      value: meritTransaction.value
-        ? BigNumber.isBigNumber(meritTransaction.value)
-          ? meritTransaction.value.toString()
-          : meritTransaction.value
-        : '0',
-    });
-
-    const multicallInterface = new utils.Interface([
-      'function aggregate3Value((address target, bool allowFailure, uint256 value, bytes callData)[] calls) payable returns ((bool success, bytes returnData)[])',
-    ]);
-
-    const callsWithFailure = calls.map((call) => [
-      call.target,
-      false, // allowFailure = false
-      call.value,
-      call.callData,
-    ]);
-
-    const data = multicallInterface.encodeFunctionData('aggregate3Value', [callsWithFailure]);
-
-    // Calculate total value needed for multicall by summing individual call values
-    const totalValue = calls.reduce((sum, call) => {
-      return BigNumber.from(sum).add(BigNumber.from(call.value)).toString();
-    }, '0');
-
-    return {
-      txType: eEthereumTxType.DLP_ACTION,
-      tx: async () => ({
-        to: multicallAddress,
-        from: currentAccount,
-        data,
-        value: totalValue,
-      }),
-      gas: async () => {
-        try {
-          const tx = {
-            to: multicallAddress,
-            from: currentAccount,
-            data,
-            value: BigNumber.from(totalValue),
-          };
-
-          const estimatedTx = await estimateGasLimit(tx, currentMarketData.chainId);
-
-          return {
-            gasLimit: estimatedTx.gasLimit?.toString(),
-            gasPrice: '0', // Legacy field - actual gas pricing handled by wallet (EIP-1559)
-          };
-        } catch (error) {
-          console.warn('Gas estimation failed for multicall, using fallback:', error);
-          return {
-            gasLimit: '800000', // Conservative fallback
-            gasPrice: '0', // Legacy field - actual gas pricing handled by wallet (EIP-1559)
-          };
-        }
-      },
-    };
-  };
 
   // Helper function to convert merit transaction to Ethereum format
   const convertMeritTransactionToEthereum = (

--- a/src/helpers/useTransactionHandler.tsx
+++ b/src/helpers/useTransactionHandler.tsx
@@ -18,6 +18,17 @@ import { useShallow } from 'zustand/shallow';
 
 export const MOCK_SIGNED_HASH = 'Signed correctly';
 
+const MAIN_ACTION_TX_TYPES = [
+  'DLP_ACTION',
+  'REWARD_ACTION',
+  'FAUCET_V2_MINT',
+  'FAUCET_MINT',
+  'STAKE_ACTION',
+  'GOV_DELEGATION_ACTION',
+  'GOVERNANCE_ACTION',
+  'V3_MIGRATION_ACTION',
+];
+
 interface UseTransactionHandlerProps {
   handleGetTxns: () => Promise<EthereumTransactionTypeExtended[]>;
   handleGetPermitTxns?: (
@@ -84,7 +95,7 @@ export const useTransactionHandler = ({
   );
 
   const [approvalTxes, setApprovalTxes] = useState<EthereumTransactionTypeExtended[] | undefined>();
-  const [actionTx, setActionTx] = useState<EthereumTransactionTypeExtended | undefined>();
+  const [actionTxes, setActionTxes] = useState<EthereumTransactionTypeExtended[] | undefined>();
   const [usePermit, setUsePermit] = useState(false);
   const mounted = useRef(false);
 
@@ -313,31 +324,44 @@ export const useTransactionHandler = ({
         });
       }
     }
-    if ((!usePermit || !approvalTxes) && actionTx) {
+    if ((!usePermit || !approvalTxes) && actionTxes?.length) {
+      let errorHandled = false;
       try {
         setMainTxState({ ...mainTxState, loading: true });
-        const params = await actionTx.tx();
-        delete params.gasPrice;
-        return processTx({
-          tx: () => sendTx(params),
-          successCallback: (txnResponse: TransactionResponse) => {
-            setMainTxState({
-              txHash: txnResponse.hash,
-              loading: false,
-              success: true,
+
+        for (let index = 0; index < actionTxes.length; index++) {
+          const actionTx = actionTxes[index];
+          const params = await actionTx.tx();
+          const isLastAction = index === actionTxes.length - 1;
+          delete params.gasPrice;
+
+          await new Promise<void>((resolve, reject) => {
+            processTx({
+              tx: () => sendTx(params),
+              successCallback: (txnResponse: TransactionResponse) => {
+                setMainTxState({
+                  txHash: txnResponse.hash,
+                  loading: !isLastAction,
+                  success: isLastAction,
+                });
+                setTxError(undefined);
+                resolve();
+              },
+              errorCallback: (error, hash) => {
+                errorHandled = true;
+                const parsedError = getErrorTextFromError(error, TxAction.MAIN_ACTION);
+                setTxError(parsedError);
+                setMainTxState({
+                  txHash: hash,
+                  loading: false,
+                });
+                reject(error);
+              },
             });
-            setTxError(undefined);
-          },
-          errorCallback: (error, hash) => {
-            const parsedError = getErrorTextFromError(error, TxAction.MAIN_ACTION);
-            setTxError(parsedError);
-            setMainTxState({
-              txHash: hash,
-              loading: false,
-            });
-          },
-        });
+          });
+        }
       } catch (error) {
+        if (errorHandled) return;
         const parsedError = getErrorTextFromError(error, TxAction.GAS_ESTIMATION, false);
         console.error(error, parsedError);
         setTxError(parsedError);
@@ -388,20 +412,7 @@ export const useTransactionHandler = ({
               } else {
                 setApprovalTxes(undefined);
               }
-              setActionTx(
-                txs.find((tx) =>
-                  [
-                    'DLP_ACTION',
-                    'REWARD_ACTION',
-                    'FAUCET_V2_MINT',
-                    'FAUCET_MINT',
-                    'STAKE_ACTION',
-                    'GOV_DELEGATION_ACTION',
-                    'GOVERNANCE_ACTION',
-                    'V3_MIGRATION_ACTION',
-                  ].includes(tx.txType)
-                )
-              );
+              setActionTxes(txs.filter((tx) => MAIN_ACTION_TX_TYPES.includes(tx.txType)));
               setMainTxState({
                 txHash: undefined,
               });
@@ -437,7 +448,7 @@ export const useTransactionHandler = ({
       return () => clearTimeout(timeout);
     } else {
       setApprovalTxes(undefined);
-      setActionTx(undefined);
+      setActionTxes(undefined);
     }
   }, [skip, ...deps, tryPermit, walletApprovalMethodPreference]);
 

--- a/src/hooks/paraswap/common.ts
+++ b/src/hooks/paraswap/common.ts
@@ -123,6 +123,10 @@ const MESSAGE_REGEX_MAP: Array<{ regex: RegExp; message: string }> = [
     regex: /^Amount \d+ is too small to proceed$/,
     message: 'Amount is too small. Please try larger amount.',
   },
+  {
+    regex: /rate limit|rate limited|Request is being rate limited/i,
+    message: 'Request is being rate limited. Please try again in a few seconds.',
+  },
 ];
 
 /**
@@ -137,6 +141,31 @@ export function convertParaswapErrorMessage(message: string): string | undefined
 
   const newMessage = MESSAGE_REGEX_MAP.find((mapping) => mapping.regex.test(message))?.message;
   return newMessage;
+}
+// Retry helper with exponential backoff for transient Paraswap errors (rate limits, timeouts)
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  baseDelay = 500
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (e: any) {
+      attempt += 1;
+      const msg = String(e?.message || e);
+      const isRateLimit = /rate limit|rate limited|Request is being rate limited/i.test(msg);
+      if (!isRateLimit || attempt > retries) {
+        throw e;
+      }
+
+      const delay = baseDelay * Math.pow(2, attempt - 1);
+      // small sleep
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((res) => setTimeout(res, delay));
+    }
+  }
 }
 
 /**
@@ -164,6 +193,32 @@ export async function fetchExactInTxParams(
     swapIn.decimals,
     swapOut.underlyingAsset,
     swapOut.decimals,
+// Retry helper with exponential backoff for transient Paraswap errors (rate limits, timeouts)
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  baseDelay = 500
+): Promise<T> {
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await fn();
+    } catch (e: any) {
+      attempt += 1;
+      const msg = String(e?.message || e);
+      const isRateLimit = /rate limit|rate limited|Request is being rate limited/i.test(msg);
+      if (!isRateLimit || attempt > retries) {
+        throw e;
+      }
+
+      const delay = baseDelay * Math.pow(2, attempt - 1);
+      // small sleep
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((res) => setTimeout(res, delay));
+    }
+  }
+}
     userAddress,
     route,
     maxSlippage
@@ -320,16 +375,18 @@ export const ExactInSwapper = (chainId: ChainId) => {
     userAddress: string,
     options: RateOptions
   ) => {
-    const priceRoute = await paraswap.getRate({
-      amount,
-      srcToken,
-      srcDecimals,
-      destToken,
-      destDecimals,
-      userAddress,
-      side: SwapSide.SELL,
-      options,
-    });
+    const priceRoute = await retryWithBackoff(() =>
+      paraswap.getRate({
+        amount,
+        srcToken,
+        srcDecimals,
+        destToken,
+        destDecimals,
+        userAddress,
+        side: SwapSide.SELL,
+        options,
+      })
+    );
 
     return priceRoute;
   };
@@ -344,21 +401,23 @@ export const ExactInSwapper = (chainId: ChainId) => {
     maxSlippage: number
   ) => {
     try {
-      const params = await paraswap.buildTx(
-        {
-          srcToken,
-          srcDecimals,
-          srcAmount: route.srcAmount,
-          destToken,
-          destDecimals,
-          slippage: maxSlippage * 100,
-          priceRoute: route,
-          userAddress: user,
-          partnerAddress: feeTarget,
-          takeSurplus: true,
-          isDirectFeeTransfer: true,
-        },
-        { ignoreChecks: true }
+      const params = await retryWithBackoff(() =>
+        paraswap.buildTx(
+          {
+            srcToken,
+            srcDecimals,
+            srcAmount: route.srcAmount,
+            destToken,
+            destDecimals,
+            slippage: maxSlippage * 100,
+            priceRoute: route,
+            userAddress: user,
+            partnerAddress: feeTarget,
+            takeSurplus: true,
+            isDirectFeeTransfer: true,
+          },
+          { ignoreChecks: true }
+        )
       );
 
       return {
@@ -397,16 +456,18 @@ export const ExactOutSwapper = (chainId: ChainId) => {
     userAddress: string,
     options: RateOptions
   ) => {
-    const priceRoute = await paraswap.getRate({
-      amount,
-      srcToken,
-      srcDecimals,
-      destToken,
-      destDecimals,
-      userAddress,
-      side: SwapSide.BUY,
-      options,
-    });
+    const priceRoute = await retryWithBackoff(() =>
+      paraswap.getRate({
+        amount,
+        srcToken,
+        srcDecimals,
+        destToken,
+        destDecimals,
+        userAddress,
+        side: SwapSide.BUY,
+        options,
+      })
+    );
 
     return priceRoute;
   };
@@ -421,21 +482,23 @@ export const ExactOutSwapper = (chainId: ChainId) => {
     maxSlippage: number
   ) => {
     try {
-      const params = await paraswap.buildTx(
-        {
-          srcToken,
-          destToken,
-          destAmount: route.destAmount,
-          slippage: maxSlippage * 100,
-          priceRoute: route,
-          userAddress: user,
-          partnerAddress: feeTarget,
-          takeSurplus: true,
-          srcDecimals,
-          destDecimals,
-          isDirectFeeTransfer: true,
-        },
-        { ignoreChecks: true }
+      const params = await retryWithBackoff(() =>
+        paraswap.buildTx(
+          {
+            srcToken,
+            destToken,
+            destAmount: route.destAmount,
+            slippage: maxSlippage * 100,
+            priceRoute: route,
+            userAddress: user,
+            partnerAddress: feeTarget,
+            takeSurplus: true,
+            srcDecimals,
+            destDecimals,
+            isDirectFeeTransfer: true,
+          },
+          { ignoreChecks: true }
+        )
       );
 
       return {


### PR DESCRIPTION
## General Changes

- Fixes the Paraswap rate-limit issue reported in #2858.
- Adds exponential backoff retries for transient Paraswap `getRate` and `buildTx` failures.
- Shows a user-friendly message when Paraswap requests are rate limited.

## Developer Notes

The change is localized to `src/hooks/paraswap/common.ts`.
I also validated the changes with Jest CI tests.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [x] End-to-end tests are passing without any errors
- [x] Code changes do not significantly increase the application bundle size
- [x] If there are new 3rd-party packages, they do not introduce potential security threats
- [x] If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [x] There are no CI changes, or they have been approved by the DevOps and Engineering team(s)