### PR TITLE
fix: theming for modal subheader

### DIFF
--- a/src/ui-config/funkit/aaveTheme.ts
+++ b/src/ui-config/funkit/aaveTheme.ts
@@ -126,6 +126,7 @@ const darkThemeObject = darkTheme({
   customBorderRadiuses,
   customDimensions: {
     modalBottomBarButtonHeight: '40px',
+    modalTopBarHeight: '76px',
   },
   customSpacings: {
     cryptoCashToggleTabPaddingY: '12px',

--- a/src/ui-config/funkit/aaveTheme.ts
+++ b/src/ui-config/funkit/aaveTheme.ts
@@ -29,6 +29,7 @@ const customFontSizings: ThemeOptions['customFontSizings'] = {
   '40': { fontSize: '41px', lineHeight: '49px' },
   '57': { fontSize: '58px', lineHeight: '69px' },
   modalTopbarTitle: { fontSize: '21px', lineHeight: '24px' },
+  modalTopbarSubtitle: { fontSize: '12px', lineHeight: '19px' },
   modalBottomBarButtonText: { fontSize: '13px', lineHeight: '16px' },
 };
 
@@ -128,6 +129,7 @@ const darkThemeObject = darkTheme({
   },
   customSpacings: {
     cryptoCashToggleTabPaddingY: '12px',
+    modalTopBarVerticalTextSpacing: '6px',
   },
   overlayBlur: 'none',
 });
@@ -200,6 +202,7 @@ const lightThemeObject = lightTheme({
   },
   customSpacings: {
     cryptoCashToggleTabPaddingY: '12px',
+    modalTopBarVerticalTextSpacing: '6px',
   },
   overlayBlur: 'none',
 });


### PR DESCRIPTION
## General Changes

- Increases modal subheader size and spacing

old
<img width="620" height="652" alt="image" src="https://github.com/user-attachments/assets/9e263cfd-f66c-4416-8c11-d1663d5759c7" />
<img width="683" height="677" alt="image" src="https://github.com/user-attachments/assets/7bd02429-ce8a-40da-8b2f-ead8733d490b" />


new
<img width="610" height="590" alt="image" src="https://github.com/user-attachments/assets/1c7c6c34-adb9-44ae-853f-f7e09164a455" />

<img width="664" height="666" alt="image" src="https://github.com/user-attachments/assets/9102fbe3-ab53-4285-95fb-3e7380f2fa43" />

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
