### PR TITLE
feat: render proposal expired and partially executed states

### DIFF
--- a/src/modules/governance/StateBadge.tsx
+++ b/src/modules/governance/StateBadge.tsx
@@ -16,6 +16,7 @@ export enum ProposalBadgeState {
   Executed = 'Executed',
   Cancelled = 'Cancelled',
   Expired = 'Expired',
+  PartiallyExecuted = 'Partially executed',
 }
 
 type BadgeProps = {
@@ -52,6 +53,7 @@ const Badge = styled('span')<BadgeProps>(({ theme, state }) => {
     [ProposalBadgeState.Executed]: theme.palette.success.main,
     [ProposalBadgeState.Cancelled]: theme.palette.error.main,
     [ProposalBadgeState.Expired]: theme.palette.error.main,
+    [ProposalBadgeState.PartiallyExecuted]: theme.palette.warning.main,
     [ProposalBadgeState.Failed]: theme.palette.error.main,
   };
   const color = COLOR_MAP[state] || '#000';
@@ -91,6 +93,8 @@ export const stateToString = (stateToString: ProposalBadgeState) => {
       return 'Cancelled';
     case ProposalBadgeState.Expired:
       return 'Expired';
+    case ProposalBadgeState.PartiallyExecuted:
+      return 'Partially executed';
     case ProposalBadgeState.Failed:
       return 'Failed';
   }
@@ -110,6 +114,8 @@ export const stringToState = (state: string) => {
       return ProposalBadgeState.Cancelled;
     case 'Expired':
       return ProposalBadgeState.Expired;
+    case 'Partially executed':
+      return ProposalBadgeState.PartiallyExecuted;
     case 'Failed':
       return ProposalBadgeState.Failed;
   }

--- a/src/modules/governance/adapters.ts
+++ b/src/modules/governance/adapters.ts
@@ -35,6 +35,10 @@ export function cacheStateToBadge(state: string): ProposalBadgeState {
       return ProposalBadgeState.Failed;
     case 'cancelled':
       return ProposalBadgeState.Cancelled;
+    case 'expired':
+      return ProposalBadgeState.Expired;
+    case 'partially_executed':
+      return ProposalBadgeState.PartiallyExecuted;
     default:
       return ProposalBadgeState.Created;
   }

--- a/src/modules/governance/proposal/ProposalLifecycleCache.tsx
+++ b/src/modules/governance/proposal/ProposalLifecycleCache.tsx
@@ -282,8 +282,7 @@ export const ProposalLifecycleCache = ({
     state === 'partially_executed' ||
     state === 'expired'
   ) {
-    const isTerminal =
-      state === 'executed' || state === 'partially_executed' || state === 'expired';
+    const isTerminal = state === 'partially_executed' || state === 'expired';
     const finalStepName =
       state === 'expired'
         ? 'Expired'

--- a/src/modules/governance/proposal/ProposalLifecycleCache.tsx
+++ b/src/modules/governance/proposal/ProposalLifecycleCache.tsx
@@ -158,7 +158,16 @@ export const ProposalLifecycleCache = ({
   }
 
   const state = proposal.state;
-  const stateOrder = ['created', 'active', 'queued', 'executed', 'failed', 'cancelled'];
+  const stateOrder = [
+    'created',
+    'active',
+    'queued',
+    'executed',
+    'partially_executed',
+    'expired',
+    'failed',
+    'cancelled',
+  ];
   const currentStateIndex = stateOrder.indexOf(state);
 
   // Build payload creation substeps
@@ -205,9 +214,12 @@ export const ProposalLifecycleCache = ({
       });
     }
     payloadExecutionSubsteps.push({
-      stepName: `Payload ${p.payloadId} executed on ${getNetworkName(p.chainId)}`,
+      stepName:
+        p.state === 'expired'
+          ? `Payload ${p.payloadId} expired on ${getNetworkName(p.chainId)}`
+          : `Payload ${p.payloadId} executed on ${getNetworkName(p.chainId)}`,
       timestamp: p.executedAt,
-      completed: p.state === 'executed',
+      completed: p.state === 'executed' || p.state === 'expired',
       active: false,
       networkLogo: getNetworkLogo(p.chainId),
     });
@@ -264,12 +276,27 @@ export const ProposalLifecycleCache = ({
   // Add final state step
   const allPayloadsExecuted = !!payloads?.length && payloads.every((p) => p.state === 'executed');
 
-  if (state === 'queued' || state === 'executed') {
+  if (
+    state === 'queued' ||
+    state === 'executed' ||
+    state === 'partially_executed' ||
+    state === 'expired'
+  ) {
+    const isTerminal =
+      state === 'executed' || state === 'partially_executed' || state === 'expired';
+    const finalStepName =
+      state === 'expired'
+        ? 'Expired'
+        : state === 'partially_executed'
+        ? 'Partially executed'
+        : allPayloadsExecuted
+        ? 'Payloads executed'
+        : 'Payload execution';
     steps.push({
-      stepName: allPayloadsExecuted ? 'Payloads executed' : 'Payload execution',
+      stepName: finalStepName,
       timestamp: allPayloadsExecuted ? proposal.executedAt : proposal.queuedAt,
-      completed: allPayloadsExecuted,
-      active: !allPayloadsExecuted,
+      completed: isTerminal || allPayloadsExecuted,
+      active: !isTerminal && !allPayloadsExecuted,
       lastStep: true,
       substeps: payloadExecutionSubsteps,
     });

--- a/src/modules/governance/proposal/ProposalLifecycleCache.tsx
+++ b/src/modules/governance/proposal/ProposalLifecycleCache.tsx
@@ -275,6 +275,13 @@ export const ProposalLifecycleCache = ({
 
   // Add final state step
   const allPayloadsExecuted = !!payloads?.length && payloads.every((p) => p.state === 'executed');
+  // proposal.executedAt is the dispatch time; payloads finish later after their timelock, so the
+  // completed step should reflect the latest payload execution, matching the on-chain finish.
+  const payloadExecutedTimes = (payloads ?? [])
+    .map((p) => p.executedAt)
+    .filter((t): t is string => !!t)
+    .sort();
+  const lastPayloadExecutedAt = payloadExecutedTimes[payloadExecutedTimes.length - 1] ?? null;
 
   if (
     state === 'queued' ||
@@ -293,7 +300,9 @@ export const ProposalLifecycleCache = ({
         : 'Payload execution';
     steps.push({
       stepName: finalStepName,
-      timestamp: allPayloadsExecuted ? proposal.executedAt : proposal.queuedAt,
+      timestamp: allPayloadsExecuted
+        ? lastPayloadExecutedAt ?? proposal.executedAt
+        : proposal.queuedAt,
       completed: isTerminal || allPayloadsExecuted,
       active: !isTerminal && !allPayloadsExecuted,
       lastStep: true,


### PR DESCRIPTION
## What

The governance cache now returns two new proposal states — `expired` and `partially_executed` — and surfaces per-payload `expired`. This renders them end-to-end and corrects the lifecycle "finished" timestamp.

- `adapters.ts`: map `expired` → `Expired`, `partially_executed` → `PartiallyExecuted`.
- `StateBadge.tsx`: `Expired` already existed (red); added `PartiallyExecuted` (amber) and the label/filter string maps. The proposal-list filter picks up both automatically.
- `ProposalLifecycleCache.tsx`:
  - timeline terminal step for the two new states, plus per-payload "expired" rendering;
  - the finished step now uses the latest payload `executedAt` (the real on-chain completion) instead of `proposal.executedAt` (the GovernanceCore dispatch, which precedes it by the executor timelock). For proposal 476 that's Apr 30 vs dispatch Apr 29 — matching vote.onaave.

## Validation

prettier + eslint clean on the changed files. The `Partially executed` label and amber colour are placeholders pending design.

Requires the governance cache backend PR that emits the new states: https://github.com/aave/governance-v3-cache/pull/114

Audit (app v3 vs vote.onaave, proposals 476/471/479): the only data discrepancies were the partial/expired state and the finished timestamp — both fixed here. Votes, quorum, created/voting times, payloads and metadata all matched.

https://linear.app/aavelabs/issue/AAVEV3-143/partial-executions-state

Closes AAVEV3-143
Closes AAVEV3-87
Closes AAVEV3-91
