### PR TITLE
chore: replace dhedge.org with chamberfi.com in safe allowedDomains

### DIFF
--- a/src/ui-config/wagmiConfig.ts
+++ b/src/ui-config/wagmiConfig.ts
@@ -87,7 +87,7 @@ const baseConnectors = prodCkConfig.connectors
     const c = connector(connectorConfig);
     if (c.id === 'safe') {
       return safe({
-        allowedDomains: [/gnosis-safe.io$/, /app.safe.global$/, /dhedge.org$/],
+        allowedDomains: [/gnosis-safe.io$/, /app.safe.global$/, /chamberfi.com$/],
       });
     } else {
       return connector;


### PR DESCRIPTION
## General Changes

- Replace the legacy `dhedge.org` domain with `chamberfi.com` in the Safe connector `allowedDomains` allowlist, following dHEDGE's rebrand to Chamber.

## Developer Notes

dHEDGE has rebranded to **Chamber** (https://chamberfi.com). The `allowedDomains` list in `src/ui-config/wagmiConfig.ts` controls which domains are permitted to embed the Aave app as a Safe App (iframe). Without this update, Chamber users embedding Aave via chamberfi.com would no longer be recognized by the Safe connector.