### PR TITLE
fix(compliance): add trailing slash to preflight-compliance fetch

### DIFF
--- a/src/hooks/compliance/service-compliance.ts
+++ b/src/hooks/compliance/service-compliance.ts
@@ -11,7 +11,9 @@ export type ComplianceCheckResponse = {
 
 export const checkCompliance = async (address: string): Promise<ComplianceCheckResponse> => {
   try {
-    const res = await fetch(`/api/preflight-compliance?address=${encodeURIComponent(address)}`);
+    // NOTE: trailing slash is required because next.config.js sets `trailingSlash: true`.
+    // Without it Next issues a 308 redirect that loops -> ERR_TOO_MANY_REDIRECTS.
+    const res = await fetch(`/api/preflight-compliance/?address=${encodeURIComponent(address)}`);
     const data = await res.json();
 
     if (res.ok) {


### PR DESCRIPTION


## General Changes

- The app sets `trailingSlash: true` in next.config.js, so requests to `/api/preflight-compliance` (without a trailing slash) get a 308 redirect to the slashed path. Combined with the cached permanent redirect this loops in the browser and surfaces as ERR_TOO_MANY_REDIRECTS, breaking the compliance gate. Call the canonical slashed path to avoid the redirect.

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
