### PR TITLE
Fix/avail liq emode

### DIFF
--- a/src/modules/reserve-overview/ReserveTopDetails.tsx
+++ b/src/modules/reserve-overview/ReserveTopDetails.tsx
@@ -5,9 +5,8 @@ import { CircleIcon } from 'src/components/CircleIcon';
 import { FormattedNumber } from 'src/components/primitives/FormattedNumber';
 import { Link } from 'src/components/primitives/Link';
 import { useRootStore } from 'src/store/root';
-import { assetIsBorrowableOnMarket } from 'src/utils/getMaxAmountAvailableToBorrow';
-
 import { GENERAL } from 'src/utils/events';
+import { assetIsBorrowableOnMarket } from 'src/utils/getMaxAmountAvailableToBorrow';
 import { useShallow } from 'zustand/shallow';
 
 import { TopInfoPanelItem } from '../../components/TopInfoPanel/TopInfoPanelItem';
@@ -59,7 +58,7 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
       <TopInfoPanelItem title={<Trans>Available liquidity</Trans>} loading={loading} hideIcon>
         <FormattedNumber
           value={
-            poolReserve?.borrowingEnabled && assetIsBorrowableOnMarket(poolReserve)
+            poolReserve && assetIsBorrowableOnMarket(poolReserve)
               ? Math.max(Number(poolReserve?.availableLiquidityUSD), 0)
               : 0
           }

--- a/src/modules/reserve-overview/ReserveTopDetails.tsx
+++ b/src/modules/reserve-overview/ReserveTopDetails.tsx
@@ -5,6 +5,8 @@ import { CircleIcon } from 'src/components/CircleIcon';
 import { FormattedNumber } from 'src/components/primitives/FormattedNumber';
 import { Link } from 'src/components/primitives/Link';
 import { useRootStore } from 'src/store/root';
+import { assetIsBorrowableOnMarket } from 'src/utils/getMaxAmountAvailableToBorrow';
+
 import { GENERAL } from 'src/utils/events';
 import { useShallow } from 'zustand/shallow';
 
@@ -57,7 +59,7 @@ export const ReserveTopDetails = ({ underlyingAsset }: ReserveTopDetailsProps) =
       <TopInfoPanelItem title={<Trans>Available liquidity</Trans>} loading={loading} hideIcon>
         <FormattedNumber
           value={
-            poolReserve?.borrowingEnabled
+            poolReserve?.borrowingEnabled && assetIsBorrowableOnMarket(poolReserve)
               ? Math.max(Number(poolReserve?.availableLiquidityUSD), 0)
               : 0
           }

--- a/src/utils/__tests__/getMaxAmountAvailableToBorrow.spec.ts
+++ b/src/utils/__tests__/getMaxAmountAvailableToBorrow.spec.ts
@@ -1,0 +1,50 @@
+import {
+  assetCanBeBorrowedByUser,
+  assetIsBorrowableOnMarket,
+} from '../getMaxAmountAvailableToBorrow';
+
+const baseReserve = {
+  borrowingEnabled: false,
+  isActive: true,
+  borrowableInIsolation: false,
+  isFrozen: false,
+  isPaused: false,
+  eModes: [{ id: 1, borrowingEnabled: true }],
+};
+
+describe('assetIsBorrowableOnMarket', () => {
+  it('returns true when borrowingEnabled is true', () => {
+    expect(
+      assetIsBorrowableOnMarket({ borrowingEnabled: true, eModes: [] })
+    ).toBe(true);
+  });
+
+  it('returns true when borrowable in any e-mode', () => {
+    expect(
+      assetIsBorrowableOnMarket({
+        borrowingEnabled: false,
+        eModes: [{ id: 1, borrowingEnabled: true }],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when not borrowable in normal mode or e-mode', () => {
+    expect(
+      assetIsBorrowableOnMarket({
+        borrowingEnabled: false,
+        eModes: [{ id: 1, borrowingEnabled: false }],
+      })
+    ).toBe(false);
+  });
+});
+
+describe('assetCanBeBorrowedByUser', () => {
+  it('allows e-mode users to borrow when their category permits it', () => {
+    expect(
+      assetCanBeBorrowedByUser(baseReserve as any, {
+        isInEmode: true,
+        userEmodeCategoryId: 1,
+      } as any)
+    ).toBe(true);
+  });
+});

--- a/src/utils/__tests__/getMaxAmountAvailableToBorrow.spec.ts
+++ b/src/utils/__tests__/getMaxAmountAvailableToBorrow.spec.ts
@@ -1,4 +1,8 @@
 import {
+  ComputedReserveData,
+  ExtendedFormattedUser,
+} from '../../hooks/app-data-provider/useAppDataProvider';
+import {
   assetCanBeBorrowedByUser,
   assetIsBorrowableOnMarket,
 } from '../getMaxAmountAvailableToBorrow';
@@ -10,13 +14,11 @@ const baseReserve = {
   isFrozen: false,
   isPaused: false,
   eModes: [{ id: 1, borrowingEnabled: true }],
-};
+} as unknown as ComputedReserveData;
 
 describe('assetIsBorrowableOnMarket', () => {
   it('returns true when borrowingEnabled is true', () => {
-    expect(
-      assetIsBorrowableOnMarket({ borrowingEnabled: true, eModes: [] })
-    ).toBe(true);
+    expect(assetIsBorrowableOnMarket({ borrowingEnabled: true, eModes: [] })).toBe(true);
   });
 
   it('returns true when borrowable in any e-mode', () => {
@@ -41,10 +43,10 @@ describe('assetIsBorrowableOnMarket', () => {
 describe('assetCanBeBorrowedByUser', () => {
   it('allows e-mode users to borrow when their category permits it', () => {
     expect(
-      assetCanBeBorrowedByUser(baseReserve as any, {
+      assetCanBeBorrowedByUser(baseReserve, {
         isInEmode: true,
         userEmodeCategoryId: 1,
-      } as any)
+      } as unknown as ExtendedFormattedUser)
     ).toBe(true);
   });
 });

--- a/src/utils/getMaxAmountAvailableToBorrow.ts
+++ b/src/utils/getMaxAmountAvailableToBorrow.ts
@@ -20,6 +20,17 @@ interface PoolReserveBorrowSubset {
   borrowCapUSD: string;
 }
 
+type MarketBorrowabilityReserve = Pick<ComputedReserveData, 'borrowingEnabled' | 'eModes'>;
+
+/**
+ * Whether a reserve has any borrow path on the market.
+ * Mirrors on-chain ValidationLogic: outside e-mode uses borrowingEnabled;
+ * inside e-mode uses the category borrowableBitmap (exposed as eMode.borrowingEnabled).
+ */
+export function assetIsBorrowableOnMarket(reserve: MarketBorrowabilityReserve): boolean {
+  return reserve.borrowingEnabled || reserve.eModes.some((eMode) => eMode.borrowingEnabled);
+}
+
 /**
  * Calculates the maximum amount a user can borrow.
  * @param poolReserve


### PR DESCRIPTION
## General Changes

- Fixes available liquidity showing `$0` on the reserve overview for assets that are only borrowable in E-mode
- Builds on #3011, which correctly hides liquidity when `borrowingEnabled` is `false` — this extends that logic to also account for E-mode borrowability
- Adds `assetIsBorrowableOnMarket()` in `getMaxAmountAvailableToBorrow.ts` to check whether a reserve is borrowable in normal mode **or** any E-mode category (mirrors on-chain `ValidationLogic` behavior)
- Updates `ReserveTopDetails.tsx` to use the new helper for the "Available liquidity" display
- Adds unit tests in `getMaxAmountAvailableToBorrow.spec.ts`

**Why this change?**

Some reserves have `borrowingEnabled: false` in normal mode but remain borrowable when a user is in E-mode (via the category `borrowableBitmap`, exposed in the UI as `eMode.borrowingEnabled`). The reserve overview is market-level, so we show liquidity if the asset is borrowable through *any* path - not just normal mode.

**How to verify**

- Open a reserve where `borrowingEnabled` is `false` but the asset is borrowable in an E-mode → "Available liquidity" should show the actual USD value
- Open a reserve that is not borrowable in normal mode or any E-mode → "Available liquidity" should show `$0`
- Run `yarn test getMaxAmountAvailableToBorrow`

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)