### PR TITLE
fix: reset usdt allowance

### DIFF
--- a/src/hooks/useApprovalTx.tsx
+++ b/src/hooks/useApprovalTx.tsx
@@ -1,5 +1,4 @@
 import { ApproveType, MAX_UINT_AMOUNT, ProtocolAction } from '@aave/contract-helpers';
-import { valueToBigNumber } from '@aave/math-utils';
 import { SignatureLike } from '@ethersproject/bytes';
 import { constants, ethers } from 'ethers';
 import { parseUnits } from 'ethers/lib/utils';
@@ -82,13 +81,10 @@ export const useApprovalTx = ({
       return;
     }
 
-    const amountToApprove = parseUnits(signatureAmount, decimals).toString();
-    const currentApproved = approvedAmount?.amount
-      ? valueToBigNumber(approvedAmount.amount).toFixed(0)
-      : '0';
+    const currentApproved = approvedAmount?.amount ?? '0';
 
     if (
-      needsUSDTApprovalReset(symbol, chainId, currentApproved, amountToApprove, underlyingChainId)
+      needsUSDTApprovalReset(symbol, chainId, currentApproved, signatureAmount, underlyingChainId)
     ) {
       setShowUSDTResetWarning(true);
       setRequiresApprovalReset(true);
@@ -103,7 +99,6 @@ export const useApprovalTx = ({
     approvedAmount?.amount,
     signatureAmount,
     setShowUSDTResetWarning,
-    decimals,
   ]);
 
   const approval = async () => {

--- a/src/modules/umbrella/UmbrellaActions.tsx
+++ b/src/modules/umbrella/UmbrellaActions.tsx
@@ -289,9 +289,9 @@ export const UmbrellaActions = ({
       actionInProgressText={<Trans>Staking</Trans>}
       sx={sx}
       blocked={blocked}
-      requiresApprovalReset={requiresApprovalReset}
       // event={STAKE.STAKE_BUTTON_MODAL}
       {...props}
+      requiresApprovalReset={requiresApprovalReset}
     />
   );
 };

--- a/src/modules/umbrella/UmbrellaActions.tsx
+++ b/src/modules/umbrella/UmbrellaActions.tsx
@@ -40,6 +40,7 @@ export interface StakeActionProps extends BoxProps {
   event: string;
   isMaxSelected: boolean;
   reserve: ComputedReserveData;
+  setShowUSDTResetWarning?: (showUSDTResetWarning: boolean) => void;
 }
 
 export const UmbrellaActions = ({
@@ -53,6 +54,7 @@ export const UmbrellaActions = ({
   stakeData,
   isMaxSelected,
   reserve,
+  setShowUSDTResetWarning,
   ...props
 }: StakeActionProps) => {
   const queryClient = useQueryClient();
@@ -139,7 +141,7 @@ export const UmbrellaActions = ({
     amount: approvedAmount?.toString() || '0',
   };
 
-  const { approval } = useApprovalTx({
+  const { approval, requiresApprovalReset } = useApprovalTx({
     usePermit,
     approvedAmount: tokenApproval,
     requiresApproval,
@@ -150,6 +152,8 @@ export const UmbrellaActions = ({
     onApprovalTxConfirmed: fetchApprovedAmount,
     signatureAmount: amount,
     onSignTxCompleted: (signedParams) => setSignatureParams(signedParams),
+    chainId: currentChainId,
+    setShowUSDTResetWarning,
   });
 
   const { currentAccount, sendTx } = useWeb3Context();
@@ -285,6 +289,7 @@ export const UmbrellaActions = ({
       actionInProgressText={<Trans>Staking</Trans>}
       sx={sx}
       blocked={blocked}
+      requiresApprovalReset={requiresApprovalReset}
       // event={STAKE.STAKE_BUTTON_MODAL}
       {...props}
     />

--- a/src/modules/umbrella/UmbrellaModalContent.tsx
+++ b/src/modules/umbrella/UmbrellaModalContent.tsx
@@ -17,6 +17,7 @@ import {
   DetailsNumberLine,
   TxModalDetails,
 } from 'src/components/transactions/FlowCommons/TxModalDetails';
+import { USDTResetWarning } from 'src/components/transactions/Warnings/USDTResetWarning';
 import { CooldownWarning } from 'src/components/Warnings/CooldownWarning';
 import { ExtendedFormattedUser } from 'src/hooks/pool/useExtendedUserSummaryAndIncentives';
 import { FormattedReservesAndIncentives } from 'src/hooks/pool/usePoolFormattedReserves';
@@ -88,6 +89,7 @@ export const UmbrellaModalContent = ({ stakeData, user, userReserve, poolReserve
 
   const [riskCheckboxAccepted, setRiskCheckboxAccepted] = useState(false);
   const [_amount, setAmount] = useState('');
+  const [showUSDTResetWarning, setShowUSDTResetWarning] = useState(false);
 
   const [currentChainId] = useRootStore(
     useShallow((store) => [store.currentChainId, store.currentNetworkConfig])
@@ -271,6 +273,8 @@ export const UmbrellaModalContent = ({ stakeData, user, userReserve, poolReserve
         </>
       )}
 
+      {showUSDTResetWarning && <USDTResetWarning />}
+
       <UmbrellaActions
         sx={{ mt: '48px' }}
         amountToStake={amount || '0'}
@@ -284,6 +288,7 @@ export const UmbrellaModalContent = ({ stakeData, user, userReserve, poolReserve
         stakeData={stakeData}
         event={STAKE.STAKE_TOKEN}
         isMaxSelected={isMaxSelected}
+        setShowUSDTResetWarning={setShowUSDTResetWarning}
       />
     </>
   );


### PR DESCRIPTION
## General Changes

- Fixes a bug in Umbrella staking for USDT where the `requiresApprovalReset` handling was missing. As a result, users were unable to stake, due to USDT's special case of requiring the allowance to be reset to zero before approving a higher amount.
- Fixes an edge case with USDT where an existing allowance below 1 unit was rounded down to 0, so `requiresApprovalReset` never fired and the approval reverted on-chain.
 

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
