### PR TITLE
fix: crash on ENS names with disallowed unicode characters

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -27,4 +27,5 @@ src/locales/
 *.mermaid
 *.log
 *.lock
+*.patch
 pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
       "form-data": "2.5.6",
       "d3-color": "^3.1.0",
       "js-cookie": "3.0.7"
+    },
+    "patchedDependencies": {
+      "connectkit@1.9.2": "patches/connectkit@1.9.2.patch",
+      "@funkit/connect@9.28.1": "patches/@funkit__connect@9.28.1.patch"
     }
   },
   "scripts": {

--- a/patches/@funkit__connect@9.28.1.patch
+++ b/patches/@funkit__connect@9.28.1.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.js b/dist/index.js
+index 06a803f781f4a101d2bdefd2f398f4387a3d9bfa..2cc34b47f37878b1e04d83e545248d35208290e5 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -943,7 +943,7 @@ function useMainnetEnsAvatar(name) {
+   const mainnetConfigured = useIsMainnetConfigured();
+   const { data: ensAvatar } = useEnsAvatar({
+     chainId: mainnet.id,
+-    name: name ? normalize(name) : void 0,
++    name: (() => { if (!name) return void 0; try { return normalize(name); } catch (e) { return void 0; } })(),
+     query: {
+       enabled: mainnetConfigured
+     }

--- a/patches/connectkit@1.9.2.patch
+++ b/patches/connectkit@1.9.2.patch
@@ -1,0 +1,13 @@
+diff --git a/build/index.es.js b/build/index.es.js
+index 5108586ac4d353e0a35ded139a65d464ceef29c8..d0cd8737204d897209507ed7c7f30eca41af183c 100644
+--- a/build/index.es.js
++++ b/build/index.es.js
+@@ -8558,7 +8558,7 @@ const Avatar = ({ address, name, size = 96, radius = 96 }) => {
+     });
+     const { data: ensAvatar } = useEnsAvatar({
+         chainId: 1,
+-        name: normalize(ensName !== null && ensName !== void 0 ? ensName : ''),
++        name: (() => { try { return normalize(ensName !== null && ensName !== void 0 ? ensName : ''); } catch (e) { return ''; } })(),
+         config: ensFallbackConfig,
+     });
+     const ens = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,14 @@ overrides:
   d3-color: ^3.1.0
   js-cookie: 3.0.7
 
+patchedDependencies:
+  '@funkit/connect@9.28.1':
+    hash: c5fd86a1767827fe8e4654db1fd2c58ef150d5354d718de12ceea11fc758b219
+    path: patches/@funkit__connect@9.28.1.patch
+  connectkit@1.9.2:
+    hash: 47cc33987e407328950ecfc097c1e1e235d66dd94829bb4f1f94d0f78c9b98ac
+    path: patches/connectkit@1.9.2.patch
+
 importers:
 
   .:
@@ -65,7 +73,7 @@ importers:
         version: 2.1.3(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@funkit/connect':
         specifier: ^9.24.0
-        version: 9.28.1(2b154bac7bd888dcdba68b19a89a4e66)
+        version: 9.28.1(patch_hash=c5fd86a1767827fe8e4654db1fd2c58ef150d5354d718de12ceea11fc758b219)(2b154bac7bd888dcdba68b19a89a4e66)
       '@heroicons/react':
         specifier: ^1.0.6
         version: 1.0.6(react@18.3.1)
@@ -143,7 +151,7 @@ importers:
         version: 1.2.0
       connectkit:
         specifier: 1.9.2
-        version: 1.9.2(@babel/core@7.29.7)(@tanstack/react-query@5.101.2(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@18.3.1))(@types/react@18.3.31)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76))
+        version: 1.9.2(patch_hash=47cc33987e407328950ecfc097c1e1e235d66dd94829bb4f1f94d0f78c9b98ac)(@babel/core@7.29.7)(@tanstack/react-query@5.101.2(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@18.3.1))(@types/react@18.3.31)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76))
       d3-array:
         specifier: ^3.2.0
         version: 3.2.4
@@ -12405,7 +12413,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@funkit/connect@9.28.1(2b154bac7bd888dcdba68b19a89a4e66)':
+  '@funkit/connect@9.28.1(patch_hash=c5fd86a1767827fe8e4654db1fd2c58ef150d5354d718de12ceea11fc758b219)(2b154bac7bd888dcdba68b19a89a4e66)':
     dependencies:
       '@aave-dao/aave-address-book': 4.60.0(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@aave/client': 0.9.3(bufferutil@4.1.0)(ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(thirdweb@5.120.1(@hey-api/openapi-ts@0.99.0(typescript@5.9.3))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.101.2)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(bufferutil@4.1.0)(ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
@@ -17772,7 +17780,7 @@ snapshots:
 
   confbox@0.2.4: {}
 
-  connectkit@1.9.2(@babel/core@7.29.7)(@tanstack/react-query@5.101.2(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@18.3.1))(@types/react@18.3.31)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76)):
+  connectkit@1.9.2(patch_hash=47cc33987e407328950ecfc097c1e1e235d66dd94829bb4f1f94d0f78c9b98ac)(@babel/core@7.29.7)(@tanstack/react-query@5.101.2(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@18.3.1))(@types/react@18.3.31)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
       '@aave/account': 0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@18.3.1))(@types/react@18.3.31)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.45.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76))
       '@tanstack/react-query': 5.101.2(react@18.3.1)


### PR DESCRIPTION
## Problem
The app white-screens for wallets whose primary ENS name contains characters that fail ENSIP-15 normalization (reported for 0xfb3c7eb936cAA12B5A884d612393969A557d4307, a zalgo-text .eth name). Two dependencies call viem's `normalize()` on the reverse-resolved name during React render with no guard, and the throw unmounts the whole tree:

1. connectkit@1.9.2, Avatar component (crashes the connect flow / account modal). Upstream fix proposed: https://github.com/family/connectkit/pull/513
2. @funkit/connect@9.28.1, useMainnetEnsAvatar hook (crashes at connect whenever funkit is configured, i.e. builds with NEXT_PUBLIC_FUNKIT_API_KEY set).

Reproducible by connecting as that address (e.g. via impersonator.xyz). Watch mode is unaffected because it never mounts either component.

## Fix
Wrap the `normalize()` call in try/catch in both packages, falling back to each package's existing no-ENS-name behavior (avatar query disabled, fallback avatar rendered, name still displayed raw). Both packages are on their latest release, so there is no fixed version to upgrade to.

Applied through pnpm's native `patchedDependencies` (patch files under `patches/`, referenced from `package.json` and pinned by hash in `pnpm-lock.yaml`). pnpm applies them at install time, so `pnpm install --frozen-lockfile` on CI reproduces them from the committed hashes. Added `*.patch` to `.prettierignore` since prettier has no parser for patch files and the pre-commit hook fails on them.

Note: this replaces the original patch-package approach after main migrated to pnpm; the funkit patch is regenerated against 9.28.1 (main's current version), where the vulnerable call site is unchanged.

## Verification
- Both patches apply on a clean `pnpm install --frozen-lockfile` (node 24 / pnpm 10.18) and the try/catch is present in the installed `connectkit` and `@funkit/connect` files.
- The wrapped code is behavior-identical to the original fix, which was verified against the reported wallet: reproduced the connectkit crash locally (EIP-6963 provider impersonating the address, open account modal) and traced the remaining funkit crash through the deployed sourcemaps to `useMainnetEnsAvatar`; after the patch, connect / account modal / dashboard / markets / governance / history all render with no `Invalid label` errors.
- Swept every copy of ens-normalize in the dependency tree (searched by its internal error strings) — these two are the only render-time call sites fed the wallet's reverse-resolved name.
- `pnpm lint:formatting` passes and patch files are correctly ignored.
