### PR TITLE
Update dependency-review.yml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,3 +17,5 @@ jobs:
           comment-summary-in-pr: on-failure
           fail-on-severity: moderate
           license-check: false
+          show-openssf-scorecard: false
+          show-patched-versions: true


### PR DESCRIPTION
Disables the OpenSSF scorecard to enable dependency review to properly render vulnerable packages in PR comments