### PR TITLE
feat: map aPlaUSDT0 Merkl reward to USDT0 parent icon

### DIFF
--- a/src/components/incentives/IncentivesTooltipContent.tsx
+++ b/src/components/incentives/IncentivesTooltipContent.tsx
@@ -183,6 +183,11 @@ const IncentivesSymbolMap: {
     symbol: 'aUSDe',
     aToken: true,
   },
+  aPlaUSDT0: {
+    tokenIconSymbol: 'usdt0',
+    symbol: 'aUSDT0',
+    aToken: true,
+  },
   tydroInkPoints: {
     tokenIconSymbol: 'TydroInkPoints',
     symbol: 'TydroInkPoints',


### PR DESCRIPTION
## Summary

The Plasma USDT0 aToken (`aPlaUSDT0`) shows up as a Merkl borrow-incentive reward, but it had no entry in `IncentivesSymbolMap`. `getSymbolMap` therefore fell back to the raw on-chain symbol with a generic icon — so the rewards tooltip rendered `aPlaUSDT0` with no parent-token icon.

This adds the mapping so it resolves to its parent **USDT0**:

```ts
aPlaUSDT0: {
  tokenIconSymbol: 'usdt0', // public/icons/tokens/usdt0.svg
  symbol: 'aUSDT0',
  aToken: true,             // renders the aToken ring
},
```

Same shape as the sibling `aPlaUSDe` / `aPlaGHO` entries. This map is the single source used by `getSymbolMap`, so both the incentives tooltip and the claim-rewards modal pick it up.

## Notes

- The `(-)` next to the token in the screenshot is just the borrow-sign indicator (`(-)` borrow / `(+)` supply), not a bug.
- The reward symbol comes verbatim from the Merkl API (`rewardToken.symbol`), which matches the map key `aPlaUSDT0`.

## Test plan

- [ ] On a Plasma market with the USDT0 Merkl borrow incentive, open the APY breakdown tooltip and confirm the reward row shows the USDT0 icon (with aToken ring) and label `aUSDT0 (-)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)