### PR TITLE
fix: disable Polygon v3 incentives (UI_INCENTIVE_DATA_PROVIDER reverting)

### DIFF
--- a/src/ui-config/marketsConfig.tsx
+++ b/src/ui-config/marketsConfig.tsx
@@ -494,7 +494,7 @@ export const marketsData: {
     v3: true,
     enabledFeatures: {
       liquiditySwap: true,
-      incentives: true,
+      // incentives: true, // disabled since UI_INCENTIVE_DATA_PROVIDER reverts on a reward token oracle
       collateralRepay: true,
       debtSwitch: true,
       withdrawAndSwitch: true,
@@ -508,7 +508,7 @@ export const marketsData: {
       SWAP_COLLATERAL_ADAPTER: AaveV3Polygon.SWAP_COLLATERAL_ADAPTER,
       WALLET_BALANCE_PROVIDER: AaveV3Polygon.WALLET_BALANCE_PROVIDER,
       UI_POOL_DATA_PROVIDER: '0x66E1aBdb06e7363a618D65a910c540dfED23754f', // AaveV3Polygon.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: AaveV3Polygon.UI_INCENTIVE_DATA_PROVIDER,
+      // UI_INCENTIVE_DATA_PROVIDER: AaveV3Polygon.UI_INCENTIVE_DATA_PROVIDER,
       COLLECTOR: AaveV3Polygon.COLLECTOR,
       DEBT_SWITCH_ADAPTER: AaveV3Polygon.DEBT_SWAP_ADAPTER,
       WITHDRAW_SWITCH_ADAPTER: AaveV3Polygon.WITHDRAW_SWAP_ADAPTER,


### PR DESCRIPTION
## Problem

`UI_INCENTIVE_DATA_PROVIDER` on Polygon v3 is reverting because the oracle for one of the reward tokens reverts. Since `usePoolsFormattedReserves` combines the reserves and incentives queries via `combineQueries`, an error in the incentives query leaves the combined result with `data: undefined` — taking down the whole Polygon market view, not just the incentives column.

## Fix

Disable the on-chain incentives path for Polygon v3 entirely. There are no rewards currently configured on the market, so there is nothing to display.