### PR TITLE
fix: tag compliance checks with surface=v3

### DIFF
--- a/pages/api/preflight-compliance.ts
+++ b/pages/api/preflight-compliance.ts
@@ -54,12 +54,15 @@ export default async function handler(
   try {
     // use ?overrideResultStatus=false | true if you want to override the result
 
-    const response = await fetch(`${COMPLIANCE_API_URL}/check/${encodeURIComponent(address)}`, {
-      method: 'GET',
-      headers: {
-        'x-compliance-secret': COMPLIANCE_SECRET,
-      },
-    });
+    const response = await fetch(
+      `${COMPLIANCE_API_URL}/check/${encodeURIComponent(address)}?surface=v3`,
+      {
+        method: 'GET',
+        headers: {
+          'x-compliance-secret': COMPLIANCE_SECRET,
+        },
+      }
+    );
 
     if (!response.ok) {
       if (response.status === 401) {


### PR DESCRIPTION
The compliance API accepts an optional `?surface=` on `/check/{address}` and records it on every denial, so `/compliance blocked-stats --surface v3` can split denials by product. This route never sent it, so every denial from the V3 interface lands as `UNATTRIBUTED`.

Reported in #aave-compliance: `--surface v3` returned 0 wallets over a full year, while the same query without the filter returned 120, all under `UNATTRIBUTED`.

The param is reporting-only and never affects the verdict. It is unauthenticated and an unrecognised value is ignored rather than rejected, so it cannot block a user.

The V4 Pro side is https://github.com/aave/aave-pro/pull/1393.

Only takes effect from deploy forward. Existing denial rows have no surface recorded and cannot be backfilled.