### PR TITLE
fix(ci): replace the disabled `::set-output` command with `$GITHUB_OUTPUT`

### DIFF
--- a/.github/actions/analyze-comment/action.yml
+++ b/.github/actions/analyze-comment/action.yml
@@ -73,11 +73,11 @@ runs:
       if: github.event_name != 'push'
       shell: bash
       run: |
-        body=$(cat .next/analyze/__bundle_analysis_comment.txt)
-        body="${body//'%'/'%25'}"
-        body="${body//$'\n'/'%0A'}"
-        body="${body//$'\r'/'%0D'}"
-        echo ::set-output name=body::$body
+        {
+          echo 'body<<BUNDLE_ANALYSIS_EOF'
+          cat .next/analyze/__bundle_analysis_comment.txt
+          echo 'BUNDLE_ANALYSIS_EOF'
+        } >> "$GITHUB_OUTPUT"
 
     - name: Find Comment
       uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d # v2.0.0

--- a/.github/workflows/test-deploy-fork.yml
+++ b/.github/workflows/test-deploy-fork.yml
@@ -40,7 +40,7 @@ jobs:
         shell: sh
         id: get_pr_number
         run: |
-          echo "::set-output name=pr_number::$(cat NUM | tr -dc '[:digit:]')"
+          echo "pr_number=$(cat NUM | tr -dc '[:digit:]')" >> "$GITHUB_OUTPUT"
 
       - name: Link this CI run to PR
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
## Problem

Two workflow steps still use the `::set-output` workflow command, which GitHub **disabled** in Actions runner 2.298.2 (October 2022). Steps that use it produce no output at all, and every consumer silently receives an empty string.

Both outputs here are consumed:

**1. `.github/actions/analyze-comment/action.yml:80`** — `steps.get-comment-body.outputs.body` feeds the `body:` input of both `Create Comment` (line 95) and `Update Comment` (line 102), so the bundle-analysis comment is posted with an empty body. This composite action is used by `build-test-deploy.yml`, `build-test-deploy-dev.yml` and `test-deploy-fork.yml`.

**2. `.github/workflows/test-deploy-fork.yml:43`** — `steps.get_pr_number.outputs.pr_number` is passed as `PR_NUMBER` into `Link this CI run to PR`, where it becomes `issue_number: Number(process.env.PR_NUMBER)`. With an empty string that evaluates to `0`, so the "Tests and deployment are running now!" comment is addressed to issue `0` instead of the pull request.

## Change

Both sites move to the supported `$GITHUB_OUTPUT` file.

For the multiline bundle-analysis text I used the documented heredoc delimiter form, which also lets the three percent-encoding lines go away — that encoding was a workaround for `::set-output` not accepting newlines, and it is no longer needed:

```diff
-        body=$(cat .next/analyze/__bundle_analysis_comment.txt)
-        body="${body//'%'/'%25'}"
-        body="${body//$'\n'/'%0A'}"
-        body="${body//$'\r'/'%0D'}"
-        echo ::set-output name=body::$body
+        {
+          echo 'body<<BUNDLE_ANALYSIS_EOF'
+          cat .next/analyze/__bundle_analysis_comment.txt
+          echo 'BUNDLE_ANALYSIS_EOF'
+        } >> "$GITHUB_OUTPUT"
```

Dropping the encoding is a small bonus fix: a `%` in the analysis output used to reach the comment as `%25`.

```diff
-          echo "::set-output name=pr_number::$(cat NUM | tr -dc '[:digit:]')"
+          echo "pr_number=$(cat NUM | tr -dc '[:digit:]')" >> "$GITHUB_OUTPUT"
```

That step declares `shell: sh`, and the redirect form used here is POSIX, so it stays portable.

## Verification

- Both files still parse as YAML, and the step ids, shells and surrounding steps are unchanged.
- I ran both snippets locally against a scratch `$GITHUB_OUTPUT`:
  - the heredoc form writes a well-formed multiline value, preserves blank lines, and round-trips a literal `100%` intact;
  - the `sh` form turns a `NUM` file containing `12345abc` into `pr_number=12345`.
- Scope is deliberately limited to the two `::set-output` occurrences — no action versions, permissions or triggers were touched.
